### PR TITLE
Fix computation of skewness and kurtosis with MCM.

### DIFF
--- a/R/calc_Statistics.R
+++ b/R/calc_Statistics.R
@@ -126,6 +126,7 @@ calc_Statistics <- function(
 
   ## calculate n
   S.n <- nrow(data)
+  S.m.n <- S.n * ncol(data.MCM)
 
   ## calculate mean
   S.mean <- mean(x = data[,1],
@@ -183,12 +184,12 @@ calc_Statistics <- function(
   ## calculate skewness
   S.skewness <- 1 / S.n * sum(((data[,1] - S.mean) / S.sd.abs)^3)
 
-  S.m.skewness <- 1 / S.n * sum(((data.MCM - S.m.mean) / S.m.sd.abs)^3)
+  S.m.skewness <- 1 / S.m.n * sum(((data.MCM - S.m.mean) / S.m.sd.abs)^3)
 
   ## calculate kurtosis
   S.kurtosis <- 1 / S.n * sum(((data[,1] - S.mean) / S.sd.abs)^4)
 
-  S.m.kurtosis <- 1 / S.n * sum(((data.MCM - S.m.mean) / S.m.sd.abs)^4)
+  S.m.kurtosis <- 1 / S.m.n * sum(((data.MCM - S.m.mean) / S.m.sd.abs)^4)
 
   ## create list objects of calculation output
   S.weighted <- list(n = S.n,

--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -50,8 +50,8 @@ test_that("check weighted values from output", {
   local_edition(3)
 
   expect_equal(temp$weighted$n, 25)
-  expect_equal(sum(unlist(temp_alt1)),24535.72)
-  expect_equal(sum(unlist(temp_alt2)),24534.1)
+  expect_equal(sum(unlist(temp_alt1)),18558.37)
+  expect_equal(sum(unlist(temp_alt2)),18555.994)
   expect_equal(round(temp$weighted$mean, digits = 3), 2896.036)
   expect_equal(round(temp$weighted$median, digits = 2), 2884.46)
   expect_equal(round(temp$weighted$sd.abs, digits = 4), 240.2228)
@@ -89,8 +89,8 @@ test_that("check MCM values from output", {
   expect_equal(round(temp$MCM$sd.rel, digits = 6), 9.999137)
   expect_equal(round(temp$MCM$se.abs, digits = 5), 59.01474)
   expect_equal(round(temp$MCM$se.rel, digits = 6), 1.999827)
-  expect_equal(round(temp$MCM$skewness, digits = 3), 1286.082)
-  expect_equal(round(temp$MCM$kurtosis, digits = 3), 4757.097)
+  expect_equal(round(temp$MCM$skewness, digits = 3), 1.286)
+  expect_equal(round(temp$MCM$kurtosis, digits = 3), 4.757)
 
 
 })


### PR DESCRIPTION
When `n.MCM` is not NULL, `data.MCM` is a matrix with as many columns as number of Monte Carlo samples: calling `sum()` over it when computating skewness and kurtosis will sum `n * n.MCM` values, so we must divide by `n * n.MCM` to produce the correct expectations.

Fixes #122.