### PR TITLE
fixes for crashes in plot_NRt()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -52,7 +52,8 @@ The values is part of the output table.
 
 ### `plot_NRt()`
 * The function reports an helpful message rather than crashing when applied
-to an object of unexpected type (#177, @mcol).
+to an object of unexpected type or when there is a mismatch in time values
+(#177, fixed with #179 by @mcol).
 
 ### `plot_RLum.Data.Analysis()`
 * The function now supports all arguments from `plot_RLum.Data.Spectrum()`; before it 

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -50,6 +50,10 @@ which would generate unexpected warnings (#163, @mcol).
 * The function now calculates the relative saturation (`n/N`) using the ration of the two integrates.
 The values is part of the output table. 
 
+### `plot_NRt()`
+* The function reports an helpful message rather than crashing when applied
+to an object of unexpected type (#177, @mcol).
+
 ### `plot_RLum.Data.Analysis()`
 * The function now supports all arguments from `plot_RLum.Data.Spectrum()`; before it 
 had only basic functionality for `RLum.Data.Spectrum-class` data. 

--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -151,6 +151,9 @@ plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k
     if (length(curves) < 2)
       .throw_error("The provided 'RLum.Analysis' object ",
                    "only contains curve data of the natural signal")
+  } else {
+    .throw_error("'data' is expected to be a list, matrix, data.frame or ",
+                 "'RLum.Analysis' object")
   }
 
   ## BASIC SETTINGS ------

--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -161,6 +161,10 @@ plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k
   regCurves <- curves[2:length(curves)]
   time <- curves[[1]][ ,1]
 
+  if (any(sapply(regCurves, nrow) != nrow(natural))) {
+    .throw_error("The time values for the natural signal don't match ",
+                 "those for the regenerated signal")
+  }
 
   ## DATA TRANSFORMATION -----
 

--- a/tests/testthat/test_plot_NRt.R
+++ b/tests/testthat/test_plot_NRt.R
@@ -19,6 +19,12 @@ test_that("input validation", {
   obj.mixed <- merge_RLum.Analysis(list(obj, TL.Spectrum))
   expect_error(plot_NRt(obj.mixed),
                "The provided 'RLum.Analysis' object must exclusively contain")
+
+  data("ExampleData.RLum.Analysis", envir = environment())
+  expect_error(plot_NRt(IRSAR.RF.Data),
+               "The time values for the natural signal don't match those for")
+  expect_error(plot_NRt(merge_RLum.Analysis(list(obj, IRSAR.RF.Data))),
+               "The time values for the natural signal don't match those for")
 })
 
 test_that("check", {

--- a/tests/testthat/test_plot_NRt.R
+++ b/tests/testthat/test_plot_NRt.R
@@ -6,10 +6,19 @@ curves <- get_RLum(obj)[seq(1, 9, 2)]
 test_that("input validation", {
   testthat::skip_on_cran()
 
+  expect_error(plot_NRt("error"),
+               "'data' is expected to be a list, matrix, data.frame or")
+  expect_error(plot_NRt(obj[[2]]),
+               "'data' is expected to be a list, matrix, data.frame or")
   expect_error(plot_NRt(curves[1]),
                 "The provided list only contains curve data of the natural signal")
   expect_error(plot_NRt(curves[[1]]@data),
                "The provided matrix only contains curve data of the natural signal")
+
+  data(ExampleData.XSYG, envir = environment())
+  obj.mixed <- merge_RLum.Analysis(list(obj, TL.Spectrum))
+  expect_error(plot_NRt(obj.mixed),
+               "The provided 'RLum.Analysis' object must exclusively contain")
 })
 
 test_that("check", {


### PR DESCRIPTION
Fixes two crashes in `plot_NRt()` and adds a test for the wrong `if` statement (the code was already corrected in 542522e). Closes #177.