### PR TITLE
Add option null.ok to .validate_positive_scalar()

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -874,13 +874,19 @@ fancy_scientific <- function(l) {
 #' @title Validate Scalar Variables Expected to be Positive
 #'
 #' @param val [numeric] (**required**): value to validate
-#' @param int [logical] (*with default*): whether the value has to be an integer (`FALSE` by default)
+#' @param int [logical] (*with default*): whether the value has to be an
+#'        integer (`FALSE` by default)
+#' @param null.ok [logical] (*with default*): whether a `NULL` value should be
+#'        considered valid (`FALSE` by default)
 #' @param name [character] (*with default*): Variable name to report in case of error; if not specified
 #'        it's inferred from the name of the name of the variable tested
 #'
 #' @md
 #' @noRd
-.validate_positive_scalar <- function(val, int = FALSE, name = NULL) {
+.validate_positive_scalar <- function(val, int = FALSE, null.ok = FALSE,
+                                      name = NULL) {
+  if (is.null(val) && null.ok)
+    return()
   if (!is.numeric(val) || length(val) != 1 || is.na(val) || val <= 0 ||
       (int && val != as.integer(val))) {
     if (is.null(name))

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -167,8 +167,11 @@ test_that("Test internals", {
   ## .validate_positive_scalar() --------------------------------------------
   expect_silent(.validate_positive_scalar(1.3))
   expect_silent(.validate_positive_scalar(2, int = TRUE))
+  expect_silent(.validate_positive_scalar(NULL, int = TRUE, null.ok = TRUE))
 
   expect_error(.validate_positive_scalar(test <- "a"),
+               "'test' must be a positive scalar")
+  expect_error(.validate_positive_scalar(test <- NULL),
                "'test' must be a positive scalar")
   expect_error(.validate_positive_scalar(iris),
                "'iris' must be a positive scalar")


### PR DESCRIPTION
Often we may want to accept `NULL` as a valid value to indicate that an argument has not been set. Setting `null.ok = TRUE` will now allow that.