### PR TITLE
complete coverage in calc_Statistics.R

### DIFF
--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -21,6 +21,10 @@ test_that("Test certain input scenarios", {
   expect_is(calc_Statistics(temp_RLum), "list")
 
   df <- ExampleData.DeValues$BT998
+  df[, 2] <- NULL
+  expect_warning(calc_Statistics(df))
+
+  df <- ExampleData.DeValues$BT998
   df[,2] <- 0
   expect_warning(calc_Statistics(df))
 


### PR DESCRIPTION
This adds a test for error-free data sets passed to `calc_Statistics()` and brings coverage for `calc_Statistics.R` to 100% (#121).