### PR TITLE
Switch globally to testthat 3rd edition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -218,3 +218,4 @@ Collate:
     'write_RLum2CSV.R'
     'zzz.R'
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/tests/testthat/test_Analyse_SAROSLdata.R
+++ b/tests/testthat/test_Analyse_SAROSLdata.R
@@ -1,6 +1,5 @@
 test_that("full example test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.BINfileData, envir = environment())
   output <- Analyse_SAR.OSLdata(input.data = CWOSL.SAR.Data,

--- a/tests/testthat/test_CW2pX.R
+++ b/tests/testthat/test_CW2pX.R
@@ -4,7 +4,6 @@ values <- CW_Curve.BosWallinga2012
 
 test_that("Check the example and the numerical values", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   values_pLM <- CW2pLM(values)
   values_pLMi <- CW2pLMi(values, P = 1/20)
@@ -28,7 +27,6 @@ test_that("Check the example and the numerical values", {
 
 test_that("Test RLum.Types", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load CW-OSL curve data
   data(ExampleData.CW_OSL_Curve, envir = environment())

--- a/tests/testthat/test_PSL2RisoeBINfiledata.R
+++ b/tests/testthat/test_PSL2RisoeBINfiledata.R
@@ -1,6 +1,6 @@
 test_that("simple test", {
   testthat::skip_on_cran()
-  local_edition(3)
+
   data("ExampleData.portableOSL", envir = environment())
   merged <- merge_RLum(ExampleData.portableOSL)
   bin <- PSL2Risoe.BINfileData(merged)

--- a/tests/testthat/test_RLum.Analysis-class.R
+++ b/tests/testthat/test_RLum.Analysis-class.R
@@ -1,6 +1,5 @@
 test_that("Check the example and the numerical values", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data("ExampleData.RLum.Analysis")
@@ -65,4 +64,3 @@ test_that("Check the example and the numerical values", {
     "Only 'RLum.Data.Curve' objects are allowed!")
 
 })
-

--- a/tests/testthat/test_RLum.Data.Curve.R
+++ b/tests/testthat/test_RLum.Data.Curve.R
@@ -1,6 +1,5 @@
 test_that("check class", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##set empty curve object and show it
   expect_output(show(set_RLum(class = "RLum.Data.Curve")))

--- a/tests/testthat/test_RLum.Data.Image.R
+++ b/tests/testthat/test_RLum.Data.Image.R
@@ -1,6 +1,5 @@
 test_that("check class ", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.RLum.Data.Image, envir = environment())

--- a/tests/testthat/test_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_RLum.Data.Spectrum.R
@@ -1,6 +1,5 @@
 test_that("check class", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##set empty spectrum object and show it
   expect_output(show(set_RLum(class = "RLum.Data.Spectrum")))

--- a/tests/testthat/test_RLum.R
+++ b/tests/testthat/test_RLum.R
@@ -1,6 +1,5 @@
 test_that("check class", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   object <- set_RLum(class = "RLum.Data.Curve")
   expect_length(rep(object, 10), 10)

--- a/tests/testthat/test_RisoeBINfileData-class.R
+++ b/tests/testthat/test_RisoeBINfileData-class.R
@@ -1,6 +1,5 @@
 test_that("Check the example and the numerical values", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##construct empty object
   temp <-

--- a/tests/testthat/test_Second2Gray.R
+++ b/tests/testthat/test_Second2Gray.R
@@ -12,7 +12,7 @@ Second2Gray(ExampleData.DeValues$BT998, results, error.prop = "absolute")
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
+
   expect_s3_class(results, class = "data.frame")
 
   expect_error(Second2Gray("test"),
@@ -33,7 +33,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(sum(results[[1]]), 14754.09)
   expect_equal(sum(results[[2]]), 507.692)

--- a/tests/testthat/test_analyse_Al2O3C_CrossTalk.R
+++ b/tests/testthat/test_analyse_Al2O3C_CrossTalk.R
@@ -1,6 +1,5 @@
 test_that("Full check", {
   skip_on_cran()
-   local_edition(3)
 
    ##load data
    data(ExampleData.Al2O3C, envir = environment())

--- a/tests/testthat/test_analyse_Al2O3C_ITC.R
+++ b/tests/testthat/test_analyse_Al2O3C_ITC.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("Full check", {
   skip_on_cran()
-  local_edition(3)
 
    ##check stops
    ##RLum-object
@@ -21,4 +20,3 @@ test_that("Full check", {
    expect_s4_class(analyse_Al2O3C_ITC(data_ITC), "RLum.Results")
 
 })
-

--- a/tests/testthat/test_analyse_Al2O3C_Measurement.R
+++ b/tests/testthat/test_analyse_Al2O3C_Measurement.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("analyse_Al2O3C_Measurements", {
   skip_on_cran()
-  local_edition(3)
 
    ##load data
    data(ExampleData.Al2O3C, envir = environment())
@@ -22,4 +21,3 @@ test_that("analyse_Al2O3C_Measurements", {
    expect_s4_class(suppressWarnings(analyse_Al2O3C_Measurement(temp)), "RLum.Results")
 
 })
-

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -1,6 +1,5 @@
 test_that("general test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## load example data (sample UNIL/NB123, see ?ExampleData.Fading)
   data("ExampleData.Fading", envir = environment())
@@ -44,7 +43,6 @@ test_that("general test", {
 
 test_that("test XSYG file fading data", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   # Create artificial object ------------------------------------------------
   l <- list()
@@ -121,4 +119,3 @@ test_that("test XSYG file fading data", {
   ), "RLum.Results")
 
 })
-

--- a/tests/testthat/test_analyse_IRSARRF.R
+++ b/tests/testthat/test_analyse_IRSARRF.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   set.seed(1)
   data(ExampleData.RLum.Analysis, envir = environment())
@@ -44,7 +43,6 @@ test_that("check class and length of output", {
 
 test_that("test controlled crash conditions", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##the sliding range should not exceed a certain value ... test it
   data(ExampleData.RLum.Analysis, envir = environment())
@@ -88,7 +86,6 @@ test_that("test controlled crash conditions", {
 
 test_that("test support for IR-RF data", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## get needed data
   file <- system.file("extdata", "RF_file.rf", package = "Luminescence")
@@ -103,7 +100,6 @@ test_that("test support for IR-RF data", {
 
 test_that("test edge cases", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.RLum.Analysis, envir = environment())
   RF_nat <- RF_reg <- IRSAR.RF.Data[[2]]

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -20,7 +20,6 @@ object_NO_TL <- get_RLum(object, record.id = -seq(1,30,2), drop = FALSE)
 
 test_that("tests class elements", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(results, "RLum.Results")
   expect_equal(length(results), 4)
@@ -32,14 +31,12 @@ test_that("tests class elements", {
 
 test_that("regression tests De values", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(object = round(sum(results$data[1:2]), digits = 0), 1716)
 })
 
 test_that("regression test LxTx table", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(object = round(sum(results$LnLxTnTx.table$LxTx), digits = 5),  20.92051)
   expect_equal(object = round(sum(results$LnLxTnTx.table$LxTx.Error), digits = 2), 0.34)
@@ -52,7 +49,6 @@ test_that("regression test LxTx table", {
 
 test_that("regression test - check rejection criteria", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(round(sum(results$rejection.criteria$Value), digits = 0),
                1669)
@@ -60,7 +56,6 @@ test_that("regression test - check rejection criteria", {
 
 test_that("simple run", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##verbose and plot off
   t <- expect_s4_class(
@@ -410,7 +405,6 @@ test_that("simple run", {
 
 test_that("advance tests run", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##this tests basically checks the parameter expansion and make
   ##sure everything is evaluated properly

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -6,7 +6,6 @@ object <- Risoe.BINfileData2RLum.Analysis(TL.SAR.Data, pos = 3)
 
 test_that("Input validation", {
   skip_on_cran()
-  local_edition(3)
 
   expect_error(analyse_SAR.TL(),
                "No value set for 'object'")
@@ -26,7 +25,6 @@ test_that("Input validation", {
 
 test_that("Test examples", {
   skip_on_cran()
-  local_edition(3)
 
   ##perform analysis
   expect_s4_class(

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("Full check of analyse_baSAR function", {
   skip_on_cran()
-  local_edition(3)
 
     set.seed(1)
     ##(1) load package test data set
@@ -39,4 +38,3 @@ test_that("Full check of analyse_baSAR function", {
     expect_type(round(sum(results$summary[, c(6:9)]), 2),type = "double")
 
 })
-

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -74,7 +74,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
     testthat::skip_on_cran()
-    local_edition(3)
 
     expect_s4_class(results, "RLum.Results")
     expect_equal(length(results), 4)
@@ -86,7 +85,6 @@ test_that("check class and length of output", {
 
 test_that("check output", {
    testthat::skip_on_cran()
-   local_edition(3)
 
    expect_equal(round(sum(results$data[1:2, 1:4]), 0),7584)
    expect_equal(round(sum(results$rejection.criteria$Value), 2),3338.69)

--- a/tests/testthat/test_analyse_portableOSL.R
+++ b/tests/testthat/test_analyse_portableOSL.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
     testthat::skip_on_cran()
-    local_edition(3)
 
     ## generate test data set for profile
     data("ExampleData.portableOSL", envir = environment())
@@ -166,7 +165,6 @@ test_that("check class and length of output", {
 
 test_that("check output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data("ExampleData.portableOSL", envir = environment())
   merged <- merge_RLum(ExampleData.portableOSL)

--- a/tests/testthat/test_apply_CosmicRayRemoval.R
+++ b/tests/testthat/test_apply_CosmicRayRemoval.R
@@ -1,6 +1,5 @@
 test_that("check function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load data
   data(ExampleData.XSYG, envir = environment())

--- a/tests/testthat/test_apply_EfficiencyCorrection.R
+++ b/tests/testthat/test_apply_EfficiencyCorrection.R
@@ -1,6 +1,5 @@
 test_that("check function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load data
   data(ExampleData.XSYG, envir = environment())

--- a/tests/testthat/test_as_latex_table.R
+++ b/tests/testthat/test_as_latex_table.R
@@ -1,6 +1,5 @@
 test_that("Check github_commits()", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   df <- data.frame(x = "test", y = 1:10)
   expect_output(Luminescence:::.as.latex.table.data.frame(df))

--- a/tests/testthat/test_bin_RLumData.R
+++ b/tests/testthat/test_bin_RLumData.R
@@ -9,7 +9,6 @@ curve <-
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(bin_RLum.Data(curve), class = "RLum.Data.Curve")
   expect_length(bin_RLum.Data(curve)[,1], 500)
@@ -18,7 +17,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(sum(bin_RLum.Data(curve)[,2]), 119200)
   expect_equal(sum(bin_RLum.Data(curve, bin = 5)[1,2]), 41146)

--- a/tests/testthat/test_calc_AliquotSize.R
+++ b/tests/testthat/test_calc_AliquotSize.R
@@ -8,7 +8,6 @@ temp <- calc_AliquotSize(
 
 test_that("consistency checks", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_AliquotSize(grain.size = 1:3))
   expect_error(calc_AliquotSize(grain.size = 100, packing.density = 2))
@@ -30,7 +29,6 @@ test_that("consistency checks", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(temp), c("RLum.Results", "RLum"))
   expect_equal(length(temp), 2)
@@ -41,7 +39,6 @@ test_that("check class and length of output", {
 
 test_that("check summary output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   result <- get_RLum(temp)
 
@@ -54,7 +51,7 @@ test_that("check summary output", {
 
 test_that("check MC run", {
   testthat::skip_on_cran()
-  local_edition(3)
+
   expect_equal(round(temp$MC$statistics$n), 100)
   expect_equal(round(temp$MC$statistics$mean), 43)
   expect_equal(round(temp$MC$statistics$median), 39)

--- a/tests/testthat/test_calc_AverageDose.R
+++ b/tests/testthat/test_calc_AverageDose.R
@@ -6,7 +6,6 @@ temp <- calc_AverageDose(ExampleData.DeValues$CA1[1:56,],
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data <- ExampleData.DeValues$CA1
   expect_error(calc_AverageDose(),
@@ -33,7 +32,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 3)
@@ -42,7 +40,6 @@ test_that("check class and length of output", {
 
 test_that("check summary output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_CentralDose.R
+++ b/tests/testthat/test_calc_CentralDose.R
@@ -10,7 +10,6 @@ temp_NA[1,1] <- NA
 
 test_that("errors and warnings function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_CentralDose(data = "error"), "'data' has to be of type 'data.frame' or 'RLum.Results'!")
   expect_error(calc_CentralDose(temp, sigmab = 10), "sigmab needs to be given as a fraction between 0 and 1")
@@ -23,7 +22,6 @@ test_that("errors and warnings function", {
 
 test_that("standard and output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(temp), c("RLum.Results", "RLum"))
   expect_equal(length(temp), 4)
@@ -35,7 +33,6 @@ test_that("standard and output", {
 
 test_that("check summary output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 
@@ -47,4 +44,3 @@ test_that("check summary output", {
   expect_equal(round(results$rel_OD_err, digits = 6), 3.458774)
   expect_equal(round(results$Lmax, digits = 5), 31.85046)
 })
-

--- a/tests/testthat/test_calc_CobbleDoseRate.R
+++ b/tests/testthat/test_calc_CobbleDoseRate.R
@@ -1,6 +1,5 @@
 test_that("basic checks", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## simple run with example data
   data("ExampleData.CobbleData", envir = environment())

--- a/tests/testthat/test_calc_CommonDose.R
+++ b/tests/testthat/test_calc_CommonDose.R
@@ -5,7 +5,6 @@ temp.nolog <- calc_CommonDose(ExampleData.DeValues$CA1, log = FALSE,
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_CommonDose(),
                "is missing, with no default")
@@ -21,7 +20,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 4)
@@ -30,7 +28,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   all.equal(calc_CommonDose(temp, verbose = FALSE),
             temp)

--- a/tests/testthat/test_calc_CosmicDoseRate.R
+++ b/tests/testthat/test_calc_CosmicDoseRate.R
@@ -5,7 +5,6 @@ temp <- calc_CosmicDoseRate(depth = 2.78, density = 1.7,
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_CosmicDoseRate(depth = -2),
                "No negative values allowed for depth and density")
@@ -39,7 +38,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 3)
@@ -53,7 +51,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example 1", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 
@@ -66,21 +63,16 @@ test_that("check values from output example 1", {
   expect_equal(round(results$d0, digits = 3), 0.152)
   expect_equal(round(results$geom_lat, digits =  1), 41.1)
   expect_equal(round(results$dc, digits = 3), 0.161)
-
-
-
 })
 
 
 test_that("check values from output example 2b", {
   testthat::skip_on_cran()
-  local_edition(3)
+
   temp <- calc_CosmicDoseRate(depth = c(5.0, 2.78), density = c(2.65, 1.7),
                               latitude = 12.04332, longitude = 4.43243,
                               altitude = 364, corr.fieldChanges = TRUE,
                               est.age = 67, error = 15)
-
-
   results <- get_RLum(temp)
 
   expect_equal(results$depth.1, 5)

--- a/tests/testthat/test_calc_FadingCorr.R
+++ b/tests/testthat/test_calc_FadingCorr.R
@@ -10,7 +10,6 @@ temp <- calc_FadingCorr(
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##trigger some errors
   expect_error(calc_FadingCorr(age.faded = "test", g_value = "test"),
@@ -62,7 +61,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example 1", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -4,7 +4,6 @@ temp <- calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE, verbose = FALSE)
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   obj <- ExampleData.CW_OSL_Curve
   expect_error(calc_FastRatio(obj, Ch_L1 = NULL),
@@ -53,7 +52,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 5)
@@ -73,7 +71,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_FiniteMixture.R
+++ b/tests/testthat/test_calc_FiniteMixture.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## load example data
   data(ExampleData.DeValues, envir = environment())

--- a/tests/testthat/test_calc_FuchsLang2001.R
+++ b/tests/testthat/test_calc_FuchsLang2001.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.DeValues, envir = environment())

--- a/tests/testthat/test_calc_HomogeneityTest.R
+++ b/tests/testthat/test_calc_HomogeneityTest.R
@@ -9,7 +9,6 @@ temp <- calc_HomogeneityTest(df, verbose = FALSE)
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_HomogeneityTest(TRUE),
                "'data' object has to be of type 'data.frame' or 'RLum.Results'")
@@ -24,7 +23,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -22,7 +22,6 @@ huntley <- calc_Huntley2006(
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   rhop.test <- rhop
   rhop.test@originator <- "unexpected"
@@ -74,7 +73,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##rhop
   expect_s4_class(rhop, class = "RLum.Results")

--- a/tests/testthat/test_calc_IEU.R
+++ b/tests/testthat/test_calc_IEU.R
@@ -6,7 +6,6 @@ temp <- calc_IEU(ExampleData.DeValues$CA1,
 
 test_that("Test general behaviour", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.DeValues, envir = environment())
 
@@ -62,7 +61,6 @@ test_that("Test general behaviour", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 5)
@@ -71,7 +69,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_Lamothe2003.R
+++ b/tests/testthat/test_calc_Lamothe2003.R
@@ -1,6 +1,5 @@
 test_that("Force function to break", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##argument check
 
@@ -78,7 +77,6 @@ test_that("Force function to break", {
 
 test_that("Test the function itself", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##This is based on the package example
   ##load data

--- a/tests/testthat/test_calc_MaxDose.R
+++ b/tests/testthat/test_calc_MaxDose.R
@@ -7,7 +7,6 @@ temp <- calc_MaxDose(ExampleData.DeValues$CA1,
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 9)
@@ -16,7 +15,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -6,7 +6,6 @@ temp <- calc_MinDose(data = ExampleData.DeValues$CA1,
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_MinDose(),
                "is missing, with no default")
@@ -26,7 +25,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 9)
@@ -51,7 +49,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_OSLLxTxDecomposed.R
+++ b/tests/testthat/test_calc_OSLLxTxDecomposed.R
@@ -2,7 +2,6 @@ data(ExampleData.LxTxOSLData, envir = environment())
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_OSLLxTxDecomposed(),
                "is missing, with no default")

--- a/tests/testthat/test_calc_OSLLxTxRatio.R
+++ b/tests/testthat/test_calc_OSLLxTxRatio.R
@@ -8,7 +8,6 @@ temp <- calc_OSLLxTxRatio(
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(temp), c("RLum.Results", "RLum"))
   expect_equal(length(temp), 2)
@@ -17,7 +16,6 @@ test_that("check class and length of output", {
 
 test_that("test arguments", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##digits
   expect_silent(calc_OSLLxTxRatio(
@@ -50,7 +48,6 @@ test_that("test arguments", {
 
 test_that("test input", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##RLum.Curve
   expect_silent(calc_OSLLxTxRatio(
@@ -99,7 +96,6 @@ test_that("test input", {
 
 test_that("force function break", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_OSLLxTxRatio(
     Lx.data[1:10,],
@@ -201,7 +197,6 @@ test_that("force function break", {
 
 test_that("create warnings", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_warning(calc_OSLLxTxRatio(
     Lx.data,
@@ -244,7 +239,6 @@ test_that("create warnings", {
 
 test_that("check weird circumstances", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##(1) - Lx curve 0
   expect_type(calc_OSLLxTxRatio(
@@ -300,7 +294,6 @@ test_that("check weird circumstances", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 
@@ -319,7 +312,6 @@ test_that("check values from output example", {
 
 test_that("test NA mode with no signal integrals", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.LxTxOSLData, envir = environment())
   temp <- expect_s4_class(calc_OSLLxTxRatio(

--- a/tests/testthat/test_calc_SourceDoseRate.R
+++ b/tests/testthat/test_calc_SourceDoseRate.R
@@ -6,7 +6,6 @@ temp <- calc_SourceDoseRate(measurement.date = "2012-01-27",
 
 test_that("General tests", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##simple run
   expect_silent(calc_SourceDoseRate(
@@ -55,7 +54,6 @@ test_that("General tests", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(temp), c("RLum.Results", "RLum"))
   expect_equal(length(temp), 3)
@@ -64,7 +62,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example 1", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -10,7 +10,6 @@ temp_RLum <- set_RLum(class = "RLum.Results", data = list(data = ExampleData.DeV
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_type(temp, "list")
   expect_equal(length(temp), 3)
@@ -18,7 +17,7 @@ test_that("check class and length of output", {
 })
 
 test_that("Test certain input scenarios", {
-  expect_is(calc_Statistics(temp_RLum), "list")
+  expect_type(calc_Statistics(temp_RLum), "list")
 
   df <- ExampleData.DeValues$BT998
   df[, 2] <- NULL
@@ -30,14 +29,11 @@ test_that("Test certain input scenarios", {
 
   df <- ExampleData.DeValues$BT998
   expect_silent(calc_Statistics(df, weight.calc = "reciprocal"))
-
-
 })
 
 
 test_that("check error messages", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   df <- ExampleData.DeValues$BT998
 
@@ -51,7 +47,6 @@ test_that("check error messages", {
 
 test_that("check weighted values from output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(temp$weighted$n, 25)
   expect_equal(sum(unlist(temp_alt1)),18558.37)

--- a/tests/testthat/test_calc_TLLxTxRatio.R
+++ b/tests/testthat/test_calc_TLLxTxRatio.R
@@ -1,6 +1,5 @@
 test_that("calc_TLLxTxRatio", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load package example data
   data(ExampleData.BINfileData, envir = environment())

--- a/tests/testthat/test_calc_ThermalLifetime.R
+++ b/tests/testthat/test_calc_ThermalLifetime.R
@@ -24,7 +24,6 @@ temp2 <- calc_ThermalLifetime(
 
 test_that("check class and length of output example 1", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 2)
@@ -33,7 +32,6 @@ test_that("check class and length of output example 1", {
 #
 test_that("check values from output example 1", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_type(temp$lifetimes, "double")
   expect_equal(dim(temp$lifetimes), c(1, 2, 11))
@@ -67,11 +65,11 @@ test_that("check class and length of output example 2", {
 
 test_that("check values from output example 2", {
   testthat::skip_on_cran()
-  testthat::expect_is(temp2$lifetimes, class = c("numeric", "vector"))
+
+  testthat::expect_type(temp2$lifetimes, "double")
+  testthat::expect_equal(class(temp2$lifetimes), "numeric")
   testthat::expect_equal(length(temp2$lifetimes), 1000)
   testthat::expect_equal(dim(temp2$profiling_matrix), c(1000, 4))
-
-
 })
 
 
@@ -103,4 +101,3 @@ test_that("check arguments", {
   expect_output(calc_ThermalLifetime(E = c(1.4, 0.001), s = c(1e05,1e03), plot = TRUE, profiling = TRUE))
 
 })
-

--- a/tests/testthat/test_calc_WodaFuchs2008.R
+++ b/tests/testthat/test_calc_WodaFuchs2008.R
@@ -1,6 +1,5 @@
 test_that("Test general functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   ## read example data set

--- a/tests/testthat/test_calc_gSGC.R
+++ b/tests/testthat/test_calc_gSGC.R
@@ -9,7 +9,6 @@ temp <- calc_gSGC(data = data.frame(
 
 test_that("plot and verbose and so", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(calc_gSGC(data = data.frame(
     LnTn =  2.361, LnTn.error = 0.087,
@@ -24,7 +23,6 @@ test_that("plot and verbose and so", {
 
 test_that("test errors", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(calc_gSGC(data = NA))
   expect_error(calc_gSGC(data = data.frame(
@@ -43,9 +41,9 @@ test_that("test errors", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  expect_is(temp, class = "RLum.Results", info = NULL, label = NULL)
-  expect_is(temp$De, class = "data.frame", info = NULL, label = NULL)
-  expect_is(temp$De.MC, class = "list", info = NULL, label = NULL)
+  expect_s4_class(temp, "RLum.Results")
+  expect_s3_class(temp$De, "data.frame")
+  expect_type(temp$De.MC, "list")
   expect_equal(length(temp), 3)
 
 })

--- a/tests/testthat/test_calc_gSGC_feldspar.R
+++ b/tests/testthat/test_calc_gSGC_feldspar.R
@@ -1,6 +1,5 @@
 test_that("test errors", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##crash function
   ##no data.frame
@@ -73,4 +72,3 @@ test_that("test errors", {
   expect_true(all(is.na(unlist(results$m.MC))))
 
 })
-

--- a/tests/testthat/test_combine_De_Dr.R
+++ b/tests/testthat/test_combine_De_Dr.R
@@ -1,6 +1,5 @@
 test_that("Test combine_De_Dr", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## simple test using the example
   ## set parameters

--- a/tests/testthat/test_convert_Activity2Concentration.R
+++ b/tests/testthat/test_convert_Activity2Concentration.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## set dataframe
   data_activity <- data.frame(

--- a/tests/testthat/test_convert_Concentration2DoseRate.R
+++ b/tests/testthat/test_convert_Concentration2DoseRate.R
@@ -1,6 +1,5 @@
 test_that("basic checks", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## template
   template <- expect_s3_class(convert_Concentration2DoseRate(), "data.frame")

--- a/tests/testthat/test_convert_Daybreak2CSV.R
+++ b/tests/testthat/test_convert_Daybreak2CSV.R
@@ -1,6 +1,5 @@
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(convert_Daybreak2CSV(),
                "file is missing")
@@ -10,7 +9,6 @@ test_that("input validation", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   res <- read_Daybreak2R(file = system.file("extdata/Daybreak_TestFile.txt",
                                             package = "Luminescence"))[[1]]

--- a/tests/testthat/test_convert_PSL2CSV.R
+++ b/tests/testthat/test_convert_PSL2CSV.R
@@ -1,6 +1,5 @@
 test_that("General test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##get file
   file <- system.file("extdata/DorNie_0016.psl", package = "Luminescence")
@@ -45,5 +44,3 @@ test_that("General test", {
   expect_false(grepl(pattern = "USER", colnames(df)[1]))
 
 })
-
-

--- a/tests/testthat/test_convert_RLum2Risoe.BINfileData.R
+++ b/tests/testthat/test_convert_RLum2Risoe.BINfileData.R
@@ -1,6 +1,5 @@
 test_that("test for errors", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(convert_RLum2Risoe.BINfileData(object = NA))
 
@@ -9,7 +8,6 @@ test_that("test for errors", {
 
 test_that("functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.RLum.Analysis, envir = environment())

--- a/tests/testthat/test_convert_SG2MG.R
+++ b/tests/testthat/test_convert_SG2MG.R
@@ -1,6 +1,5 @@
 test_that("test conversion from single grain data to multiple grain data", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## load example dataset
   data(ExampleData.BINfileData, envir = environment())

--- a/tests/testthat/test_convert_Wavelength2Energy.R
+++ b/tests/testthat/test_convert_Wavelength2Energy.R
@@ -1,6 +1,5 @@
 test_that("test convert functions", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   # Set up test scenario ------------------------------------------------------------------------
   #create artifical dataset according to Mooney et al. (2013)

--- a/tests/testthat/test_convert_XSYG2CSV.R
+++ b/tests/testthat/test_convert_XSYG2CSV.R
@@ -1,6 +1,5 @@
 test_that("test convert functions", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##test for errors
   expect_error(convert_XSYG2CSV(),

--- a/tests/testthat/test_extract_IrradiationTimes.R
+++ b/tests/testthat/test_extract_IrradiationTimes.R
@@ -1,6 +1,5 @@
 test_that("Test the extraction of irradiation times", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##set file
   file <- system.file("extdata/XSYG_file.xsyg", package="Luminescence")
@@ -21,5 +20,3 @@ test_that("Test the extraction of irradiation times", {
   expect_type(temp$irr.times$START, "double")
 
 })
-
-

--- a/tests/testthat/test_extract_ROI.R
+++ b/tests/testthat/test_extract_ROI.R
@@ -1,6 +1,5 @@
 test_that("extract_ROI", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## generate random data
   m <- matrix(runif(100,0,255), ncol = 10, nrow = 10)
@@ -62,4 +61,3 @@ test_that("extract_ROI", {
                "\\[extract\\_ROI\\(\\)\\] roi\\_summary method not supported, check manual!")
 
 })
-

--- a/tests/testthat/test_fit_CWCurve.R
+++ b/tests/testthat/test_fit_CWCurve.R
@@ -1,6 +1,5 @@
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.CW_OSL_Curve, envir = environment())
   fit <- fit_CWCurve(values = ExampleData.CW_OSL_Curve,
@@ -16,7 +15,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.CW_OSL_Curve, envir = environment())
   fit <- fit_CWCurve(values = ExampleData.CW_OSL_Curve,

--- a/tests/testthat/test_fit_EmissionSpectra.R
+++ b/tests/testthat/test_fit_EmissionSpectra.R
@@ -1,6 +1,5 @@
 test_that("standard check", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.XSYG, envir = environment())

--- a/tests/testthat/test_fit_LMCurve.R
+++ b/tests/testthat/test_fit_LMCurve.R
@@ -10,7 +10,6 @@ fit <- fit_LMCurve(values = values.curve,
 
 test_that("crashs and warnings function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## wrong input type
   expect_error(object = fit_LMCurve(values = "error"),
@@ -28,7 +27,6 @@ test_that("crashs and warnings function", {
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(fit, "RLum.Results")
   expect_equal(length(fit), 4)
@@ -40,7 +38,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(fit$data$n.components, 3)
   expect_equal(round(fit$data$Im1, digits = 0), 169)
@@ -61,7 +58,6 @@ fit <- fit_LMCurve(values = values.curve,
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s4_class(fit, "RLum.Results")
   expect_equal(length(fit), 4)
@@ -70,7 +66,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(fit$data$n.components, 3)
   expect_equal(round(fit$data$Im1, digits = 0), 169)
@@ -80,4 +75,3 @@ test_that("check values from output example", {
 
 
 })
-

--- a/tests/testthat/test_fit_OSLLifeTimes.R
+++ b/tests/testthat/test_fit_OSLLifeTimes.R
@@ -7,7 +7,6 @@ temp_analysis <- set_RLum("RLum.Analysis", records = temp_list)
 
 test_that("standard check", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##trigger errors
   expect_null(fit_OSLLifeTimes(object = "test"))
@@ -58,4 +57,3 @@ test_that("standard check", {
     n.components = 1), regexp = "log-scale requires x-values > 0, set min xlim to 0.01!")
 
 })
-

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -6,7 +6,6 @@ d4 <- ExampleData.SurfaceExposure$set_2
 
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(fit_SurfaceExposure("test"),
                "'data' must be of class data.frame")
@@ -25,7 +24,6 @@ fit <- fit_SurfaceExposure(data = d1, sigmaphi = 5e-10, mu = 0.9,
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(fit), c("RLum.Results", "RLum"))
   expect_equal(length(fit), 5)
@@ -42,7 +40,6 @@ fit <- fit_SurfaceExposure(data = d1, sigmaphi = 5e-10, mu = 0.9, weights = TRUE
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(round(fit$summary$age), 9624)
   expect_equal(round(fit$summary$age_error), 273)
@@ -56,7 +53,6 @@ fit <- fit_SurfaceExposure(data = data.table(d2), age = 1e4,
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(fit), c("RLum.Results", "RLum"))
   expect_equal(length(fit), 5)
@@ -73,7 +69,6 @@ fit <- fit_SurfaceExposure(data = d3, age = c(1e3, 1e4, 1e5, 1e6), sigmaphi = 5e
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(fit), c("RLum.Results", "RLum"))
   expect_equal(nrow(fit$summary), 4)
@@ -104,7 +99,6 @@ test_that("check values from output example", {
 #### WARNINGS & FAILURES
 test_that("not enough parameters provided", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_message(
     fit_SurfaceExposure(data = d1, plot = FALSE, verbose = TRUE),

--- a/tests/testthat/test_fit_ThermalQuenching.R
+++ b/tests/testthat/test_fit_ThermalQuenching.R
@@ -11,7 +11,6 @@ data_NA[1,] <- NA
 
 test_that("standard check", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##trigger errors
   expect_error(fit_ThermalQuenching(data = "test"))
@@ -61,4 +60,3 @@ test_that("standard check", {
 
 
 })
-

--- a/tests/testthat/test_get_RLum.R
+++ b/tests/testthat/test_get_RLum.R
@@ -11,7 +11,6 @@ temp_RLumResults <- set_RLum(class = "RLum.Results")
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_s3_class(get_RLum(temp), class = "data.frame")
   expect_type(get_RLum(temp, data.object = "args"), "list")
@@ -26,7 +25,6 @@ test_that("check class and length of output", {
 
 test_that("check get_RLum on a list and NULL", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   object <- set_RLum(class = "RLum.Analysis", records = rep(set_RLum(class = "RLum.Data.Curve"), 10))
   expect_warning(get_RLum(object, recordType = "test"),

--- a/tests/testthat/test_github.R
+++ b/tests/testthat/test_github.R
@@ -7,7 +7,6 @@
 
 test_that("Check github_commits()", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   response <- tryCatch(github_commits(), error = function(e) return(e))
 
@@ -22,7 +21,6 @@ test_that("Check github_commits()", {
 
 test_that("Check github_branches()", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   response <- tryCatch(github_branches(), error = function(e) return(e))
 
@@ -37,7 +35,6 @@ test_that("Check github_branches()", {
 
 test_that("Check github_issues()", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   response <- tryCatch(github_issues(), error = function(e) return(e))
 

--- a/tests/testthat/test_import_Data.R
+++ b/tests/testthat/test_import_Data.R
@@ -1,6 +1,5 @@
 test_that("Test general import", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## BINX
   expect_type(

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -1,6 +1,5 @@
 test_that("Test internals", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   # .expand_parameters() ------------------------------------------------------
   ##create empty function ... reminder

--- a/tests/testthat/test_merge_RLum.Analysis.R
+++ b/tests/testthat/test_merge_RLum.Analysis.R
@@ -1,6 +1,5 @@
 test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.RLum.Analysis, envir = environment())
   o1 <- IRSAR.RF.Data

--- a/tests/testthat/test_merge_RLum.R
+++ b/tests/testthat/test_merge_RLum.R
@@ -1,6 +1,5 @@
 test_that("Merge tests", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load data
   data(ExampleData.RLum.Analysis, envir = environment())

--- a/tests/testthat/test_merge_RLumDataCurve.R
+++ b/tests/testthat/test_merge_RLumDataCurve.R
@@ -1,6 +1,5 @@
 test_that("Merge tests", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.XSYG, envir = environment())

--- a/tests/testthat/test_merge_RLumResults.R
+++ b/tests/testthat/test_merge_RLumResults.R
@@ -1,6 +1,5 @@
 test_that("Merge RLum.Results", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## check whether arguments are retained
   a <- array(runif(300, 0,255), c(10,10,3))

--- a/tests/testthat/test_merge_Risoe.BINfileData.R
+++ b/tests/testthat/test_merge_Risoe.BINfileData.R
@@ -1,6 +1,5 @@
 test_that("Test merging", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##expect error
   expect_error(merge_Risoe.BINfileData(input.objects = c("data", "data2")),

--- a/tests/testthat/test_methods_DRAC.R
+++ b/tests/testthat/test_methods_DRAC.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("methods_DRAC", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   input <- template_DRAC()
 
@@ -73,4 +72,3 @@ test_that("methods_DRAC", {
 
 
 })
-

--- a/tests/testthat/test_methods_S3.R
+++ b/tests/testthat/test_methods_S3.R
@@ -1,6 +1,5 @@
 test_that("Test various S3 methods", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## create test data
   data(ExampleData.CW_OSL_Curve, envir = environment())
@@ -21,8 +20,4 @@ test_that("Test various S3 methods", {
   expect_silent(plot(list(temp, temp)))
   expect_silent(plot(subset(CWOSL.SAR.Data, ID == 1)))
   expect_silent(hist(dose.rate))
-
-
-
-
 })

--- a/tests/testthat/test_names_RLum.R
+++ b/tests/testthat/test_names_RLum.R
@@ -1,6 +1,5 @@
 test_that("Test whether function works", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.RLum.Analysis, envir = environment())
   expect_silent(names_RLum(IRSAR.RF.Data))

--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -1,6 +1,5 @@
 test_that("Test examples from the example page", {
   testthat::skip_on_cran()
-  local_edition(3)
 
    ## load example data and recalculate to Gray
   data(ExampleData.DeValues, envir = environment())
@@ -165,7 +164,6 @@ test_that("Test examples from the example page", {
 
 test_that("Cause full function stop", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##wrong input data
   expect_error(plot_AbanicoPlot(data = "Michael"),
@@ -173,4 +171,3 @@ test_that("Cause full function stop", {
 
 
 })
-

--- a/tests/testthat/test_plot_DRCSummary.R
+++ b/tests/testthat/test_plot_DRCSummary.R
@@ -1,6 +1,5 @@
 test_that("Test certain input scenarios", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##function stop
   expect_error(plot_DRCSummary("test"), regexp = "The input is not of class 'RLum.Results'")
@@ -11,7 +10,6 @@ test_that("Test certain input scenarios", {
 
 test_that("Test plotting", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   #load data example data
   data(ExampleData.BINfileData, envir = environment())

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -1,6 +1,5 @@
 test_that("plot_DetPlot", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##ExampleData.BINfileData contains two BINfileData objects
   ##CWOSL.SAR.Data and TL.SAR.Data

--- a/tests/testthat/test_plot_Functions.R
+++ b/tests/testthat/test_plot_Functions.R
@@ -1,6 +1,5 @@
 test_that("test pure success of the plotting without warning or error", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##distribution plots
   data(ExampleData.DeValues, envir = environment())
@@ -127,15 +126,10 @@ test_that("test pure success of the plotting without warning or error", {
                              sigmab = 0.2, n.components = c(2:4),
                              pdf.weight = TRUE, dose.scale = c(0, 100))
     plot_RLum(FMM)
-
-
-
-
 })
 
 test_that("test for return values, if any", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.DeValues, envir = environment())
   output <- plot_AbanicoPlot(ExampleData.DeValues, output = TRUE)

--- a/tests/testthat/test_plot_GrowthCurve.R
+++ b/tests/testthat/test_plot_GrowthCurve.R
@@ -1,6 +1,5 @@
 test_that("plot_GrowthCurve", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## load data
   data(ExampleData.LxTxData, envir = environment())

--- a/tests/testthat/test_plot_OSLAgeSummary.R
+++ b/tests/testthat/test_plot_OSLAgeSummary.R
@@ -1,6 +1,5 @@
 test_that("Basic test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##cause error
   expect_error(plot_OSLAgeSummary("error"),

--- a/tests/testthat/test_plot_RLum.Analysis.R
+++ b/tests/testthat/test_plot_RLum.Analysis.R
@@ -1,6 +1,5 @@
 test_that("Test the basic plot functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##create dataset
   ##load data

--- a/tests/testthat/test_plot_RLum.Data.Curve.R
+++ b/tests/testthat/test_plot_RLum.Data.Curve.R
@@ -1,6 +1,5 @@
 test_that("Test the basic plot functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## create dataset
   #load Example data

--- a/tests/testthat/test_plot_RLum.Data.Image.R
+++ b/tests/testthat/test_plot_RLum.Data.Image.R
@@ -1,6 +1,5 @@
 test_that("Test image plotting", {
   testthat::skip_on_cran()
-  local_edition(3)
 
     ## create dataset to test
     image <- as(array(rnorm(1000), dim = c(10,10,10)), "RLum.Data.Image")

--- a/tests/testthat/test_plot_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_plot_RLum.Data.Spectrum.R
@@ -1,6 +1,5 @@
 test_that("test pure success of the plotting without warning or error", {
   testthat::skip_on_cran()
-  local_edition(3)
 
     ##RLum.Data.Spectrum -------
     data(ExampleData.XSYG, envir = environment())

--- a/tests/testthat/test_plot_RLum.R
+++ b/tests/testthat/test_plot_RLum.R
@@ -1,6 +1,5 @@
 test_that("test_plot_RLum", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## create dataset to test
   image <- as(array(rnorm(1000), dim = c(10,10,10)), "RLum.Data.Image")

--- a/tests/testthat/test_plot_ROI.R
+++ b/tests/testthat/test_plot_ROI.R
@@ -1,6 +1,5 @@
 test_that("Complete test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##create suitable dataset
   file <- system.file("extdata", "RF_file.rf", package = "Luminescence")

--- a/tests/testthat/test_plot_RadialPlot.R
+++ b/tests/testthat/test_plot_RadialPlot.R
@@ -1,6 +1,5 @@
 test_that("dedicated test for the radialplot", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##distribution plots
   set.seed(12310)

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -1,6 +1,5 @@
 test_that("test the import of various BIN-file versions", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##test for various errors
   expect_error(read_BIN2R(file = ""), "[read_BIN2R()] File does not exist!", fixed = TRUE)

--- a/tests/testthat/test_read_Daybreak2R.R
+++ b/tests/testthat/test_read_Daybreak2R.R
@@ -1,6 +1,5 @@
 test_that("Test functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   txt.file <- system.file("extdata/Daybreak_TestFile.txt",
                           package = "Luminescence")

--- a/tests/testthat/test_read_HeliosOSL2R.R
+++ b/tests/testthat/test_read_HeliosOSL2R.R
@@ -1,6 +1,5 @@
 test_that("Test functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## crash function
   expect_error(

--- a/tests/testthat/test_read_PSL2R.R
+++ b/tests/testthat/test_read_PSL2R.R
@@ -2,7 +2,6 @@ psl.file <- system.file("extdata/DorNie_0016.psl", package = "Luminescence")
 
 test_that("Test functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## default values
   expect_s4_class(read_PSL2R(
@@ -18,7 +17,6 @@ test_that("Test functionality", {
 
 test_that("Input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## directory given (assumes that we have a .psl file under inst/extdata)
   expect_message(

--- a/tests/testthat/test_read_RF2R.R
+++ b/tests/testthat/test_read_RF2R.R
@@ -1,6 +1,5 @@
 test_that("Test functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load file path
   file <- system.file("extdata", "RF_file.rf", package = "Luminescence")

--- a/tests/testthat/test_read_SPE2R.R
+++ b/tests/testthat/test_read_SPE2R.R
@@ -1,6 +1,5 @@
 test_that("Test general functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##crash function
   expect_null(read_SPE2R(file = "text"))

--- a/tests/testthat/test_read_TIFF2R.R
+++ b/tests/testthat/test_read_TIFF2R.R
@@ -1,6 +1,5 @@
 test_that("Test general functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##crash function
   expect_error(object = read_TIFF2R(file = "text"),

--- a/tests/testthat/test_read_XSYG2R.R
+++ b/tests/testthat/test_read_XSYG2R.R
@@ -1,6 +1,5 @@
 test_that("test import of XSYG files", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##force error
   expect_null(read_XSYG2R("https://raw.githubusercontent.com/R-Lum/rxylib/master/inst/extg", fastForward = TRUE))
@@ -27,5 +26,3 @@ test_that("test import of XSYG files", {
   expect_type(results[[1]]@info$file, type = "character")
 
 })
-
-

--- a/tests/testthat/test_replicate_RLum.R
+++ b/tests/testthat/test_replicate_RLum.R
@@ -1,6 +1,5 @@
 test_that("Test replication of RLum-objects", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.RLum.Analysis, envir = environment())
   expect_silent(results <- rep(IRSAR.RF.Data[[1]], 5))

--- a/tests/testthat/test_report_RLum.R
+++ b/tests/testthat/test_report_RLum.R
@@ -1,6 +1,5 @@
 test_that("Test Simple RLum Report", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## the test fails on AppVeyor for no obvious reason on the windows
   ## platform ... attempts to reproduce this failure failed. So

--- a/tests/testthat/test_scale_GammaDose.R
+++ b/tests/testthat/test_scale_GammaDose.R
@@ -9,7 +9,6 @@ results <- scale_GammaDose(data = d,
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(results), c("RLum.Results", "RLum"))
   expect_equal(length(results), 6)
@@ -18,7 +17,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(formatC(results$summary$dose_rate_total, 4), "0.9242")
   expect_equal(formatC(results$summary$dose_rate_total_err, 4), "0.2131")
@@ -32,7 +30,6 @@ results <- scale_GammaDose(data = d,
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(results), c("RLum.Results", "RLum"))
   expect_equal(length(results), 6)
@@ -41,7 +38,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(formatC(results$summary$dose_rate_total, 4), "0.9214")
   expect_equal(formatC(results$summary$dose_rate_total_err, 4), "0.2124")
@@ -55,7 +51,6 @@ results <- scale_GammaDose(data = d,
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(is(results), c("RLum.Results", "RLum"))
   expect_equal(length(results), 6)
@@ -64,7 +59,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_equal(formatC(results$summary$dose_rate_total, 4), "0.9123")
   expect_equal(formatC(results$summary$dose_rate_total_err, 4), "0.2097")
@@ -82,7 +76,6 @@ test_that("console & plot", {
 ## WARNINGS & FAILURES
 test_that("check input data", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(
     scale_GammaDose(NA, plot = FALSE, verbose = TRUE),
@@ -158,4 +151,3 @@ test_that("check input data", {
   "Invalid 'fractional_gamma_dose'. Valid options:"
   )
 })
-

--- a/tests/testthat/test_smooth_RLum.R
+++ b/tests/testthat/test_smooth_RLum.R
@@ -11,7 +11,6 @@ temp_analysis <- set_RLum("RLum.Analysis", records = list(temp, temp))
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##standard tests
   expect_s4_class(temp, class = "RLum.Data.Curve")
@@ -31,7 +30,6 @@ test_that("check class and length of output", {
 
 test_that("check values from output example", {
  testthat::skip_on_cran()
-  local_edition(3)
 
  expect_equal(round(mean(smooth_RLum(temp, k = 5)[,2], na.rm = TRUE), 0), 100)
  expect_equal(round(mean(smooth_RLum(temp, k = 10)[,2], na.rm = TRUE), 0), 85)

--- a/tests/testthat/test_structure_RLum.R
+++ b/tests/testthat/test_structure_RLum.R
@@ -1,6 +1,5 @@
 test_that("Test whether the function works", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.RLum.Analysis, envir = environment())
   expect_silent(structure_RLum(IRSAR.RF.Data))

--- a/tests/testthat/test_subset_RLum.R
+++ b/tests/testthat/test_subset_RLum.R
@@ -1,7 +1,6 @@
 # RLum.Analysis -----------------------------------------------------------
 test_that("subset RLum.Analysis", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data("ExampleData.RLum.Analysis")
   temp <- IRSAR.RF.Data

--- a/tests/testthat/test_subset_SingleGrainData.R
+++ b/tests/testthat/test_subset_SingleGrainData.R
@@ -1,6 +1,5 @@
 test_that("Check subset_SingleGrain", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## get example ready
   data(ExampleData.BINfileData, envir = environment())

--- a/tests/testthat/test_template_DRAC.R
+++ b/tests/testthat/test_template_DRAC.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("Check template creation ", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## test output class
   expect_s3_class(template_DRAC(), "DRAC.list")
@@ -36,4 +35,3 @@ test_that("Check template creation ", {
   expect_error(template_DRAC(preset = 999))
 
 })
-

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -1,6 +1,5 @@
 test_that("RLum.Data.Curve", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   data(ExampleData.BINfileData, envir = environment())
   temp <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
@@ -66,7 +65,6 @@ test_that("RLum.Data.Curve", {
 
 test_that("RLum.Data.Spectrum", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## simple test for RLum.Data.Spectrum ... this can be kept
   ## simple because everything else was tested already
@@ -82,7 +80,6 @@ test_that("RLum.Data.Spectrum", {
 
 test_that("RLum.Data.Image", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## simple test for RLum.Data.Spectrum ... this can be kept
   ## simple because everything else was tested already
@@ -96,7 +93,6 @@ test_that("RLum.Data.Image", {
 
 test_that("RLum.Analysis", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##load example data
   data(ExampleData.BINfileData, envir = environment())
@@ -142,15 +138,9 @@ test_that("RLum.Analysis", {
 
 test_that("Crash function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## trigger stop
   testthat::expect_error(
     object = trim_RLum.Data("error"),
     regexp = "\\[trim\\_RLum.Data\\(\\)\\] Unsupported input class\\!")
-
-
-
 })
-
-

--- a/tests/testthat/test_use_DRAC.R
+++ b/tests/testthat/test_use_DRAC.R
@@ -1,7 +1,6 @@
 ##Full check
 test_that("Test DRAC", {
   testthat::skip_on_cran()
-  local_edition(3)
 
  ##use manual example
  ##create template
@@ -52,4 +51,3 @@ test_that("Test DRAC", {
  expect_error(use_DRAC(input), "The limit of allowed datasets is 5000!")
 
 })
-

--- a/tests/testthat/test_verify_SingleGrainData.R
+++ b/tests/testthat/test_verify_SingleGrainData.R
@@ -1,6 +1,5 @@
 test_that("Various function test", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   expect_error(verify_SingleGrainData("test"),
                "Input type 'character' is not allowed for this function")

--- a/tests/testthat/test_write_R2BIN.R
+++ b/tests/testthat/test_write_R2BIN.R
@@ -1,6 +1,5 @@
 test_that("write to empty connection", {
   testthat::skip_on_cran()
-  local_edition(3)
 
 #Unit test for write_BIN2R() function
 

--- a/tests/testthat/test_write_R2TIFF.R
+++ b/tests/testthat/test_write_R2TIFF.R
@@ -1,6 +1,5 @@
 test_that("Test general functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## load example data
   data(ExampleData.RLum.Data.Image, envir = environment())

--- a/tests/testthat/test_write_RLum2CSV.R
+++ b/tests/testthat/test_write_RLum2CSV.R
@@ -1,6 +1,5 @@
 test_that("test errors and general export function", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##test error
   expect_error(write_RLum2CSV(),

--- a/tests/testthat/test_zzz.R
+++ b/tests/testthat/test_zzz.R
@@ -1,6 +1,5 @@
 test_that("Test zzz functions ... they should still work", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ##get right answer
   expect_equal(get_rightAnswer(), 46)


### PR DESCRIPTION
These removes all occurrences of `local_edition(3)` by setting the edition in the `DESCRIPTION` file, and replaces the few uses of `expect_is()`, which has been deprecated in the 3rd edition.