### PR TITLE
Bin2RLum: new argument 'keep.empty' to discard 0-record object

### DIFF
--- a/R/Risoe.BINfileData2RLum.Analysis.R
+++ b/R/Risoe.BINfileData2RLum.Analysis.R
@@ -41,6 +41,10 @@
 #' @param protocol \code{\link{character}} (optional): sets protocol type for
 #' analysis object. Value may be used by subsequent analysis functions.
 #'
+#' @param keep.empty \code{\link{logical}} (with default): If \code{TRUE} (default)
+#' an \code{RLum.Analysis} object is returned even if it does not contain any
+#' records. Set to \code{FALSE} to discard all empty objects.
+#'
 #' @param txtProgressBar \link{logical} (with default): enables or disables
 #' \code{\link{txtProgressBar}}.
 #'
@@ -77,6 +81,7 @@ Risoe.BINfileData2RLum.Analysis<- function(
   ltype = NULL,
   dtype = NULL,
   protocol = "unknown",
+  keep.empty = TRUE,
   txtProgressBar = FALSE
 ){
 
@@ -286,14 +291,17 @@ Risoe.BINfileData2RLum.Analysis<- function(
         object <- set_RLum(
           class = "RLum.Analysis",
           records = lapply(temp_id,function(x) {
-            .Risoe.BINfileData2RLum.Data.Curve(object, id = x)
+            Luminescence:::.Risoe.BINfileData2RLum.Data.Curve(object, id = x)
           }),
           protocol = protocol,
           originator = "Risoe.BINfileData2RLum.Analysis"
         )
+        
+        if (!keep.empty && length(object@records) == 0)
+          return(NULL)
 
         ##add unique id of RLum.Analysis object to each curve object as .pid using internal function
-        .set_pid(object)
+        Luminescence:::.set_pid(object)
 
       })
 

--- a/man/Risoe.BINfileData2RLum.Analysis.Rd
+++ b/man/Risoe.BINfileData2RLum.Analysis.Rd
@@ -6,7 +6,7 @@
 \usage{
 Risoe.BINfileData2RLum.Analysis(object, pos = NULL, grain = NULL,
   run = NULL, set = NULL, ltype = NULL, dtype = NULL,
-  protocol = "unknown", txtProgressBar = FALSE)
+  protocol = "unknown", keep.empty = TRUE, txtProgressBar = FALSE)
 }
 \arguments{
 \item{object}{\code{\linkS4class{Risoe.BINfileData}} (\bold{required}):
@@ -41,6 +41,10 @@ limit the converted data. Commonly allowed values are listed in \code{\linkS4cla
 \item{protocol}{\code{\link{character}} (optional): sets protocol type for
 analysis object. Value may be used by subsequent analysis functions.}
 
+\item{keep.empty}{\code{\link{logical}} (with default): If \code{TRUE} (default)
+an \code{RLum.Analysis} object is returned even if it does not contain any
+records. Set to \code{FALSE} to discard all empty objects.}
+
 \item{txtProgressBar}{\link{logical} (with default): enables or disables
 \code{\link{txtProgressBar}}.}
 }
@@ -63,7 +67,7 @@ The \code{protocol} argument of the \code{\linkS4class{RLum.Analysis}}
 object is set to 'unknown' if not stated otherwise.
 }
 \section{Function version}{
- 0.4.1 (2016-05-19 23:33:15)
+ 0.4.1
 }
 \examples{
 
@@ -76,7 +80,7 @@ Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
 }
 \author{
 Sebastian Kreutzer, IRAMAT-CRP2A, Universite Bordeaux Montaigne (France)
-\cr R Luminescence Package Team}
+}
 \references{
 #
 }


### PR DESCRIPTION
Depending on the query the function returns empty RLum.Analysis objects, i.e. the object has 0 records. Further processing of these objects then often require manually removing the empty objects first. We can skip this not so easy task by dropping all empty objects already here.

Example:
```r
library(Luminescence)
data("ExampleData.BINfileData")
bin <- CWOSL.SAR.Data
print(Risoe.BINfileData2RLum.Analysis(bin, ltype = "IRSL", set = 2, keep.empty = TRUE))
print(Risoe.BINfileData2RLum.Analysis(bin, ltype = "IRSL", set = 2, keep.empty = FALSE))
```