### PR TITLE
Silence some more test output

### DIFF
--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -163,18 +163,14 @@ analyse_SAR.TL <- function(
   ##=============================================================================#
   # General Integrity Checks ---------------------------------------------------
 
-  ##MISSING INPUT
-  if(missing("signal.integral.min") == TRUE){
-    stop("[analyse_SAR.TL()] No value set for 'signal.integral.min'!", call. = FALSE)
+  if (!is(object, "RLum.Analysis")) {
+    .throw_error("Input object is not of type 'RLum.Analyis'")
   }
-
-  if(missing("signal.integral.max") == TRUE){
-    stop("[analyse_SAR.TL()] No value set for 'signal.integral.max'!", call. = FALSE)
+  if (missing("signal.integral.min")) {
+    .throw_error("No value set for 'signal.integral.min'")
   }
-
-  ##INPUT OBJECTS
-  if(is(object, "RLum.Analysis") == FALSE){
-    stop("[analyse_SAR.TL()] Input object is not of type 'RLum.Analyis'!", call. = FALSE)
+  if (missing("signal.integral.max")) {
+    .throw_error("No value set for 'signal.integral.max'")
   }
 
 
@@ -188,7 +184,7 @@ analyse_SAR.TL <- function(
   ##set vector for sequence structure
   temp.protocol.step <- rep(sequence.structure,length(object@records))[1:length(object@records)]
 
-  ##grep object strucute
+  ## grep object structure
   temp.sequence.structure <- structure_RLum(object)
 
   ##set values for step
@@ -197,22 +193,18 @@ analyse_SAR.TL <- function(
   ##remove TL curves which are excluded
   temp.sequence.structure <- temp.sequence.structure[which(
     temp.sequence.structure[,"protocol.step"]!="EXCLUDE"),]
-
   ##check integrity; signal and bg range should be equal
   if(length(
     unique(
       temp.sequence.structure[temp.sequence.structure[,"protocol.step"]=="SIGNAL","n.channels"]))>1){
 
-    stop(paste(
-      "[analyse_SAR.TL()] Signal range differs. Check sequence structure.\n",
-      temp.sequence.structure
-    ))
+    .throw_error("Signal range differs, check sequence structure.\n",
+                 temp.sequence.structure)
   }
 
   ##check if the wanted curves are a multiple of the structure
   if(length(temp.sequence.structure[,"id"])%%length(sequence.structure)!=0)
-    stop("[analyse_SAR.TL()] Input TL curves are not a multiple of the sequence structure.",
-         call. = FALSE)
+    .throw_error("Input TL curves are not a multiple of the sequence structure")
 
   # # Calculate LnLxTnTx values  --------------------------------------------------
   ##grep IDs for signal and background curves
@@ -413,10 +405,10 @@ analyse_SAR.TL <- function(
                                      object@records[[TL.signal.ID[1]]]@data[signal.integral.max,1])
 
 
-  ##warning if number of curves exceed colour values
+  ## warning if number of curves exceeds colour values
   if(length(col)<length(TL.signal.ID/2)){
-    cat("\n[analyse_SAR.TL.R] Warning: To many curves! Only the first",
-        length(col),"curves are plotted!")
+    message("\n[analyse_SAR.TL.R()] Warning: Too many curves, ",
+            "only the first ", length(col), " curves are plotted")
   }
 
 
@@ -634,8 +626,6 @@ analyse_SAR.TL <- function(
     ##set failed text and mark De as failed
     if (length(grep("FAILED", RejectionCriteria$status)) > 0) {
       mtext("[FAILED]", col = "red")
-
-
     }
   }
 

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -871,6 +871,29 @@ fancy_scientific <- function(l) {
 
 }
 
+#' @title Silence Output and Warnings during Tests
+#'
+#' This is helpful so that during tests the terminal is not filled up by
+#' the output from the function tested, which is often left intentionally
+#' verbose to facilitate the coverage analysis.
+#'
+#' This was originally defined in `tests/testthat/setup.R`, but unfortunately
+#' that file is not sourced by `covr::file_coverage()` (as opposed to what
+#' happens with `testthat::test_file()` and `covr::package_coverage()`),
+#' which makes it harder to work iteratively with it.
+#'
+#' @param expr [expression] an R expression (often a function, but can be
+#'        any amount of code) the output of which needs to be silenced
+#'
+#' @examples
+#' SW({
+#'   template_DRAC(preset = "DRAC-example_quartz")
+#' })
+#'
+#' @md
+#' @noRd
+SW <- function(expr) capture.output(suppressMessages(suppressWarnings(expr)))
+
 #' @title Validate Scalar Variables Expected to be Positive
 #'
 #' @param val [numeric] (**required**): value to validate

--- a/R/write_R2BIN.R
+++ b/R/write_R2BIN.R
@@ -142,7 +142,7 @@ write_R2BIN <- function(
         ##we want to have a minimum binning (smallest number possible)
         bin_width <- ceiling(length(x)/9999)
 
-        ##it should be symatric, thus, remove values
+        ##it should be symmetric, thus, remove values
         if((length(x)/bin_width)%%2 != 0){
           x <- x[-length(x)]
 
@@ -253,7 +253,6 @@ write_R2BIN <- function(
     if(temp.file.name[length(temp.file.name)]=="bin"){
       temp.file.name[length(temp.file.name)] <- "binx"
       file <- paste(temp.file.name, collapse=".")
-
     }
   }
 
@@ -1329,6 +1328,5 @@ write_R2BIN <- function(
   if(txtProgressBar) close(pb)
 
   ##output
-  message(paste0("\t >> ",ID-1,"records have been written successfully!\n\n"))
-
+  message("\t >> ", ID - 1, " records have been written successfully!\n\n")
 }

--- a/R/write_RLum2CSV.R
+++ b/R/write_RLum2CSV.R
@@ -210,11 +210,12 @@ write_RLum2CSV <- function(
       ##adjust the names
       names(object_list) <- paste0(1:length(object_list),"_",names(object_list))
 
-
     } else {
-      try(stop("[write_RLum2CSV()] One particular RLum-object is not yet supported! NULL returned!", call. = FALSE))
+      # nocov start
+      message("[write_RLum2CSV()] Error: One particular RLum-object ",
+              "is not yet supported, NULL returned")
       return(NULL)
-
+      # nocov end
     }
 
   } else if (inherits(object, "data.frame")) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,8 +1,0 @@
-# Silence output and warnings
-#
-# Surround with this function the code that is printing out to the console,
-# such as in:
-# SW({
-# template_DRAC(preset = "DRAC-example_quartz")
-# })
-SW <- function(expr) capture.output(suppressMessages(suppressWarnings(expr)))

--- a/tests/testthat/test_analyse_Al2O3C_CrossTalk.R
+++ b/tests/testthat/test_analyse_Al2O3C_CrossTalk.R
@@ -28,7 +28,9 @@ test_that("Full check", {
                  "Input for 'signal_integral' corrected to")
 
   ## irradiation_time_correction
+  SW({
   corr <- analyse_Al2O3C_ITC(data_ITC)
+  })
   expect_s4_class(
       analyse_Al2O3C_CrossTalk(data_CrossTalk,
                                irradiation_time_correction = corr),

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -130,6 +130,7 @@ test_that("simple run", {
 
   ##verbose and plot on
   ##full dataset
+  SW({
   expect_s4_class(
     analyse_SAR.CWOSL(
       object = object[[1]],
@@ -230,6 +231,7 @@ test_that("simple run", {
     ),
     class = "RLum.Results"
   )
+  })
 
   ## check if a different point was selected
   expect_equal(round(t$rejection.criteria$Value[2],2), expected = 0.01)
@@ -261,8 +263,9 @@ test_that("simple run", {
   expect_error(analyse_SAR.CWOSL("fail"),
                "Input object is not of type 'RLum.Analysis'")
 
-    ##check stop for OSL.components ... failing
-    expect_null(analyse_SAR.CWOSL(
+  ## check stop for OSL.components ... failing
+  SW({
+  expect_null(analyse_SAR.CWOSL(
        object = object[[1]],
        signal.integral.min = 1,
        signal.integral.max = 2,
@@ -274,6 +277,7 @@ test_that("simple run", {
        plot = FALSE,
        verbose = FALSE
      ))
+  })
 
    expect_error(analyse_SAR.CWOSL(
      object = object[[1]],
@@ -495,5 +499,4 @@ test_that("advance tests run", {
     ),
     class = "RLum.Results"
   )
-
 })

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -9,13 +9,12 @@ test_that("Input validation", {
 
   expect_error(analyse_SAR.TL(),
                "No value set for 'object'")
+  expect_error(analyse_SAR.TL("test"),
+               "Input object is not of type 'RLum.Analyis'")
   expect_error(analyse_SAR.TL(object),
                "No value set for 'signal.integral.min'")
   expect_error(analyse_SAR.TL(object, signal.integral.min = 1),
                "No value set for 'signal.integral.max'")
-  expect_error(analyse_SAR.TL("test", signal.integral.min = 1,
-                              signal.integral.max = 2),
-               "Input object is not of type 'RLum.Analyis'")
   expect_error(analyse_SAR.TL(list(object, "test")),
                "elements in the input list must be of class 'RLum.Analysis'")
   expect_error(analyse_SAR.TL(object, signal.integral.min = 1,
@@ -27,6 +26,7 @@ test_that("Test examples", {
   skip_on_cran()
 
   ##perform analysis
+  SW({
   expect_s4_class(
     analyse_SAR.TL(
       object,
@@ -59,4 +59,10 @@ test_that("Test examples", {
         sequence.structure = c("SIGNAL", "BACKGROUND")),
     "log-scale needs positive values; log-scale disabled"
   )
+
+  expect_warning(
+    analyse_SAR.TL(object, signal.integral.min = 2, signal.integral.max = 3,
+                   sequence.structure = c("SIGNAL", "EXCLUDE")),
+    "'fit.weights' ignored since the error column is invalid or 0")
+  })
 })

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -18,6 +18,8 @@ object <-
   set_RLum(class = "RLum.Analysis",
            records = object,
            protocol = "pIRIR")
+
+SW({
 results <- analyse_pIRIRSequence(
   object,
   signal.integral.min = 1,
@@ -48,6 +50,7 @@ suppressWarnings( # warnings thrown by analyse_SAR.CWOSL and plot_GrowthCurve
     verbose = FALSE
   )
 )
+})
 
 test_that("input validation", {
   expect_error(analyse_pIRIRSequence(),
@@ -60,6 +63,8 @@ test_that("input validation", {
                                      background.integral.min = 900,
                                      background.integral.max = 1000),
                "Input object is not of type 'RLum.Analyis'")
+
+  SW({
   expect_warning(analyse_pIRIRSequence(list(object),
                                        signal.integral.max = 2,
                                        background.integral.min = 900,
@@ -70,6 +75,7 @@ test_that("input validation", {
                                        background.integral.min = 900,
                                        background.integral.max = 1000),
                  "'signal.integral.max' missing, set to 2")
+  })
 })
 
 test_that("check class and length of output", {

--- a/tests/testthat/test_calc_AverageDose.R
+++ b/tests/testthat/test_calc_AverageDose.R
@@ -24,10 +24,13 @@ test_that("input validation", {
   expect_message(expect_null(
       calc_AverageDose(data[0, ], sigma_m = 0.1)),
       "Error: data set contains 0 rows")
+
+  SW({
   expect_warning(calc_AverageDose(cbind(data, data), sigma_m = 0.1),
                  "number of columns in data set > 2")
   expect_warning(calc_AverageDose(rbind(data, NA), sigma_m = 0.1),
                  "NA values in data set detected")
+  })
 })
 
 test_that("check class and length of output", {

--- a/tests/testthat/test_calc_CommonDose.R
+++ b/tests/testthat/test_calc_CommonDose.R
@@ -1,7 +1,9 @@
 data(ExampleData.DeValues, envir = environment())
+SW({
 temp <- calc_CommonDose(ExampleData.DeValues$CA1, plot = FALSE, verbose = TRUE)
 temp.nolog <- calc_CommonDose(ExampleData.DeValues$CA1, log = FALSE,
                               plot = FALSE, verbose = TRUE)
+})
 
 test_that("input validation", {
   testthat::skip_on_cran()

--- a/tests/testthat/test_calc_CosmicDoseRate.R
+++ b/tests/testthat/test_calc_CosmicDoseRate.R
@@ -1,7 +1,8 @@
+SW({
 temp <- calc_CosmicDoseRate(depth = 2.78, density = 1.7,
                             latitude = 38.06451, longitude = 1.49646,
                             altitude = 364, error = 10)
-
+})
 
 test_that("input validation", {
   testthat::skip_on_cran()
@@ -43,10 +44,12 @@ test_that("check class and length of output", {
   expect_equal(length(temp), 3)
 
   ## length(depth) > length(density), half.depth
+  SW({
   calc_CosmicDoseRate(depth = c(2.78, 3.12), density = 1.7,
                       corr.fieldChanges = TRUE, est.age = 20,
                       latitude = 28.06451, longitude = 1.49646,
                       altitude = 364, half.depth = TRUE)
+  })
 })
 
 test_that("check values from output example 1", {
@@ -69,10 +72,12 @@ test_that("check values from output example 1", {
 test_that("check values from output example 2b", {
   testthat::skip_on_cran()
 
+  SW({
   temp <- calc_CosmicDoseRate(depth = c(5.0, 2.78), density = c(2.65, 1.7),
                               latitude = 12.04332, longitude = 4.43243,
                               altitude = 364, corr.fieldChanges = TRUE,
                               est.age = 67, error = 15)
+  })
   results <- get_RLum(temp)
 
   expect_equal(results$depth.1, 5)

--- a/tests/testthat/test_calc_FadingCorr.R
+++ b/tests/testthat/test_calc_FadingCorr.R
@@ -30,6 +30,7 @@ test_that("check class and length of output", {
   expect_equal(length(temp), 2)
 
   ##check the verbose mode
+  SW({
   expect_s4_class(calc_FadingCorr(
     age.faded = c(0.1,0),
     g_value = c(5.0, 1.0),
@@ -44,6 +45,8 @@ test_that("check class and length of output", {
   expect_s4_class(calc_FadingCorr(age.faded = c(0.1,0),
                                   g_value = fading, tc = 2592000),
                   "RLum.Results")
+  })
+
   fading@originator <- "unexpected"
   expect_message(
       expect_null(calc_FadingCorr(age.faded = c(0.1,0),
@@ -51,12 +54,14 @@ test_that("check class and length of output", {
                "Unknown originator for the provided RLum.Results object")
 
   ## auto, seed (Note: this is slow!)
+  SW({
   calc_FadingCorr(
     age.faded = c(0.1,0),
     g_value = c(5.0, 1.0),
     tc = 2592000,
     seed = 1,
     n.MC = "auto")
+  })
 })
 
 test_that("check values from output example 1", {

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -44,10 +44,12 @@ test_that("input validation", {
                                             Ch_L2 = 2000)),
                  "The calculated channel for L2 (2000) exceeds the number",
                  fixed = TRUE)
+  SW({
   expect_warning(calc_FastRatio(ExampleData.CW_OSL_Curve,
                                 Ch_L3 = c(1000, 1000)),
                  "The calculated channels for L3 (1000, 1000) exceed",
                  fixed = TRUE)
+  })
 })
 
 test_that("check class and length of output", {
@@ -57,6 +59,7 @@ test_that("check class and length of output", {
   expect_equal(length(temp), 5)
 
   ## fitCW.sigma and fitCW.curve
+  SW({
   calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE,
                  fitCW.sigma = TRUE, fitCW.curve = TRUE)
 
@@ -67,6 +70,7 @@ test_that("check class and length of output", {
   expect_warning(calc_FastRatio(get_RLum(TL.Spectrum)),
                  "L3 contains more counts (566) than L2 (562)",
                  fixed = TRUE)
+  })
 })
 
 test_that("check values from output", {

--- a/tests/testthat/test_calc_FuchsLang2001.R
+++ b/tests/testthat/test_calc_FuchsLang2001.R
@@ -30,11 +30,14 @@ test_that("check class and length of output", {
   expect_equal(get_RLum(temp)$n.usedDeValues, 22)
 
   ## using an RLum.Results object as input
+  SW({
   expect_s4_class(calc_FuchsLang2001(data = temp, startDeValue = 24,
                                      plot = FALSE),
                   "RLum.Results")
+  })
 
   ##the check output
+  SW({
   output <- expect_s4_class(
     calc_FuchsLang2001(
       data = ExampleData.DeValues$BT998,
@@ -43,5 +46,5 @@ test_that("check class and length of output", {
       verbose = TRUE
 
     ), "RLum.Results")
-
+  })
 })

--- a/tests/testthat/test_calc_HomogeneityTest.R
+++ b/tests/testthat/test_calc_HomogeneityTest.R
@@ -17,8 +17,10 @@ test_that("check class and length of output", {
   expect_equal(length(temp), 3)
 
   ## using an RLum.Results object as input
+  SW({
   expect_s4_class(calc_HomogeneityTest(temp),
                   "RLum.Results")
+  })
 })
 
 test_that("check values from output example", {
@@ -33,6 +35,8 @@ test_that("check values from output example", {
   expect_equal(round(results$P.value,3), 0.004)
 
   ##test the unlogged version
+  SW({
   temp <- calc_HomogeneityTest(df, log = FALSE)$summary
+  })
   expect_equal(round(temp$P.value,3),0.001)
 })

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -65,10 +65,12 @@ test_that("input validation", {
                                 ddot = ddot, readerDdot = "test"),
                "'ddot' and 'readerDdot' must be numeric vectors")
 
+  SW({
   expect_warning(calc_Huntley2006(data[, 1:2], rhop = rhop, n.MC = 2,
                                   ddot = ddot, readerDdot = readerDdot,
                                   fit.method = "GOK"),
                  "'data' only had two columns")
+  })
 })
 
 test_that("check class and length of output", {
@@ -107,6 +109,7 @@ test_that("check values from calc_Huntley2008()", {
   expect_equal(round(sum(residuals(huntley$fits$simulated)),1),  0.8)
   expect_equal(round(sum(residuals(huntley$fits$measured)),4),  0.1894)
   expect_equal(round(sum(residuals(huntley$fits$unfaded)),2),  0)
+})
 
 ## COMPARE calc_Kars2008 (deprecated) vs. re-named calc_Huntley2006
 test_that("compare deprecated calc_Kars2008 and calc_Huntley2006", {
@@ -240,6 +243,7 @@ test_that("Further tests calc_Huntley2006", {
   class = "data.frame", row.names = c(NA, -7L))
 
   set.seed(1)
+  SW({
   expect_warning(calc_Huntley2006(
     data = df,
     LnTn = NULL,
@@ -252,6 +256,5 @@ test_that("Further tests calc_Huntley2006", {
     plot = FALSE,
     n.MC = 100),
     regexp = "\\[calc\\_Huntley2006\\(\\)\\] Ln\\/Tn is smaller than the minimum computed LxTx value.")
- })
-
+  })
 })

--- a/tests/testthat/test_convert_Daybreak2CSV.R
+++ b/tests/testthat/test_convert_Daybreak2CSV.R
@@ -10,8 +10,10 @@ test_that("input validation", {
 test_that("check class and length of output", {
   testthat::skip_on_cran()
 
+  SW({
   res <- read_Daybreak2R(file = system.file("extdata/Daybreak_TestFile.txt",
                                             package = "Luminescence"))[[1]]
+  })
   expect_null(convert_Daybreak2CSV(res, path = tempdir()))
   expect_type(convert_Daybreak2CSV(res, path = tempdir(), export = FALSE),
               "list")

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -14,8 +14,10 @@ test_that("input validation", {
   expect_error(fit_SurfaceExposure(d4, age = 1e4),
                "'age' must be of the same length")
 
+  SW({
   expect_warning(fit_SurfaceExposure(rbind(d1, NA), mu = 0.9),
                  "\\[fit\\_SurfaceExposure\\(\\)\\] NA values in 'data' were removed")
+  })
 })
 
 ## Example data 1
@@ -100,6 +102,7 @@ test_that("check values from output example", {
 test_that("not enough parameters provided", {
   testthat::skip_on_cran()
 
+  SW({
   expect_message(
     fit_SurfaceExposure(data = d1, plot = FALSE, verbose = TRUE),
     "Unable to fit the data"
@@ -126,4 +129,5 @@ test_that("not enough parameters provided", {
   expect_message(fit_SurfaceExposure(as.matrix(d1), log = "y"),
                  "Original error from minpack.lm::nlsLM(): singular gradient",
                  fixed = TRUE)
+  })
 })

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -163,6 +163,16 @@ test_that("Test internals", {
   expect_warning(fun.ext(),
                  "[fun.ext()] Warning message", fixed = TRUE)
 
+  ## SW() ------------------------------------------------------------------
+  expect_silent(SW(cat("silenced message")))
+  expect_silent(SW(message("silenced message")))
+  expect_silent(SW(warning("silenced message")))
+  expect_silent(SW(.throw_warning("silenced message")))
+  expect_error(SW(stop("error message")),
+               "error message")
+  expect_error(SW(.throw_error("error message")),
+               "error message")
+
   ## .validate_positive_scalar() --------------------------------------------
   expect_silent(.validate_positive_scalar(1.3))
   expect_silent(.validate_positive_scalar(2, int = TRUE))
@@ -201,5 +211,4 @@ test_that("Test internals", {
       TOLOFF = 0
     )
   )
-
 })

--- a/tests/testthat/test_merge_Risoe.BINfileData.R
+++ b/tests/testthat/test_merge_Risoe.BINfileData.R
@@ -23,6 +23,8 @@ test_that("Test merging", {
 
   binx <- system.file("extdata/BINfile_V8.binx", package = "Luminescence")
   output.file <- tempfile()
+  SW({
   merge_Risoe.BINfileData(c(binx, binx), output.file)
+  })
   expect_true(file.exists(output.file))
 })

--- a/tests/testthat/test_write_R2BIN.R
+++ b/tests/testthat/test_write_R2BIN.R
@@ -38,12 +38,16 @@ data(ExampleData.BINfileData, envir = environment())
 
   ##create files
   path <- tempfile()
+  SW({
   write_R2BIN(object = new, file = paste0(path, "BINfile_V3.bin"), version = "03")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V4.bin"), version = "04")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V5.binx"), version = "05")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V6.binx"), version = "06")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V7.binx"), version = "07")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V8.binx"), version = "08")
+  ## silent correction of the file extension
+  write_R2BIN(object = new, file = paste0(path, "BINfile_V8.bin"), version = "08")
+  })
 
   temp <- new
   temp@METADATA[1, "TIME"] <- "1215"
@@ -51,6 +55,7 @@ data(ExampleData.BINfileData, envir = environment())
   temp@METADATA[1, "SAMPLE"] <- ""
   temp@METADATA[1, "COMMENT"] <- ""
   temp@.RESERVED <- list(val1 = c("a", "b"), val2 = c("c", "d"))
+  SW({
   write_R2BIN(object = temp, file = paste0(path, "BINfile_V3.bin"),
               version = "03")
   temp@METADATA[, "VERSION"] <- 4
@@ -69,6 +74,7 @@ data(ExampleData.BINfileData, envir = environment())
   temp@METADATA[, "VERSION"] <- 8
   write_R2BIN(object = temp, file = paste0(path, "BINfile_V8.binx"),
               version = "08")
+  })
 
   ##catch errors
   expect_error(write_R2BIN(object = new, file = FALSE),
@@ -97,7 +103,7 @@ data(ExampleData.BINfileData, envir = environment())
                "'SAMPLE' exceeds storage limit")
 
   temp <- new
-  temp@DATA[[2]] <- 1:10000
+  temp@DATA[[2]] <- 1:25000
   temp@METADATA[1, "POSITION"] <- paste0(rep("a", 50), collapse="")
   expect_error(write_R2BIN(object = temp, file = "test"),
                "records contain more than 9,999 data points")

--- a/tests/testthat/test_write_R2BIN.R
+++ b/tests/testthat/test_write_R2BIN.R
@@ -45,8 +45,6 @@ data(ExampleData.BINfileData, envir = environment())
   write_R2BIN(object = new, file = paste0(path, "BINfile_V6.binx"), version = "06")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V7.binx"), version = "07")
   write_R2BIN(object = new, file = paste0(path, "BINfile_V8.binx"), version = "08")
-  ## silent correction of the file extension
-  write_R2BIN(object = new, file = paste0(path, "BINfile_V8.bin"), version = "08")
   })
 
   temp <- new
@@ -112,4 +110,9 @@ data(ExampleData.BINfileData, envir = environment())
                              file = paste0(path, "BINfile_V8.binx")),
                  "'COMMENT' exceeds storage limit"),
     "Some data sets are longer than 9,999 points")
+
+  ## silent correction of the file extension
+  skip_on_os("windows") # FIXME(mcol)
+  write_R2BIN(object = new, file = paste0(path, "BINfile_V8.bin"), version = "08")
+
 })

--- a/tests/testthat/test_write_RLum2CSV.R
+++ b/tests/testthat/test_write_RLum2CSV.R
@@ -28,7 +28,9 @@ test_that("test errors and general export function", {
   ##test RLum.Results objects
   ## load example data
   data(ExampleData.DeValues, envir = environment())
+  SW({
   results <-  calc_CommonDose(ExampleData.DeValues$CA1)
+  })
 
   ##using option compact
   expect_warning(write_RLum2CSV(object = results,export = FALSE),


### PR DESCRIPTION
This moves the `SW()` function into `R/internals_RLum.R`, as having it defined in `tests/testthat/setup.R` doesn't work for `covr::file_coverage()`, which doesn't source that file automatically (as opposed to what happens with `testthat::test_file()` and `covr::package_coverage()`), and that makes it harder to work iteratively with it.

This also completes the silencing of the test files I've touched until now for coverage (part of #120).