### PR TITLE
Fix crash in calc_TLLxTxRatio() if Tx.data.background=NULL.

### DIFF
--- a/R/calc_TLLxTxRatio.R
+++ b/R/calc_TLLxTxRatio.R
@@ -149,6 +149,7 @@ calc_TLLxTxRatio <- function(
 # Calculate Lx/Tx values --------------------------------------------------
     ## preset variables
     net_LnLx <- net_LnLx.Error <- net_TnTx <- net_TnTx.Error <- NA
+    BG.Error <- NA
 
     ## calculate values
     LnLx <- sum(Lx.data.signal[signal.integral.min:signal.integral.max, 2])

--- a/tests/testthat/test_calc_TLLxTxRatio.R
+++ b/tests/testthat/test_calc_TLLxTxRatio.R
@@ -102,4 +102,11 @@ test_that("calc_TLLxTxRatio", {
   expect_equal(round(results$LxTx, digits =  6), 3.187877)
   expect_equal(round(results$LxTx.Error, digits = 6), 1.485073)
 
+  expect_s4_class(calc_TLLxTxRatio(
+    Lx.data.signal,
+    Lx.data.background=NULL,
+    Tx.data.signal,
+    Tx.data.background=NULL,
+    signal.integral.min,
+    signal.integral.max), class = "RLum.Results")
 })


### PR DESCRIPTION
This gives a default value to the `BG.Error` variable, as otherwise it wouldn't have any in the `Tx.data.background=NULL` case. Fixes #129.

The additional test added also brings coverage to 100% (#121).