### PR TITLE
Don't let a 1-column matrix become a vector in convert_Wavelength2Energy()

### DIFF
--- a/R/convert_Wavelength2Energy.R
+++ b/R/convert_Wavelength2Energy.R
@@ -173,7 +173,8 @@ convert_Wavelength2Energy <- function(
 
     #sort values if needed
     if(order){
-      object@data <-  object@data[order(as.numeric(rownames(object@data))),]
+      object@data <- object@data[order(as.numeric(rownames(object@data))), ,
+                                 drop = FALSE]
       rownames(object@data) <- sort(as.numeric(rownames(object@data)))
 
     }

--- a/tests/testthat/test_convert_Wavelength2Energy.R
+++ b/tests/testthat/test_convert_Wavelength2Energy.R
@@ -34,6 +34,9 @@ test_that("test convert functions", {
 
   ##test order argument
   expect_type(convert_Wavelength2Energy(data, order = TRUE), "double")
+  res <- convert_Wavelength2Energy(object, order = TRUE)
+  expect_equal(order(rownames(res@data)),
+               1:nrow(res@data))
 
   ##test special treatment of RLum.Data.Spectrum objects
   object@info[["curveDescripter"]] <- "energy"


### PR DESCRIPTION
Fixes #133.