### PR TITLE
Simplify and correct the check for Inf in plot_KDE()

### DIFF
--- a/R/plot_KDE.R
+++ b/R/plot_KDE.R
@@ -231,18 +231,19 @@ plot_KDE <- function(
       }
     }
 
-    ##check for Inf values and remove them if need
-    if(any(is.infinite(unlist(data[[i]])))){
-      Inf_id <- which(is.infinite(unlist(data[[i]]))[1:nrow(data[[i]])/ncol(data[[i]])])
+    ## find the index Inf values in each of the two columns and remove the
+    ## corresponding rows if needed
+    inf.idx <- unlist(lapply(data[[i]], function(x) which(is.infinite(x))))
+    if (length(inf.idx) > 0) {
+      inf.row <- sort(unique(inf.idx))
       .throw_warning("Inf values removed in rows: ",
-                     paste(Inf_id, collapse = ", "), " in data.frame ", i)
-      data[[i]] <- data[[i]][-Inf_id,]
-      rm(Inf_id)
+                     paste(inf.row, collapse = ", "), " in data.frame ", i)
+      data[[i]] <- data[[i]][-inf.row, ]
+      rm(inf.idx, inf.row)
 
       ##check if empty
       if(nrow(data[[i]]) == 0){
         data[i] <- NULL
-
       }
     }
   }

--- a/tests/testthat/test_plot_KDE.R
+++ b/tests/testthat/test_plot_KDE.R
@@ -8,6 +8,9 @@ test_that("input validation", {
                "Input data must be one of 'data.frame', 'RLum.Results' or")
   expect_error(plot_KDE(list()),
                "'data' is an empty list")
+  expect_error(expect_warning(plot_KDE(data.frame(a = Inf, b = 1)),
+                              "Inf values removed in rows: 1 in data.frame 1"),
+               "Your input is empty due to Inf removal")
   expect_error(plot_KDE(df, ylim = c(0, 1)),
                "'ylim' must be a vector of length 4")
 
@@ -49,6 +52,15 @@ test_that("check functionality", {
 
   ## RLum.Results object
   expect_silent(plot_KDE(calc_CommonDose(df, plot = FALSE, verbose = FALSE)))
+
+  ## infinite values
+  df.inf <- df
+  df.inf[9, 1] <- Inf
+  expect_warning(plot_KDE(df.inf),
+                 "Inf values removed in rows: 9 in data.frame 1")
+  df.inf[2, 2] <- Inf
+  expect_warning(plot_KDE(df.inf),
+                 "Inf values removed in rows: 2, 9 in data.frame 1")
 
   ## missing values
   df.na <- df


### PR DESCRIPTION
This makes the check for `Inf` values a bit easier to follow and now it reports the correct row indices removed. Fixes #187.