### PR TITLE
Fix computation of number of breaks in calc_WodaFuchs2008()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -42,6 +42,10 @@ an exponential fit is applied then this values are used as start parameters.
 ### `calc_TLLxTxRatio()`
 * Function crashed for `Tx.data.background = NULL` (#129); fixed with #130 thanks to @mcol
 
+### `calc_WodaFuchs2008()`
+* The function computed the number of breaks for the histogram incorrectly
+(#197, fixed with #198).
+
 ### `fit_EmissionSpectra()`
 * Parameter `input_scale` was not correctly propagated when the function would
 self-call (#160, @mcol).

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -117,14 +117,8 @@ calc_WodaFuchs2008 <- function(
 
   ## optionally estimate class breaks based on bin width
   if(is.null(breaks)) {
-
-    n_breaks <- (max(data[,1],
-                     na.rm = TRUE) -
-                   min(data[,1],
-                       na.rm = TRUE) / bin_width)
-
+    n_breaks <- diff(range(data[, 1], na.rm = TRUE)) / bin_width
   } else {
-
     n_breaks <- breaks
   }
 

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -122,22 +122,15 @@ calc_WodaFuchs2008 <- function(
     n_breaks <- breaks
   }
 
+  if (n_breaks <= 3) {
+    .throw_warning("Fewer than 4 bins produced, 'n_breaks' reset to 4")
+    n_breaks = 4
+  }
+
   ## calculate histogram
   H <- hist(x = data[,1],
             breaks = n_breaks,
             plot = FALSE)
-
-  ## check/do log-normal model fit if needed
-  if(n_breaks <= 3) {
-
-    warning("[calc_WodaFuchs()] Less than four bins, now set to four!")
-
-    ## calculate histogram
-    H <- hist(x = data[,1],
-              breaks = 4,
-              plot = FALSE)
-
-  }
 
   ## extract values from histogram object
   H_c <- H$counts

--- a/tests/testthat/test_calc_WodaFuchs2008.R
+++ b/tests/testthat/test_calc_WodaFuchs2008.R
@@ -15,4 +15,8 @@ test_that("Test general functionality", {
   ##test arguments
   expect_s4_class(calc_WodaFuchs2008(data = ExampleData.DeValues$CA1, breaks = 20), "RLum.Results")
 
+  ## issue #197
+  set.seed(1)
+  df <- data.frame(rnorm(20, 10), rnorm(20, 0.5))
+  expect_silent(calc_WodaFuchs2008(df))
 })


### PR DESCRIPTION
With some code clean up to avoid calling `hist()` twice if `n_breaks < 4`. Fixes #197.