### PR TITLE
Use nocov start/end to exclude untestable regions from coverage

### DIFF
--- a/R/addins_RLum.R
+++ b/R/addins_RLum.R
@@ -48,6 +48,7 @@
 
   ##check if package is installed
   if(!requireNamespace("rstudioapi", quietly = TRUE)){
+    # nocov start
     message("Package 'rstudioapi' is not installed but needed to search for TODOs, do you want to install it?\n\n",
             " [n/N]: No (default)\n",
             " [y/Y]: Yes\n")
@@ -58,7 +59,7 @@
     if(tolower(answer) == "y"){
       utils::install.packages("rstudioapi", dependencies = TRUE)
     }
-
+    # nocov end
   }else{
 
   ##parse code

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -788,6 +788,7 @@ analyse_baSAR <- function(
   ##check whether rjags is available
   ##code snippet taken from
   ##http://r-pkgs.had.co.nz/description.html
+  # nocov start
   if (!requireNamespace("rjags", quietly = TRUE)) {
     stop("[analyse_baSAR()] To use this function you have to first install the package 'rjags'.",
          call. = FALSE)
@@ -797,6 +798,7 @@ analyse_baSAR <- function(
     stop("[analyse_baSAR()] To use this function you have to first install the package 'coda'.",
          call. = FALSE)
   }
+  # nocov end
 
   #capture additional piped arguments
   additional_arguments <- list(

--- a/R/combine_De_Dr.R
+++ b/R/combine_De_Dr.R
@@ -513,10 +513,12 @@ if (!all(t_pkg <- c(
   requireNamespace("rjags", quietly = TRUE),
   requireNamespace("coda", quietly = TRUE),
   requireNamespace("mclust", quietly = TRUE)))) {
+  # nocov start
   t_names <- c('rjags', 'coda', 'mclust')
     stop(paste0("[combine_De_Dr()] To use this function you have to first
          install the package(s) ", paste(t_names[!t_pkg], collapse = ",")),
          call. = FALSE)
+  # nocov end
 }
 
 # Integrity checks --------------------------------------------------------

--- a/R/install_DevelopmentVersion.R
+++ b/R/install_DevelopmentVersion.R
@@ -74,7 +74,7 @@ install_DevelopmentVersion <- function(force_install = FALSE) {
 
     message("Please copy and run the following code in your R command-line:\n")
     if (!requireNamespace("devtools", quietly = TRUE))
-      message("install.packages('devtools')")
+      message("install.packages('devtools')") # nocov
 
     message(branches$INSTALL[as.numeric(index)], "\n")
 
@@ -96,9 +96,11 @@ install_DevelopmentVersion <- function(force_install = FALSE) {
 
     # check if 'devtools' is available and install if not
     if (!requireNamespace("devtools", quietly = TRUE)) {
+      # nocov start
       message("Please install the 'devtools' package first by running the following command:\n",
               "install.packages('devtools')")
       return(NULL)
+      # nocov end
     }
 
     # detach the 'Luminescence' package

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -3578,9 +3578,11 @@ plot_AbanicoPlot <- function(
   ## INTERACTIVE PLOT ----------------------------------------------------------
   if (interactive) {
     if (!requireNamespace("plotly", quietly = TRUE))
+      # nocov start
       stop("The interactive abanico plot requires the 'plotly' package. To install",
            " this package run 'install.packages('plotly')' in your R console.",
            call. = FALSE)
+      # nocov end
 
     ##cheat R check (global visible binding error)
     x <- NA

--- a/R/plot_FilterCombinations.R
+++ b/R/plot_FilterCombinations.R
@@ -295,8 +295,10 @@ plot_FilterCombinations <- function(
 
       ##check for plotly
       if (!requireNamespace("plotly", quietly = TRUE)) {
+        # nocov start
         stop("[plot_FilterCombinations()] Package 'plotly' needed interactive plot functionality. Please install it.",
              call. = FALSE)
+        # nocov end
       }
 
       ##create basic plot

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -712,9 +712,11 @@ plot_Histogram <- function(
   if (interactive) {
 
     if (!requireNamespace("plotly", quietly = TRUE))
+      # nocov start
       stop("The interactive histogram requires the 'plotly' package. To install",
            " this package run 'install.packages('plotly')' in your R console.",
            call. = FALSE)
+      # nocov end
 
     ## tidy data ----
     data <- as.data.frame(data)

--- a/R/plot_RLum.Data.Spectrum.R
+++ b/R/plot_RLum.Data.Spectrum.R
@@ -879,8 +879,10 @@ if(plot){
     ## Plot: interactive ----
     ##http://r-pkgs.had.co.nz/description.html
     if (!requireNamespace("plotly", quietly = TRUE)) {
+      # nocov start
       stop("[plot_RLum.Data.Spectrum()] Package 'plotly' needed for this plot type. Please install it.",
            call. = FALSE)
+      # nocov end
     }
 
        ##set up plot

--- a/R/read_TIFF2R.R
+++ b/R/read_TIFF2R.R
@@ -35,9 +35,11 @@ read_TIFF2R <- function(
   ## most of the users don't need this import, no need to bother them
   ## with required libraries
   if (!requireNamespace("tiff", quietly = TRUE))
+    # nocov start
     stop("Importing TIFF files requires the package tiff.\n",
          "To install this package run 'install.packages('tiff')' in your R console.",
          call. = FALSE)
+    # nocov end
 
   if(!file.exists(file))
     stop("[read_TIFF2R()] File does not exist or is not readable!", call. = FALSE)
@@ -53,4 +55,3 @@ read_TIFF2R <- function(
   set_RLum(class = "RLum.Data.Image", data = temp@data)
 
 }
-

--- a/R/report_RLum.R
+++ b/R/report_RLum.R
@@ -195,6 +195,7 @@ report_RLum <- function(
   ## PRE-CHECKS ----
 
   # check if required namespace(s) are available
+  # nocov start
   if (!requireNamespace("rmarkdown", quietly = TRUE))
     stop("Creating object reports requires the 'rmarkdown' package.",
          " To install this package run 'install.packages('rmarkdown')' in your R console.",
@@ -211,6 +212,7 @@ report_RLum <- function(
   } else {
     isRStudio <- TRUE
   }
+  # nocov end
 
   # check if files exist
   if (!is.null(css.file))

--- a/R/write_R2TIFF.R
+++ b/R/write_R2TIFF.R
@@ -41,9 +41,11 @@ write_R2TIFF <- function(
   ## most of the users don't need this import, no need to bother them
   ## with required libraries
   if (!requireNamespace("tiff", quietly = TRUE))
+    # nocov start
     stop("Exporting objects to TIFF files requires the package tiff.\n",
          "To install this package run 'install.packages('tiff')' in your R console.",
          call. = FALSE)
+    # nocov end
 
 # Transform  --------------------------------------------------------------
   ## make a list ... it is just easier
@@ -85,4 +87,3 @@ write_R2TIFF <- function(
   }
 
 }
-


### PR DESCRIPTION
Testing blocks that depend on the result of `requireNamespace()` is almost impossible, as the packages being checked are by design present on CI and in our development machines. This marks those regions with `nocov start` and `nocov end` to tell `covr` that they shouldn't be counted as missing from coverage. Helps marginally with #121.