### PR TITLE
Start silencing output from tests

### DIFF
--- a/R/calc_gSGC_feldspar.R
+++ b/R/calc_gSGC_feldspar.R
@@ -186,9 +186,9 @@ calc_gSGC_feldspar <- function (
 
       ## in case the initial uniroot solve does not work
       if(inherits(temp, "try-error")) {
-        try(stop(paste0("[calc_gSGC_feldspar()] No solution was found for dataset: #", i,"! NA returned"), call. = FALSE))
+        message("[calc_gSGC_feldspar()] Error: No solution found for ",
+                "dataset #", i, ", NA returned")
         return(NA)
-
       }
 
       De <- temp$root

--- a/R/read_RF2R.R
+++ b/R/read_RF2R.R
@@ -46,8 +46,8 @@ read_RF2R <- function(
 
       ##check whether it worked
       if(inherits(temp, "try-error")){
-        try(
-          stop("[read_RF2R()] Import for file ", f, " failed. NULL returned!", call. = FALSE))
+        message("[read_RF2R()] Error: Import for file '", f,
+                "' failed, NULL returned")
         return(NULL)
       }else{
         return(temp)
@@ -109,7 +109,8 @@ read_RF2R <- function(
 
     ##test the header
     if(inherits(header, 'try-error')){
-      try(stop("[read_RF2R()] Header extraction failed, try to continue without ... ", call. = FALSE))
+      message("[read_RF2R()] Error: Header extraction failed, ",
+              "trying to continue without ... ")
       header <- NA
     }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,8 @@
+# Silence output and warnings
+#
+# Surround with this function the code that is printing out to the console,
+# such as in:
+# SW({
+# template_DRAC(preset = "DRAC-example_quartz")
+# })
+SW <- function(expr) capture.output(suppressMessages(suppressWarnings(expr)))

--- a/tests/testthat/test_Analyse_SAROSLdata.R
+++ b/tests/testthat/test_Analyse_SAROSLdata.R
@@ -8,7 +8,6 @@ test_that("full example test", {
                                 position = c(1:1),
                                 output.plot = FALSE)
 
-
   ##checks
   expect_type(output, "list")
   expect_length(output, 3)
@@ -26,6 +25,7 @@ test_that("full example test", {
                regexp = "No 'OSL' curves found")
 
   ## should work
+  SW({
   expect_type(Analyse_SAR.OSLdata(input.data = CWOSL.SAR.Data, signal.integral = 1:3,
                                   background.integral = 200:250, position = 1,
                                   background.count.distribution = "non-poisson",
@@ -34,5 +34,5 @@ test_that("full example test", {
   expect_type(
     Analyse_SAR.OSLdata(tmp, 1:3, 200:250, output.plot = TRUE, output.plot.single = TRUE),
     "list")
-
+  })
 })

--- a/tests/testthat/test_Risoe.BINfileData2RLum.Analysis.R
+++ b/tests/testthat/test_Risoe.BINfileData2RLum.Analysis.R
@@ -25,13 +25,17 @@ test_that("input validation", {
 test_that("input validation", {
   testthat::skip_on_cran()
 
+  SW({
   res <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data,
                                          txtProgressBar = TRUE)
+  })
   expect_type(res, "list")
   expect_length(res, 24)
 
+  SW({
   res <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1:3,
                                          txtProgressBar = TRUE)
+  })
   expect_type(res, "list")
   expect_length(res, 3)
 

--- a/tests/testthat/test_analyse_Al2O3C_ITC.R
+++ b/tests/testthat/test_analyse_Al2O3C_ITC.R
@@ -18,18 +18,22 @@ test_that("input validation", {
 #  expect_error(analyse_Al2O3C_ITC(data_ITC, dose_points = list(NA)),
 #               "At least three regeneration points are required") XXX!
 
+  SW({
   expect_warning(analyse_Al2O3C_ITC(data_ITC, signal_integral = 0),
                  "Input for 'signal_integral' corrected to 1:99")
+  })
 })
 
 test_that("Full check", {
   skip_on_cran()
 
   ##run analysis
+  SW({
   expect_s4_class(analyse_Al2O3C_ITC(data_ITC), "RLum.Results")
   expect_s4_class(analyse_Al2O3C_ITC(list(data_ITC), signal_integral = 2,
                                      method_control = list(fit.method = "EXP")),
                   "RLum.Results")
+  })
 
   expect_warning(expect_null(analyse_Al2O3C_ITC(list(data_ITC),
                                                 dose_points = list(2))),

--- a/tests/testthat/test_analyse_Al2O3C_Measurement.R
+++ b/tests/testthat/test_analyse_Al2O3C_Measurement.R
@@ -4,6 +4,7 @@ data(ExampleData.Al2O3C, envir = environment())
 test_that("input validation", {
   skip_on_cran()
 
+  SW({
   expect_error(analyse_Al2O3C_Measurement(),
                "is missing, with no default")
   expect_error(analyse_Al2O3C_Measurement("error"),
@@ -27,15 +28,18 @@ test_that("input validation", {
 
   expect_warning(Luminescence:::.warningCatcher(
                                      analyse_Al2O3C_Measurement(object = data_CrossTalk, signal_integral = 1000)))
+  })
 })
 
 test_that("analyse_Al2O3C_Measurements", {
   skip_on_cran()
 
-   ##run analysis
+  ## run analysis
+  SW({
    expect_s4_class(suppressWarnings(analyse_Al2O3C_Measurement(data_CrossTalk)), "RLum.Results")
    expect_s4_class(suppressWarnings(analyse_Al2O3C_Measurement(data_CrossTalk, calculate_TL_dose = TRUE)),
                                     "RLum.Results")
+   })
   expect_output(analyse_Al2O3C_Measurement(data_CrossTalk[[2]],
                         test_parameter = list(stimulation_power = 0.01)))
   expect_output(analyse_Al2O3C_Measurement(data_CrossTalk[[2]],
@@ -43,6 +47,7 @@ test_that("analyse_Al2O3C_Measurements", {
 
   ## tests without TL curves
   temp <- get_RLum(data_CrossTalk, recordType = "OSL", drop = FALSE)
+  SW({
   expect_s4_class(analyse_Al2O3C_Measurement(temp),
                   "RLum.Results")
   expect_output(analyse_Al2O3C_Measurement(temp, travel_dosimeter = 2),
@@ -51,4 +56,5 @@ test_that("analyse_Al2O3C_Measurements", {
                  "'travel_dosimeter' specifies every position")
   expect_message(analyse_Al2O3C_Measurement(temp, travel_dosimeter = 2000),
                  "Invalid position in 'travel_dosimeter', nothing corrected")
+  })
 })

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -13,6 +13,8 @@ test_that("input validation", {
                "'n.MC' must be a positive integer scalar")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method.control = 3),
                "'method.control' has to be of type 'list'")
+
+  SW({
   expect_warning(analyse_IRSAR.RF(IRSAR.RF.Data,
                                   method.control = list(unknown = "test")),
                  "'unknown' not supported for 'method.control'")
@@ -25,11 +27,9 @@ test_that("input validation", {
                  "Your machine has only [0-9]* cores")
   }
 
-  suppressWarnings(
   expect_warning(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
                                   method.control = list(vslide_range = 1:4)),
                  "'vslide_range' in 'method.control' has more than 2 elements")
-  )
 
   expect_message(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
                                   method.control = list(cores = "4")),
@@ -37,12 +37,14 @@ test_that("input validation", {
 
   expect_warning(analyse_IRSAR.RF(IRSAR.RF.Data, method = "UNKNOWN"),
                  "Analysis skipped: Unknown method or threshold of test")
+  })
 })
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
 
   set.seed(1)
+  SW({
   results_fit <- analyse_IRSAR.RF(object = IRSAR.RF.Data, plot = TRUE, method = "FIT")
   results_slide <- suppressWarnings(
     analyse_IRSAR.RF(object = IRSAR.RF.Data, plot = TRUE, method = "SLIDE", n.MC = NULL))
@@ -65,6 +67,7 @@ test_that("check class and length of output", {
       method.control = list(vslide_range = 'auto', trace_vslide = FALSE),
       txtProgressBar = FALSE
     ), class = "RLum.Results")
+  })
 
   expect_equal(is(results_fit), c("RLum.Results", "RLum"))
   expect_equal(length(results_fit), 5)
@@ -100,12 +103,13 @@ test_that("test support for IR-RF data", {
   file <- system.file("extdata", "RF_file.rf", package = "Luminescence")
   temp <- read_RF2R(file)
 
-  suppressWarnings(
+  SW({
   expect_warning(expect_s4_class(
       analyse_IRSAR.RF(object = temp[1:3], method = "SLIDE",
                        plot_reduced = TRUE, n.MC = 1),
       "RLum.Results"),
-      "Narrow density distribution, no density distribution plotted"))
+      "Narrow density distribution, no density distribution plotted")
+  })
 })
 
 test_that("test edge cases", {
@@ -117,6 +121,7 @@ test_that("test edge cases", {
   RF_nat@data[,2] <- runif(length(RF_nat@data[,2]), 65.4, 76.7)
   RF_nat@data <- RF_nat@data[1:50,]
 
+  SW({
   expect_s4_class(suppressWarnings(analyse_IRSAR.RF(
     set_RLum("RLum.Analysis", records = list(RF_nat, RF_reg)),
     method = "SLIDE",
@@ -128,6 +133,7 @@ test_that("test edge cases", {
     mtext = "Subtitle",
     txtProgressBar = FALSE
   )), "RLum.Results")
+  })
 
   ## this RF_nat.lim after
   ##  'length = 2' in coercion to 'logical(1)' error

--- a/tests/testthat/test_calc_FiniteMixture.R
+++ b/tests/testthat/test_calc_FiniteMixture.R
@@ -25,12 +25,14 @@ test_that("check class and length of output", {
                "Only 'se' or 'sigmab' allowed for the pdf.sigma argument")
 
   ## simple run
+  SW({
   temp <- expect_s4_class(calc_FiniteMixture(
     ExampleData.DeValues$CA1,
     sigmab = 0.2,
     n.components = 2,
     grain.probability = TRUE,
     verbose = TRUE), "RLum.Results")
+  })
 
   ## check length of output
   expect_equal(length(temp), 10)
@@ -45,6 +47,7 @@ test_that("check class and length of output", {
   expect_equal(results$proportion[2], 0.8904)
 
   ## test plot
+  SW({
   expect_s4_class(calc_FiniteMixture(
     ExampleData.DeValues$CA1,
     sigmab = 0.2,
@@ -53,5 +56,5 @@ test_that("check class and length of output", {
     trace = TRUE,
     main = "Plot title",
     verbose = TRUE), "RLum.Results")
-
+  })
 })

--- a/tests/testthat/test_calc_Lamothe2003.R
+++ b/tests/testthat/test_calc_Lamothe2003.R
@@ -17,12 +17,14 @@ test_that("Force function to break", {
                regexp = "Input for 'dose_rate.source' is not of type 'numeric' and/or of length < 2!")
 
   ##check warnings
+  SW({
   expect_s4_class(
     suppressWarnings(calc_Lamothe2003(
       object = data.frame(
         x = c(0,10,20), y = c(1.4,0.7,2.3), z = c(0.01,0.02, 0.03)),
       dose_rate.envir = c(1,2,3), dose_rate.source = c(1,2,3), g_value = c(1,1,1))),
     "RLum.Results")
+  })
 
   ##g_value
   expect_error(
@@ -100,6 +102,7 @@ test_that("Test the function itself", {
   )
 
   ##run fading correction
+  SW({
   expect_s4_class(calc_Lamothe2003(
     object = results,
     dose_rate.envir =  c(1.676 , 0.180),
@@ -107,8 +110,10 @@ test_that("Test the function itself", {
     g_value =  c(2.36, 0.6),
     plot = TRUE,
     fit.method = "EXP"), class = "RLum.Results")
+  })
 
   ##run fading correction
+  SW({
   expect_s4_class(calc_Lamothe2003(
     object = results,
     dose_rate.envir =  c(1.676 , 0.180),
@@ -118,11 +123,13 @@ test_that("Test the function itself", {
     tc.g_value = 1200,
     plot = TRUE,
     fit.method = "EXP"), class = "RLum.Results")
+  })
 
   ## pretend to have an analyse_pIRIRSequence originator to increase coverage
   results.mod <- results
   results.mod@originator <- "analyse_pIRIRSequence"
   results.mod@data$LnLxTnTx.table$Signal <- 1
+  SW({
   expect_s4_class(calc_Lamothe2003(
     object = results.mod,
     dose_rate.envir =  c(1.676 , 0.180),
@@ -130,13 +137,16 @@ test_that("Test the function itself", {
     g_value =  c(2.36, 0.6),
     plot = FALSE,
     fit.method = "EXP"), class = "RLum.Results")
+  })
 
   ## signal information present
+  SW({
   res <- suppressWarnings(
     calc_Lamothe2003(
       object = data.frame(x = c(0,10,20), y = c(1.4,0.7,2.3),
                           z = c(0.01,0.02, 0.03), Signal=1:3),
       dose_rate.envir = c(1,2), dose_rate.source = c(1,2),
       g_value = c(1,1)))
+  })
   expect_equal(res$data$SIGNAL, 1:3)
 })

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -32,6 +32,7 @@ test_that("check class and length of output", {
   ## invert
   expect_silent(calc_MinDose(ExampleData.DeValues$CA1, sigmab = 0.1,
                              invert = TRUE, verbose = FALSE, plot = FALSE))
+  SW({
   expect_output(calc_MinDose(ExampleData.DeValues$CA1, sigmab = 0.1,
                              invert = TRUE, log = FALSE, log.output = TRUE,
                              verbose = TRUE, plot = FALSE),
@@ -45,6 +46,7 @@ test_that("check class and length of output", {
                               bootstrap = TRUE, bs.M = 10,
                               multicore = TRUE, cores = 2),
                  "Spawning 2 instances of R for parallel computation")
+  })
 })
 
 test_that("check values from output example", {

--- a/tests/testthat/test_calc_gSGC_feldspar.R
+++ b/tests/testthat/test_calc_gSGC_feldspar.R
@@ -53,8 +53,8 @@ test_that("test errors", {
     plot = TRUE),
     "RLum.Results")
 
-  ##test own curve parameters
-  results <- expect_s4_class(calc_gSGC_feldspar(
+  ## test own curve parameters
+  expect_message(results <- calc_gSGC_feldspar(
     data = data,
     gSGC.parameters = data.frame(
       y1 = 0.6,
@@ -66,9 +66,10 @@ test_that("test errors", {
       y0 = 0.001,
       y0_err = 0.0001
     )),
-    "RLum.Results")
+    "No solution found for dataset")
 
   ##regression tests
+  expect_s4_class(results, "RLum.Results")
   expect_true(all(is.na(unlist(results$m.MC))))
 
 })

--- a/tests/testthat/test_combine_De_Dr.R
+++ b/tests/testthat/test_combine_De_Dr.R
@@ -11,6 +11,7 @@ test_that("Test combine_De_Dr", {
   set.seed(1276)
 
   ## break function
+  SW({
   expect_error(combine_De_Dr(
     Dr = Dr,
     int_OD = 0.1,
@@ -30,6 +31,7 @@ test_that("Test combine_De_Dr", {
     legend = TRUE,
     method_control = list(n.iter = 100,
                           n.chains = 1)), "RLum.Results")
+  })
 
   ## check whether mcmc is NULL
   expect_null(results$mcmc_IAM)
@@ -37,6 +39,7 @@ test_that("Test combine_De_Dr", {
 
   ## run the same with different par settings
   oldpar <- par(mfrow = c(2,2))
+  SW({
   results <- expect_s4_class(combine_De_Dr(
     Dr = Dr,
     int_OD = 0.1,
@@ -50,7 +53,7 @@ test_that("Test combine_De_Dr", {
       n.chains = 1,
       return_mcmc = TRUE
       )), "RLum.Results")
-
+  })
 
   ## check the length of the output
   expect_length(results, 9)
@@ -60,9 +63,12 @@ test_that("Test combine_De_Dr", {
   expect_s3_class(results$mcmc_BCAM, "mcmc.list")
 
   ## try to plot the results again
+  SW({
   plot_OSLAgeSummary(results)
+  })
 
   ## diag = TRUE
+  SW({
   expect_error(combine_De_Dr(
     Dr = Dr, int_OD = 0.1, De, s, Age_range = c(0, 100),
     method_control = list(n.iter = 100, n.chains = 1, diag = TRUE)),
@@ -71,14 +77,17 @@ test_that("Test combine_De_Dr", {
     Dr = Dr, int_OD = 0.1, De, s, Age_range = c(0, 100),
     method_control = list(n.iter = 100, n.chains = 2, diag = TRUE)),
     "RLum.Results")
+  })
 
   ## cdf_ADr_quantiles = TRUE and outlier_method = "RousseeuwCroux1993"
+  SW({
   expect_s4_class(combine_De_Dr(
     Dr = Dr, int_OD = 0.1, De, s, Age_range = c(0, 100),
     cdf_ADr_quantiles = TRUE,
     outlier_method = "RousseeuwCroux1993",
     method_control = list(n.iter = 100, n.chains = 1)),
     "RLum.Results")
+  })
 
   ## reset the graphical parameters to the original values
   par(oldpar)

--- a/tests/testthat/test_convert_XSYG2CSV.R
+++ b/tests/testthat/test_convert_XSYG2CSV.R
@@ -10,7 +10,9 @@ test_that("test convert functions", {
                regexp = "[read_BIN2R()] File does not exist!",
                fixed = TRUE)
   #expect_error(convert_PSL2CSV(file = "", export = FALSE))
-  expect_error(suppressWarnings(convert_XSYG2CSV(file = "", export = FALSE)))
+  expect_error(expect_message(convert_XSYG2CSV(file = "", export = FALSE),
+                              "XML file not readable, nothing imported"),
+               "Object needs to be a member of the object class RLum")
 
   ##test conversion itself
     ##BIN2CSV

--- a/tests/testthat/test_extract_IrradiationTimes.R
+++ b/tests/testthat/test_extract_IrradiationTimes.R
@@ -11,29 +11,36 @@ test_that("input validation", {
   expect_error(extract_IrradiationTimes(xsyg, file.BINX = "fail"),
                "Wrong BINX file name or file does not exist!")
 
+  SW({
   ## FIXME(mcol): catch this error properly
   expect_error(extract_IrradiationTimes(xsyg, file.BINX = binx,
                                         txtProgressBar = FALSE),
                "replacement has 3 rows, data has 2")
-
   expect_warning(extract_IrradiationTimes(list(xsyg), file.BINX = binx),
                  "'file.BINX' is not supported in self-call mode")
+  })
 })
 
 test_that("Test the extraction of irradiation times", {
   testthat::skip_on_cran()
 
   ##general test
+  SW({
   res <- expect_s4_class(extract_IrradiationTimes(xsyg, txtProgressBar = FALSE),
                          "RLum.Results")
+  })
 
   ##check whether it makes sense
   expect_equal(sum(res$irr.times$IRR_TIME), 80)
 
+  SW({
   extract_IrradiationTimes(list(xsyg), recordType = list("OSL (UVVIS)"))
+  })
 
   ## apply the function to something previously imported via read_BIN2R
+  SW({
   temp <- read_BIN2R(binx, fastForward = TRUE)
   temp <- expect_s4_class(extract_IrradiationTimes(temp)[[1]], "RLum.Results")
+  })
   expect_type(temp$irr.times$START, "double")
 })

--- a/tests/testthat/test_fit_EmissionSpectra.R
+++ b/tests/testthat/test_fit_EmissionSpectra.R
@@ -18,10 +18,12 @@ test_that("standard check", {
 
 
   ## wrong graining argument -------
+  SW({
   expect_error(fit_EmissionSpectra(TL.Spectrum, frame = 5,
       method_control = list(graining = 10000)),
       "method_control$graining cannot exceed the available channels (1024)",
       fixed = TRUE)
+  })
 
   ## for matrix input -------
   expect_error(fit_EmissionSpectra("fail"),
@@ -30,12 +32,15 @@ test_that("standard check", {
   mat <- get_RLum(TL.Spectrum)[, 1:4]
   expect_error(fit_EmissionSpectra(object = mat, frame = 1000),
                "'frame' invalid. Allowed range min: 1 and max: 3")
+  SW({
   expect_s4_class(
       fit_EmissionSpectra(object = mat, plot = FALSE, verbose = FALSE,
                           method_control = list(max.runs = 5)),
       "RLum.Results")
+  })
 
   # plain run -------
+  SW({
   results <-  expect_s4_class(fit_EmissionSpectra(
     object = TL.Spectrum,
     frame = 5,
@@ -44,6 +49,7 @@ test_that("standard check", {
     plot = TRUE,
     start_parameters = c(2.17),
     method_control = list(max.runs = 100)), "RLum.Results")
+  })
 
   # silent mode -------
   expect_silent(fit_EmissionSpectra(
@@ -60,17 +66,21 @@ test_that("standard check", {
  expect_type(results$data, "double")
 
   ## input_scale
+  SW({
   expect_s4_class(
       fit_EmissionSpectra(object = TL.Spectrum, frame = 5,
                           input_scale = "wavelength", plot = FALSE,
                           method_control = list(max.runs = 5)),
       "RLum.Results")
+  })
 
   ## plot
   set.seed(1)
+  SW({
   expect_s4_class(
       fit_EmissionSpectra(object = TL.Spectrum, frame = 5, plot = TRUE,
                           n_components = 3, verbose = FALSE, mtext = "Subtitle",
                           method_control = list(max.runs = 5)),
       "RLum.Results")
+  })
 })

--- a/tests/testthat/test_fit_LMCurve.R
+++ b/tests/testthat/test_fit_LMCurve.R
@@ -21,18 +21,21 @@ test_that("input validation", {
                "Unknown method for 'fit.method'")
 
   ## warning for failed confint ...skip on windows because with R >= 4.2 is does not fail anymore
+  SW({
   if (!grepl(pattern = "mingw", sessionInfo()$platform) && !grepl(pattern = "linux", sessionInfo()$platform))
     expect_warning(fit_LMCurve(values = values.curve, fit.calcError = TRUE))
-
+  })
 })
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
 
+  SW({
   fit <- fit_LMCurve(values.curve, values.bg = values.curveBG,
                      n.components = 3, log = "x",
                      start_values = data.frame(Im = c(170,25,400),
                                                xm = c(56,200,1500)))
+  })
 
   expect_s4_class(fit, "RLum.Results")
   expect_equal(length(fit), 4)
@@ -48,12 +51,14 @@ test_that("check class and length of output", {
 })
 
 ## Test 2 with LM
+SW({
 fit <- fit_LMCurve(values = values.curve,
                    values.bg = values.curveBG,
                    n.components = 3,
                    log = "x",
                    fit.method = "LM",
                    plot = FALSE)
+})
 
 test_that("check class and length of output", {
   testthat::skip_on_cran()
@@ -67,7 +72,7 @@ test_that("check class and length of output", {
   expect_equal(round(fit$data$b1, digits = 0), 2)
   expect_equal(round(fit$data$`pseudo-R^2`, digits = 0), 1)
 
-
+  SW({
   expect_message(fit <- fit_LMCurve(values.curve, values.bg = values.curveBG,
                                     start_values = data.frame(Im = c(70,25,400),
                                                               xm = c(56,200,10))),
@@ -87,4 +92,5 @@ test_that("check class and length of output", {
                                  fit.advanced = TRUE, fit.calcError = TRUE),
                  "The computation of the parameter confidence intervals failed")
   )
+  })
 })

--- a/tests/testthat/test_read_Daybreak2R.R
+++ b/tests/testthat/test_read_Daybreak2R.R
@@ -7,19 +7,25 @@ test_that("Test functionality", {
                           package = "Luminescence")
 
   ## TXT
+  SW({
   expect_type(read_Daybreak2R(txt.file), "list")
-  expect_silent(read_Daybreak2R(txt.file, verbose = FALSE))
   expect_type(read_Daybreak2R(txt.file, txtProgressBar = FALSE),
               "list")
+  })
+  expect_silent(read_Daybreak2R(txt.file, verbose = FALSE))
 
   ## DAT
+  SW({
   expect_type(read_Daybreak2R(dat.file), "list")
   expect_s3_class(read_Daybreak2R(dat.file, raw = TRUE),
                   "data.table")
+  })
   expect_silent(read_Daybreak2R(dat.file, verbose = FALSE))
 
   ## list
+  SW({
   expect_type(read_Daybreak2R(list(dat.file)), "list")
+  })
 
   ## directory
   expect_error(

--- a/tests/testthat/test_read_RF2R.R
+++ b/tests/testthat/test_read_RF2R.R
@@ -12,7 +12,9 @@ test_that("Test functionality", {
   expect_type(read_RF2R(file), type = "list")
 
   ##import list
-  expect_type(read_RF2R(list(file, "test")), type = "list")
+  expect_type(expect_message(read_RF2R(list(file, "test")),
+                             "Error: Import for file 'test' failed"),
+              type = "list")
 
   ##import false list
   expect_warning(read_RF2R(c(file, file)), regexp = "'file' has a length > 1. Only the first element was taken!")
@@ -29,6 +31,7 @@ test_that("Test functionality", {
   file.wrong <- "RF_wrong_header.Rf"
   writeLines(gsub("grain_d=20", "grain_d=", readLines(file)),
              file.wrong)
-  read_RF2R(file.wrong)
+  expect_message(read_RF2R(file.wrong),
+                 "Error: Header extraction failed")
   file.remove(file.wrong)
 })

--- a/tests/testthat/test_template_DRAC.R
+++ b/tests/testthat/test_template_DRAC.R
@@ -3,7 +3,11 @@ test_that("Check template creation ", {
   testthat::skip_on_cran()
 
   ## test output class
-  expect_s3_class(template_DRAC(), "DRAC.list")
+  SW({
+  expect_message(res <- template_DRAC(),
+                 "IMPORTANT NOTE")
+  })
+  expect_s3_class(res, "DRAC.list")
   expect_s3_class(template_DRAC(notification = FALSE), "DRAC.list")
   expect_s3_class(template_DRAC(nrow = 10, notification = FALSE), "DRAC.list")
 

--- a/tests/testthat/test_use_DRAC.R
+++ b/tests/testthat/test_use_DRAC.R
@@ -4,7 +4,9 @@ test_that("Test DRAC", {
 
  ##use manual example
  ##create template
+ SW({
  input <- template_DRAC(preset = "DRAC-example_quartz")
+ })
 
  ##test
  expect_s3_class(input, "DRAC.list")
@@ -37,7 +39,9 @@ test_that("Test DRAC", {
  input$`errDe (Gy)` <- 0.2
 
  ##run DRAC
+ SW({
  output <- expect_s4_class(use_DRAC(input), "RLum.Results")
+ })
 
  ## print method for DRAC.highlights
  expect_output(print(output$DRAC$highlights), regexp = "TO:GP = errAge")
@@ -65,8 +69,10 @@ test_that("Test DRAC", {
               "The provided data object is not a valid DRAC template")
 
  ## exceed allowed limit
+ SW({
  expect_warning(input <- template_DRAC(preset = "DRAC-example_quartz",
                                        nrow = 5001),
                 "More than 5000 datasets might not be supported")
+ })
  expect_error(use_DRAC(input), "The limit of allowed datasets is 5000!")
 })


### PR DESCRIPTION
This introduces the `SW()` function to silence pretty much everything that the functions write to the terminal during the tests, and starts applying it to a first bunch of tests. Part of #120.