### PR TITLE
Small improvement in input validation in template_DRAC()

### DIFF
--- a/R/template_DRAC.R
+++ b/R/template_DRAC.R
@@ -98,6 +98,9 @@ template_DRAC <- function(
   # 2 - add option to return the DRAC example data set
 
   ## correct incoming to prevent negative values
+  if (!is.numeric(nrow)) {
+    .throw_error("'nrow' must be a positive integer scalar")
+  }
   nrow <- max(1, nrow[1])
 
   ## throw warning

--- a/tests/testthat/test_template_DRAC.R
+++ b/tests/testthat/test_template_DRAC.R
@@ -32,10 +32,14 @@ test_that("Check template creation ", {
   expect_s3_class(template_DRAC(nrow = -1, notification = FALSE), "DRAC.list")
 
   ## expect failure
+  expect_error(template_DRAC("preset"),
+               "'nrow' must be a positive integer scalar")
   expect_warning(template_DRAC(nrow = 5001, notification = FALSE),
                  regexp = "\\[template_DRAC\\(\\)\\] More than 5000 datasets might not be supported!")
-  expect_error(template_DRAC(preset = "this_one_does_not_exist"))
-  expect_error(template_DRAC(preset = c("this_one_does_not_exist", "this_one_neither")))
-  expect_error(template_DRAC(preset = 999))
-
+  expect_error(template_DRAC(preset = "does_not_exist"),
+               "Invalid preset")
+  expect_error(template_DRAC(preset = c("does_not_exist", "neither_this_one")),
+               "'preset' must be a 'character' of length 1")
+  expect_error(template_DRAC(preset = 999),
+               "'preset' must be a 'character' of length 1")
 })


### PR DESCRIPTION
Forgetting to name the `preset` argument would generate this output:

```R
> template_DRAC("preset", notification = FALSE)
Error in rep(NA_character_, nrow) : invalid 'times' argument In addition: Warning messages:
1: [template_DRAC()] More than 5000 datasets might not be supported! 
2: In structure(rep(NA_character_, nrow), required = TRUE, allowsX = FALSE :
  NAs introduced by coercion
```

With this we get:
```R
> template_DRAC("preset", notification = FALSE)
Error: [template_DRAC()] 'nrow' must be a positive integer scalar
```