### PR TITLE
Fix .throw_error() and .throw_warning()

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -834,12 +834,17 @@ fancy_scientific <- function(l) {
 #'@title Throws a Custom Tailored Error Message
 #'
 #'@param ... the error message to throw
+#'@param nframe [numeric] (*with default*): the frame where the function
+#'       name to return in the error message should be searched: the
+#'       default value of 1 is generally fine, unless [throw_error] is
+#'       called from an internal function (whose name is not of interest
+#'       to the user), in which case a value of 2 should be used.
 #'
 #'@md
 #'@noRd
-.throw_error <- function(...) {
+.throw_error <- function(..., nframe = 1) {
   ## get name of calling function
-  f_calling <- paste0("[", as.character(sys.call(-1)), "()] ")
+  f_calling <- paste0("[", deparse(sys.call(-nframe)[1]), "] ")
 
   ## stop
   stop(paste0(f_calling, ...), call. = FALSE)
@@ -849,12 +854,17 @@ fancy_scientific <- function(l) {
 #'@title Throws a Custom Tailored Warning Message
 #'
 #'@param ... the warning message to throw
+#'@param nframe [numeric] (*with default*): the frame where the function
+#'       name to return in the warning message should be searched: the
+#'       default value of 1 is generally fine, unless [throw_warning] is
+#'       called from an internal function (whose name is not of interest
+#'       to the user), in which case a value of 2 should be used
 #'
 #'@md
 #'@noRd
-.throw_warning <- function(...) {
+.throw_warning <- function(..., nframe = 1) {
   ## get name of calling function
-  f_calling <- paste0("[", as.character(sys.call(-1)), "()] ")
+  f_calling <- paste0("[", deparse(sys.call(-nframe)[1]), "] ")
 
   ## stop
   warning(paste0(f_calling, ...), call. = FALSE)
@@ -875,7 +885,7 @@ fancy_scientific <- function(l) {
       (int && val != as.integer(val))) {
     if (is.null(name))
       name <- all.vars(match.call())[1]
-    stop("'", name, "' must be a positive ", if (int) "integer ",
-         "scalar", call. = FALSE)
+    .throw_error("'", name, "' must be a positive ", if (int) "integer ",
+                 "scalar", nframe = 2)
   }
 }

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -139,14 +139,32 @@ test_that("Test internals", {
   expect_equal(sum(unlist(t)), expected = 110)
 
   ## .throw_error() ---------------------------------------------------------
-  expect_error(.throw_error("Error message"),
-               "Error message")
+  fun.int <- function() .throw_error("Error message")
+  fun.ext <- function() fun.int()
+  expect_error(fun.int(),
+               "[fun.int()] Error message", fixed = TRUE)
+  expect_error(fun.ext(),
+               "[fun.int()] Error message", fixed = TRUE)
+
+  fun.int <- function() .throw_error("Error message", nframe = 2)
+  fun.ext <- function() fun.int()
+  expect_error(fun.ext(),
+               "[fun.ext()] Error message", fixed = TRUE)
 
   ## .throw_warning() -------------------------------------------------------
-  expect_warning(.throw_warning("Warning message"),
-                 "Warning message")
+  fun.int <- function() .throw_warning("Warning message")
+  fun.ext <- function() fun.int()
+  expect_warning(fun.int(),
+                 "[fun.int()] Warning message", fixed = TRUE)
+  expect_warning(fun.ext(),
+                 "[fun.int()] Warning message", fixed = TRUE)
 
-  # .validate_positive_scalar() ---------------------------------------------
+  fun.int <- function() .throw_warning("Warning message", nframe = 2)
+  fun.ext <- function() fun.int()
+  expect_warning(fun.ext(),
+                 "[fun.ext()] Warning message", fixed = TRUE)
+
+  ## .validate_positive_scalar() --------------------------------------------
   expect_silent(.validate_positive_scalar(1.3))
   expect_silent(.validate_positive_scalar(2, int = TRUE))
 


### PR DESCRIPTION
There are two problems with the current implementation of `.throw_error()` and `.throw_warning()` which were noted in #152:

```R
> .validate_positive_scalar(iris)
Error: [.validate_positive_scalar()] 'iris' must be a positive scalar[iris()] 'iris' must be a positive scalar
```

1. The name of the caller function is not computed correctly if the caller has arguments, which messes up the output
2. If the caller is an internal function, the internal name would be exposed to the user, rather than the name of the function the user called

This PR makes the function print the name of the calling function just once and allows using them from other internal functions, thanks to the new `nframe` argument that allows to control which function name is reported from the error/warning message.

When `.throw_error()/.throw_warning()` are called from an exported Luminescence function, one can use these two functions without worrying about `nframe`, they will work by default as expected. The only time that we should set `nframe = 2` is when we use the throwing functions from an internal function, such as in `.validate_positive_scalar()`.