### PR TITLE
Don't pollute the workspace with example data when running tests

### DIFF
--- a/tests/testthat/test_RLum.Analysis-class.R
+++ b/tests/testthat/test_RLum.Analysis-class.R
@@ -2,7 +2,7 @@ test_that("Check the example and the numerical values", {
   testthat::skip_on_cran()
 
   ##load example data
-  data("ExampleData.RLum.Analysis")
+  data(ExampleData.RLum.Analysis, envir = environment())
   obj <- IRSAR.RF.Data
 
   ## set_RLum()

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -1,4 +1,4 @@
-data("ExampleData.CW_OSL_Curve")
+data(ExampleData.CW_OSL_Curve, envir = environment())
 temp <- calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE, verbose = FALSE)
 
 

--- a/tests/testthat/test_report_RLum.R
+++ b/tests/testthat/test_report_RLum.R
@@ -7,11 +7,12 @@ test_that("Test Simple RLum Report", {
   testthat::skip_on_os("windows")
 
   ### load example data
-  data("ExampleData.DeValues")
+  data(ExampleData.DeValues, envir = environment())
+  SW({
   temp <- calc_CommonDose(ExampleData.DeValues$CA1)
+  })
 
   # create the standard HTML report
   testthat::expect_null(report_RLum(object = temp, timestamp = FALSE, show_report = FALSE))
   testthat::expect_null(report_RLum(object = temp, timestamp = FALSE, show_report = FALSE, compact = FALSE))
-
 })

--- a/tests/testthat/test_subset_RLum.R
+++ b/tests/testthat/test_subset_RLum.R
@@ -2,7 +2,7 @@
 test_that("subset RLum.Analysis", {
   testthat::skip_on_cran()
 
-  data("ExampleData.RLum.Analysis")
+  data(ExampleData.RLum.Analysis, envir = environment())
   temp <- IRSAR.RF.Data
 
 


### PR DESCRIPTION
Calling `data(datasetName)` without the `envir = environment()` option loads the objects in the workspace, and tests shouldn't do that.