### PR TITLE
Remove warnings from fit_SurfaceExposure() if data contains NAs

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -40,6 +40,10 @@ an exponential fit is applied then this values are used as start parameters.
 * Parameter `input_scale` was not correctly propagated when the function would
 self-call (#160, @mcol).
 
+### `fit_SurfaceExposure()`
+* Fix #162 to remove a dimension mismatch if the input data contained `NA`s,
+which would generate unexpected warnings (#163, @mcol).
+
 ### `plot_GrowthCurve()`
 * The function now calculates the relative saturation (`n/N`) using the ration of the two integrates.
 The values is part of the output table. 

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -289,7 +289,14 @@ fit_SurfaceExposure <- function(
   else
     wi <- rep(1, times = nrow(data))
 
-  # extract errors into seperate variable
+  ## remove rows with NA
+  if (any(is.na(data))) {
+    data <- data[complete.cases(data), ]
+    if (settings$verbose)
+      warning("NA values in 'data' were removed.", call. = FALSE)
+  }
+
+  ## extract errors into separate variable
   if (ncol(data) >= 3 && !global_fit)
     error <- data[ ,3]
   else
@@ -298,13 +305,6 @@ fit_SurfaceExposure <- function(
   ## Take only the first to columns (depth, signal)
   if (ncol(data) > 2 && !global_fit)
     data <- data[ ,1:2]
-
-  ## remove rows with NA
-  if (any(is.na(data))) {
-    data <- data[complete.cases(data), ]
-    if (settings$verbose)
-      warning("NA values in 'data' were removed.", call. = FALSE)
-  }
 
   ## Data preprocessing ----
 

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -255,7 +255,7 @@ fit_SurfaceExposure <- function(
     # TODO: Support weighted fitting for global fit
     if (weights) {
       if (settings$verbose)
-        warning("Argument 'weights' is not supported when multiple data sets are provided for global fitting.", call. = FALSE)
+        warning("[fit_SurfaceExposure()] Argument 'weights' is not supported when multiple data sets are provided for global fitting.", call. = FALSE)
       weights <- FALSE
     }
 
@@ -293,7 +293,7 @@ fit_SurfaceExposure <- function(
   if (any(is.na(data))) {
     data <- data[complete.cases(data), ]
     if (settings$verbose)
-      warning("NA values in 'data' were removed.", call. = FALSE)
+      warning("[fit_SurfaceExposure()] NA values in 'data' were removed.", call. = FALSE)
   }
 
   ## extract errors into separate variable

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -9,7 +9,7 @@ test_that("input validation", {
   local_edition(3)
 
   expect_warning(fit_SurfaceExposure(rbind(d1, NA)),
-                 "NA values in 'data' were removed")
+                 "\\[fit\\_SurfaceExposure\\(\\)\\] NA values in 'data' were removed")
 })
 
 ## Example data 1

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -4,6 +4,14 @@ d2 <- ExampleData.SurfaceExposure$sample_2
 d3 <- ExampleData.SurfaceExposure$set_1
 d4 <- ExampleData.SurfaceExposure$set_2
 
+test_that("input validation", {
+  testthat::skip_on_cran()
+  local_edition(3)
+
+  expect_warning(fit_SurfaceExposure(rbind(d1, NA)),
+                 "NA values in 'data' were removed")
+})
+
 ## Example data 1
 fit <- fit_SurfaceExposure(data = d1, sigmaphi = 5e-10, mu = 0.9,
                            plot = FALSE, verbose = FALSE)


### PR DESCRIPTION
Fixes a dimension mismatch in `fit_SurfaceExposure()` when the input data contains `NA`s, by removing them before subsetting the data further. Fixes #162.