### PR TITLE
Remove test results for R version < 3.6

### DIFF
--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -34,15 +34,7 @@ test_that("regression tests De values", {
   testthat::skip_on_cran()
   local_edition(3)
 
-  ##fix for different R versions
-  if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(object = round(sum(results$data[1:2]), digits = 0), 1716)
-
-  }else{
-    expect_equal(object = round(sum(results$data[1:2]), digits = 0), 1716)
-
-  }
-
+  expect_equal(object = round(sum(results$data[1:2]), digits = 0), 1716)
 })
 
 test_that("regression test LxTx table", {
@@ -62,15 +54,8 @@ test_that("regression test - check rejection criteria", {
   testthat::skip_on_cran()
   local_edition(3)
 
-  ##fix for different R versions
-  if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(object = round(sum(results$rejection.criteria$Value), digits = 0),  1669)
-
-  }else{
-    expect_equal(object = round(sum(results$rejection.criteria$Value), digits = 0),  1669)
-
-  }
-
+  expect_equal(round(sum(results$rejection.criteria$Value), digits = 0),
+               1669)
 })
 
 test_that("simple run", {

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -88,15 +88,6 @@ test_that("check output", {
    testthat::skip_on_cran()
    local_edition(3)
 
-   ##fix for different R versions
-   if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-     expect_equal(round(sum(results$data[1:2, 1:4]), 0),7583)
-
-   }else{
-     expect_equal(round(sum(results$data[1:2, 1:4]), 0),7584)
-
-   }
-
+   expect_equal(round(sum(results$data[1:2, 1:4]), 0),7584)
    expect_equal(round(sum(results$rejection.criteria$Value), 2),3338.69)
-
 })

--- a/tests/testthat/test_calc_AliquotSize.R
+++ b/tests/testthat/test_calc_AliquotSize.R
@@ -58,19 +58,10 @@ test_that("check MC run", {
   expect_equal(round(temp$MC$statistics$n), 100)
   expect_equal(round(temp$MC$statistics$mean), 43)
   expect_equal(round(temp$MC$statistics$median), 39)
-
-  ##fix for different R versions
-  if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(temp$MC$statistics$sd.abs), 20)
-
-  }else{
-    expect_equal(round(temp$MC$statistics$sd.abs), 19)
-
-  }
+  expect_equal(round(temp$MC$statistics$sd.abs), 19)
   expect_equal(round(temp$MC$statistics$sd.rel), 45)
   expect_equal(round(temp$MC$statistics$se.abs), 2)
   expect_equal(round(temp$MC$statistics$se.rel), 5)
   expect_length(temp$MC$kde$x, 10000)
   expect_length(temp$MC$kde$y, 10000)
 })
-

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -101,19 +101,9 @@ test_that("check values from analyse_FadingMeasurement()", {
 test_that("check values from calc_Huntley2008()", {
   testthat::skip_on_cran()
 
-  ##fix for different R versions
-  if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(huntley$results$Sim_Age, 1), 41.3)
-    expect_equal(round(huntley$results$Sim_Age_2D0, 0), 164)
-    expect_equal(round(sum(huntley$Ln),4), 0.1585)
-
-  }else{
-    expect_equal(round(huntley$results$Sim_Age, 1), 34)
-    expect_equal(round(huntley$results$Sim_Age_2D0, 0), 175)
-    expect_equal(round(sum(huntley$Ln),2), 0.16)
-
-  }
-
+  expect_equal(round(huntley$results$Sim_Age, 1), 34)
+  expect_equal(round(huntley$results$Sim_Age_2D0, 0), 175)
+  expect_equal(round(sum(huntley$Ln),2), 0.16)
 
   expect_equal(round(sum(huntley$data),0), 191530)
   expect_equal(round(sum(residuals(huntley$fits$simulated)),1),  0.8)

--- a/tests/testthat/test_plot_GrowthCurve.R
+++ b/tests/testthat/test_plot_GrowthCurve.R
@@ -300,61 +300,16 @@ temp_LambertW <-
   )
 
    expect_equal(round(temp_EXP$De[[1]], digits = 2), 1737.88)
-
-   ##fix for different R versions
-   if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(sum(temp_EXP$De.MC, na.rm = TRUE), digits = 0), 17441)
-
-   }else{
-     expect_equal(round(sum(temp_EXP$De.MC, na.rm = TRUE), digits = 0), 17562)
-
-   }
-
+   expect_equal(round(sum(temp_EXP$De.MC, na.rm = TRUE), digits = 0), 17562)
    expect_equal(round(temp_LIN$De[[1]], digits = 2), 1811.33)
-
-   ##fix for different R versions
-   if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-     expect_equal(round(sum(temp_LIN$De.MC, na.rm = TRUE), digits = 0),18238)
-
-   }else{
-     expect_equal(round(sum(temp_LIN$De.MC, na.rm = TRUE), digits = 0),18398)
-
-   }
-
+   expect_equal(round(sum(temp_LIN$De.MC, na.rm = TRUE), digits = 0),18398)
    expect_equal(round(temp_EXPLIN$De[[1]], digits = 2), 1791.53)
-
-   ##fix for different R versions
-   if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(sum(temp_EXPLIN$De.MC, na.rm = TRUE), digits = 0),17474)
-
-   }else{
-     expect_equal(round(sum(temp_EXPLIN$De.MC, na.rm = TRUE), digits = 0),18045)
-
-   }
-
+   expect_equal(round(sum(temp_EXPLIN$De.MC, na.rm = TRUE), digits = 0),18045)
    expect_equal(round(temp_EXPEXP$De[[1]], digits = 2), 1787.15)
-
-   ##fix for different R versions
-   if(R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(sum(temp_EXPEXP$De.MC, na.rm = TRUE), digits = 0), 7316)
-
-   }else{
-     expect_equal(round(sum(temp_EXPEXP$De.MC, na.rm = TRUE), digits = 0), 7303,
-                  tolerance = 10)
-
-   }
-
+   expect_equal(round(sum(temp_EXPEXP$De.MC, na.rm = TRUE), digits = 0), 7303,
+                tolerance = 10)
    expect_equal(round(temp_QDR$De[[1]], digits = 2), 1666.2)
-
-   ##fix for different R versions
-   if (R.version$major == "3" && as.numeric(R.version$minor) < 6){
-    expect_equal(round(sum(temp_QDR$De.MC, na.rm = TRUE), digits = 0), 14937)
-
-   }else{
-    expect_equal(round(sum(temp_QDR$De.MC, na.rm = TRUE), digits = 0), 16476)
-
-   }
-
+   expect_equal(round(sum(temp_QDR$De.MC, na.rm = TRUE), digits = 0), 16476)
    expect_equal(round(temp_GOK$De[[1]], digits = 0), 1786)
    ##fix for different R versions
    if (R.version$major > "3"){


### PR DESCRIPTION
We don't support R versions < 4.3, so the test for results previous to the RNG changes of R 3.6 can be removed.