### PR TITLE
Support vectors and single-colums dataframes in calc_WodaFuchs2008()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -43,6 +43,8 @@ an exponential fit is applied then this values are used as start parameters.
 * Function crashed for `Tx.data.background = NULL` (#129); fixed with #130 thanks to @mcol
 
 ### `calc_WodaFuchs2008()`
+* The function now officially supports numeric vectors and single-column
+data frames as input (#200).
 * The function computed the number of breaks for the histogram incorrectly
 (#197, fixed with #198).
 

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -9,8 +9,10 @@
 #' model is estimated based on all input equivalent doses smaller that of the
 #' modelled central value.
 #'
-#' @param data [data.frame] or [RLum.Results-class] object (**required**):
-#' for [data.frame]: two columns: De (`values[,1]`) and De error (`values[,2]`).
+#' @param data [data.frame] [vector], or [RLum.Results-class] object (**required**):
+#' for [data.frame]: either two columns: De (`values[,1]`) and De error
+#' (`values[,2]`), or one: De (`values[,1]`). If a numeric vector or a
+#' single-column data frame is provided, De error is set to `NA`.
 #' For plotting multiple data sets, these must be provided as `list`
 #' (e.g. `list(dataset1, dataset2)`).
 #'
@@ -79,12 +81,10 @@ calc_WodaFuchs2008 <- function(
 
       }
 
-      if(length(data) < 2) {
-
-        data <- cbind(data,
-                      rep(x = NA,
-                          times = length(data)))
-
+      ## if data is a numeric vector or a single-column data frame,
+      ## append a second column of NAs
+      if (NCOL(data) < 2) {
+        data <- cbind(data, NA)
       }
     }
 
@@ -103,16 +103,15 @@ calc_WodaFuchs2008 <- function(
   ## calculations -------------------------------------------------------------
 
   ## estimate bin width based on Woda and Fuchs (2008)
-  if(sum(is.na(data[,2]) == nrow(data))) {
-    message("[calc_WodFuchs2008()] No errors provided. Bin width set by 10 percent of input data!")
-
+  if (all(is.na(data[, 2]))) {
+    message("[calc_WodFuchs2008()] No errors provided. Bin width set ",
+            "by 10 percent of input data")
     bin_width <- median(data[,1] / 10,
                         na.rm = TRUE)
   } else {
 
     bin_width <- median(data[,2],
                         na.rm = TRUE)
-
   }
 
   ## optionally estimate class breaks based on bin width

--- a/man/calc_WodaFuchs2008.Rd
+++ b/man/calc_WodaFuchs2008.Rd
@@ -7,8 +7,10 @@
 calc_WodaFuchs2008(data, breaks = NULL, plot = TRUE, ...)
 }
 \arguments{
-\item{data}{\link{data.frame} or \linkS4class{RLum.Results} object (\strong{required}):
-for \link{data.frame}: two columns: De (\code{values[,1]}) and De error (\code{values[,2]}).
+\item{data}{\link{data.frame} \link{vector}, or \linkS4class{RLum.Results} object (\strong{required}):
+for \link{data.frame}: either two columns: De (\code{values[,1]}) and De error
+(\code{values[,2]}), or one: De (\code{values[,1]}). If a numeric vector or a
+single-column data frame is provided, De error is set to \code{NA}.
 For plotting multiple data sets, these must be provided as \code{list}
 (e.g. \code{list(dataset1, dataset2)}).}
 

--- a/tests/testthat/test_calc_WodaFuchs2008.R
+++ b/tests/testthat/test_calc_WodaFuchs2008.R
@@ -19,4 +19,12 @@ test_that("Test general functionality", {
   set.seed(1)
   df <- data.frame(rnorm(20, 10), rnorm(20, 0.5))
   expect_silent(calc_WodaFuchs2008(df))
+
+  ## numeric vector
+  expect_message(calc_WodaFuchs2008(df[, 1]),
+                 "No errors provided")
+
+  ## single-column data.frame
+  expect_message(calc_WodaFuchs2008(df[, 1, drop = FALSE]),
+                 "No errors provided")
 })


### PR DESCRIPTION
This is another case (like #189) where the code accepted more types than documented, but dealt with it incorrectly. Now what we accept is fully documented, and the code is tested.

This also fixes the check for NAs: the previous code did `sum(is.na(data[,2]) == nrow(data))`, but what was meant was `sum(is.na(data[,2])) == nrow(data)`. I ended up rewriting it in an even cleaner way.