### PR TITLE
two small errors in fit_SurfaceExposure()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -43,6 +43,8 @@ self-call (#160, @mcol).
 ### `fit_SurfaceExposure()`
 * Fix #162 to remove a dimension mismatch if the input data contained `NA`s,
 which would generate unexpected warnings (#163, @mcol).
+* The function doesn't stop anymore with an error if called on an
+`RLum.Results` object (#165, @mcol).
 
 ### `plot_GrowthCurve()`
 * The function now calculates the relative saturation (`n/N`) using the ration of the two integrates.

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -446,7 +446,9 @@ fit_SurfaceExposure <- function(
 
     if (grepl("y", plot_settings$log)) {
       plot_settings$ylim[1] <- 0.01
-      plot_settings$x <- data[which(data[ ,2] > 0),]
+      pos.idx <- which(data[, 2] > 0)
+      error <- error[pos.idx]
+      plot_settings$x <- data[pos.idx, ]
     }
 
     ## create main plot

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -237,7 +237,7 @@ fit_SurfaceExposure <- function(
 
   ## Data type validation
   if (inherits(data, "RLum.Results"))
-    object <- get_RLum(data, "data")
+    data <- get_RLum(data, "data")
 
   if (inherits(data, "matrix"))
     data <- as.data.frame(data)

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -126,4 +126,7 @@ test_that("not enough parameters provided", {
                                             log = "y", plot = TRUE),
                  "Original error from minpack.lm::nlsLM(): evaluation of fn",
                  fixed = TRUE)
+  expect_message(fit_SurfaceExposure(as.matrix(d1), log = "y"),
+                 "Original error from minpack.lm::nlsLM(): singular gradient",
+                 fixed = TRUE)
 })

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -126,6 +126,9 @@ test_that("not enough parameters provided", {
                                             log = "y", plot = TRUE),
                  "Original error from minpack.lm::nlsLM(): evaluation of fn",
                  fixed = TRUE)
+  expect_message(fit_SurfaceExposure(res),
+                 "Original error from minpack.lm::nlsLM(): singular gradient",
+                 fixed = TRUE)
   expect_message(fit_SurfaceExposure(as.matrix(d1), log = "y"),
                  "Original error from minpack.lm::nlsLM(): singular gradient",
                  fixed = TRUE)


### PR DESCRIPTION
Fixes these two little bugs:
1. A small bug in data subsetting, similar to #162 
2. An error reported if called on an `RLum.Results` object due to an assignment to a wrongly-named variable