### PR TITLE
Propagate the input_scale argument in fit_EmissionSpectra()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -36,6 +36,10 @@ an exponential fit is applied then this values are used as start parameters.
 ### `calc_TLLxTxRatio()`
 * Function crashed for `Tx.data.background = NULL` (#129); fixed with #130 thanks to @mcol
 
+### `fit_EmissionSpectra()`
+* Parameter `input_scale` was not correctly propagated when the function would
+self-call (#160, @mcol).
+
 ### `plot_GrowthCurve()`
 * The function now calculates the relative saturation (`n/N`) using the ration of the two integrates.
 The values is part of the output table. 

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -281,6 +281,7 @@ fit_EmissionSpectra <- function(
           start_parameters = start_parameters,
           n_components = n_components,
           sub_negative = sub_negative,
+          input_scale = input_scale,
           method_control = method_control,
           frame = frame,
           mtext = mtext[[o]]),
@@ -697,4 +698,3 @@ fit_EmissionSpectra <- function(
   return(results)
 
 }
-

--- a/tests/testthat/test_fit_EmissionSpectra.R
+++ b/tests/testthat/test_fit_EmissionSpectra.R
@@ -54,5 +54,10 @@ test_that("standard check", {
  expect_s3_class(results$fit[[1]], "nls")
  expect_type(results$data, "double")
 
+  ## input_scale
+  expect_s4_class(
+      fit_EmissionSpectra(object = TL.Spectrum, frame = 5,
+                          input_scale = "wavelength", plot = FALSE,
+                          method_control = list(max.runs = 10)),
+      "RLum.Results")
 })
-


### PR DESCRIPTION
Argument `input_scale` was not propagated in the self-call, so it was effectively ignored in most cases.