### PR TITLE
Check length of g_value argument in calc_Lamothe2003().

### DIFF
--- a/R/calc_Lamothe2003.R
+++ b/R/calc_Lamothe2003.R
@@ -200,6 +200,17 @@ calc_Lamothe2003 <- function(
     }
   }
 
+  ## g_value
+  if (!inherits(g_value, "numeric") || length(g_value) < 2) {
+    stop("[calc_Lamothe2003()] Input for 'g_value' is not of type 'numeric' and/or of length < 2!", call. = FALSE)
+  } else {
+    if (length(g_value) > 2) {
+      warning("[calc_Lamothe2003()] 'g_value' has length > 2. Take only the first two entries.",
+              call. = FALSE, immediate. = TRUE)
+      g_value <- g_value[1:2]
+    }
+  }
+
   ##tc
   if(is.null(tc) && !is.null(tc.g_value))
     stop("[calc_Lamothe2003()] If you set 'tc.g_value' you have to provide a value for 'tc' too!", call. = FALSE)

--- a/tests/testthat/test_calc_Lamothe2003.R
+++ b/tests/testthat/test_calc_Lamothe2003.R
@@ -22,7 +22,7 @@ test_that("Force function to break", {
     suppressWarnings(calc_Lamothe2003(
       object = data.frame(
         x = c(0,10,20), y = c(1.4,0.7,2.3), z = c(0.01,0.02, 0.03)),
-      dose_rate.envir = c(1,2,3), dose_rate.source = c(1,2,3), g_value = c(1,1))),
+      dose_rate.envir = c(1,2,3), dose_rate.source = c(1,2,3), g_value = c(1,1,1))),
     "RLum.Results")
 
   ##g_value
@@ -34,6 +34,11 @@ test_that("Force function to break", {
     ),
     regexp = "Input for 'g_value' missing but required!"
   )
+  expect_error(
+    calc_Lamothe2003(object = NULL, dose_rate.envir = c(1,2),
+                     dose_rate.source = c(1,2), g_value = 1),
+    "Input for 'g_value' is not of type 'numeric' and/or of length < 2"
+  )
 
   ##object
   expect_error(suppressWarnings(
@@ -41,19 +46,21 @@ test_that("Force function to break", {
       object = NULL,
       dose_rate.envir = c(1, 2, 3),
       dose_rate.source = c(1, 2, 3),
-      g_value = NULL
-    ),
+      g_value = c(1, 2)
+    )),
     regexp = "Unsupported data type for 'object'"
-  ))
+  )
 
   expect_error(suppressWarnings(
     calc_Lamothe2003(
       object = set_RLum("RLum.Results"),
       dose_rate.envir = c(1, 2, 3),
       dose_rate.source = c(1, 2, 3),
-      g_value = NULL
-    )
-  ))
+      g_value = c(1, 2)
+    )),
+    "Input for 'object' created by function calc_Lamothe2003() not supported",
+    fixed=TRUE
+  )
 
   ##tc
   expect_error(
@@ -63,9 +70,9 @@ test_that("Force function to break", {
       dose_rate.source = c(1, 2, 3),
       g_value = c(1, 1),
       tc.g_value = 1000
-    ),
-    regexp = "If you set 'tc.g_value' you have to provide a value for 'tc' too!"
-  ))
+    )),
+    "If you set 'tc.g_value' you have to provide a value for 'tc' too!"
+  )
 
 
 })


### PR DESCRIPTION
This introduces checks similar to those that were already present for `dose_rate.envir` and `dose_rate.source`. Fixes #131.

This also fixes some tests that were not actually checking correctly for errors due to wrong nesting of `suppressWarning()`, whose closing bracket was misplaced.