### PR TITLE
Improve validation of data size in fit_OSLLifeTimes()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -46,6 +46,11 @@ an exponential fit is applied then this values are used as start parameters.
 * Parameter `input_scale` was not correctly propagated when the function would
 self-call (#160, @mcol).
 
+### `fit_OSLLifeTimes()`
+* The validation of the minimum dataset size didn't account for the use of
+the `signal.range` argument (#182, fixed by #195, @mcol).
+
+
 ### `fit_SurfaceExposure()`
 * Fix #162 to remove a dimension mismatch if the input data contained `NA`s,
 which would generate unexpected warnings (#163, @mcol).

--- a/man/fit_OSLLifeTimes.Rd
+++ b/man/fit_OSLLifeTimes.Rd
@@ -19,7 +19,8 @@ fit_OSLLifeTimes(
 \arguments{
 \item{object}{\linkS4class{RLum.Data.Curve}, \linkS4class{RLum.Analysis}, \link{data.frame} or \link{matrix} \strong{(required)}:
 Input object containing the data to be analysed. All objects can be provided also as list for an automated
-processing. Please note: \code{NA} values are automatically removed and the dataset should comprise at least 5 data points.}
+processing. Please note: \code{NA} values are automatically removed and the dataset should comprise at least 5 data points (possibly more if \code{n.components} is
+set to a value greater than 1)}
 
 \item{tp}{\link{numeric} (\emph{with default}): option to account for the stimulation pulse width. For off-time measurements
 the default value is 0. \code{tp} has the same unit as the measurement data, e.g., µs. Please set this parameter

--- a/tests/testthat/test_fit_OSLLifeTimes.R
+++ b/tests/testthat/test_fit_OSLLifeTimes.R
@@ -18,12 +18,17 @@ test_that("input validation", {
                "recordType NA not supported for input object")
 
   expect_message(expect_null(fit_OSLLifeTimes(temp_mat[1:3, ])),
-                 "Error: The dataset has fewer than 5 data points, NULL returned")
+                 "For 1 components the dataset must have at least 5 signal points")
+  expect_message(fit_OSLLifeTimes(temp_mat, n.components = 1,
+                                  signal_range = c(1, 3), verbose = FALSE),
+                 "For 1 components the dataset must have at least 5 signal points")
+  expect_message(fit_OSLLifeTimes(temp_mat, n.components = 2,
+                                  signal_range = c(1, 6), verbose = FALSE),
+                 "For 2 components the dataset must have at least 7 signal points")
 
-#  crash: 'start_parameters' not found
-#  expect_warning(fit_OSLLifeTimes(temp_mat, n.components = 1,
-#                                  signal_range = 1:3, verbose = FALSE),
-#                 "'signal_range' has more than 2 elements")
+  expect_warning(fit_OSLLifeTimes(temp_mat, n.components = 1,
+                                  signal_range = c(1, 150:200), verbose = FALSE),
+                 "'signal_range' has more than 2 elements")
   expect_warning(fit_OSLLifeTimes(temp_mat, n.components = 1,
                                   signal_range = c(1, 300), verbose = FALSE),
                  "'signal_range' > number of channels, reset to maximum")


### PR DESCRIPTION
This now takes `signal.range` into account and establishes the minimum required also accounting for `n.components`. Fixes #182.