### PR TITLE
Finish silencing the test ouput

### DIFF
--- a/R/analyse_Al2O3C_ITC.R
+++ b/R/analyse_Al2O3C_ITC.R
@@ -154,7 +154,7 @@ analyse_Al2O3C_ITC <- function(
         plot = plot,
         main = ifelse("main"%in% names(list(...)), list(...)$main, paste0("ALQ #",x)),
         ...
-      ))
+      ), outFile = stdout()) # redirect error messages so they can be silenced
 
       ##catch error
       if(inherits(results, "try-error")){

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -1329,7 +1329,8 @@ analyse_baSAR <- function(
         sheet = additional_arguments$sheet,
         col_names = additional_arguments$col_names,
         col_types = additional_arguments$col_types,
-        skip = additional_arguments$skip
+        skip = additional_arguments$skip,
+        progress = FALSE,
       ), stringsAsFactors = FALSE)
 
       ###check whether data format is somehow odd, check only the first three columns

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -1978,7 +1978,6 @@ analyse_baSAR <- function(
 
   ##>> try here is much better, as the user might run a very long preprocessing and do not
   ##want to fail here
-  old.opts <- options(try.outFile = stdout()) # redirect error messages
   results <-
     try(.baSAR_function(
       Nb_aliquots = Nb_aliquots,
@@ -1993,8 +1992,7 @@ analyse_baSAR <- function(
       method_control = method_control,
       baSAR_model = baSAR_model,
       verbose = verbose
-    ))
-  options(old.opts) # restore original options
+    ), outFile = stdout()) # redirect error messages so they can be silenced
 
   ##check whether this became NULL
   if(!is(results, "try-error")){

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -581,16 +581,14 @@ fit_LMCurve<- function(
 
   }else{#endif::missing start values
     ##------------------------------------------------------------------------##
-    old.opts <- options(try.outFile = stdout()) # redirect error messages
     fit<-try(nls(y~eval(fit.function),
                  trace=fit.trace, data.frame(x=values[,1],y=values[,2]),
                  algorithm="port", start=list(Im=start_values[,1],xm=start_values[,2]),#end start values input
                  nls.control(maxiter=500),
                  lower=c(xm=0,Im=0),
                  #upper=c(xm=max(x),Im=max(y)*1.1)# set lower boundaries for components
-    )# nls
-    )# end try
-    options(old.opts) # restore original options
+                 ), outFile = stdout() # redirect error messages so they can be silenced
+             ) # end try
   }#endif::startparameter
 
   ##------------------------------------------------------------------------##

--- a/tests/testthat/test_analyse_Al2O3C_ITC.R
+++ b/tests/testthat/test_analyse_Al2O3C_ITC.R
@@ -33,9 +33,8 @@ test_that("Full check", {
   expect_s4_class(analyse_Al2O3C_ITC(list(data_ITC), signal_integral = 2,
                                      method_control = list(fit.method = "EXP")),
                   "RLum.Results")
-  })
-
   expect_warning(expect_null(analyse_Al2O3C_ITC(list(data_ITC),
                                                 dose_points = list(2))),
                  "Nothing was merged as the object list was found to be empty")
+  })
 })

--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -65,7 +65,7 @@ test_that("Test examples from the example page", {
 
   ## now with user-defined green line for minimum age model
   CAM <- calc_CentralDose(ExampleData.DeValues,
-                          plot = FALSE)
+                          plot = FALSE, verbose = FALSE)
 
   expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
                    line = CAM,

--- a/tests/testthat/test_plot_Functions.R
+++ b/tests/testthat/test_plot_Functions.R
@@ -19,6 +19,7 @@ test_that("test pure success of the plotting without warning or error", {
       background.integral.min = 900,
       background.integral.max = 1000,
       n.channels = 5,
+      verbose = FALSE,
     ),
     "RLum.Results"
   )
@@ -87,11 +88,12 @@ test_that("test pure success of the plotting without warning or error", {
 
     ##special plot RLum.Reuslts
     data(ExampleData.DeValues, envir = environment())
-    mam <- calc_MinDose(data = ExampleData.DeValues$CA1, sigmab = 0.2, log = TRUE, plot = FALSE)
+    mam <- calc_MinDose(data = ExampleData.DeValues$CA1, sigmab = 0.2,
+                        log = TRUE, plot = FALSE, verbose = FALSE)
     expect_silent(plot_RLum(mam))
-    cdm <- calc_CentralDose(ExampleData.DeValues$CA1)
+    cdm <- calc_CentralDose(ExampleData.DeValues$CA1, verbose = FALSE)
     expect_silent(plot_RLum(cdm))
-    FMM <- calc_FiniteMixture(ExampleData.DeValues$CA1,
+    FMM <- calc_FiniteMixture(ExampleData.DeValues$CA1, verbose = FALSE,
                              sigmab = 0.2, n.components = c(2:4),
                              pdf.weight = TRUE, dose.scale = c(0, 100))
     plot_RLum(FMM)

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -10,23 +10,23 @@ test_that("test the import of various BIN-file versions", {
   if (!httr::http_error(github.url)) {
     ## V3
     expect_s4_class(read_BIN2R(file.path(github.url, "BINfile_V3.bin"),
-                               txtProgressBar = FALSE),
+                               verbose = FALSE),
                     class = "Risoe.BINfileData")
   }
 
   ## V4
   expect_s4_class(read_BIN2R(test_path("_data/BINfile_V4.bin"),
-                             txtProgressBar = FALSE),
+                             verbose = FALSE),
                   class = "Risoe.BINfileData")
 
   ## V5
   expect_s4_class(read_BIN2R(test_path("_data/BINfile_V5.binx"),
-                             txtProgressBar = FALSE),
+                             verbose = FALSE),
                   class = "Risoe.BINfileData")
 
   ## V6
   expect_s4_class(read_BIN2R(test_path("_data/BINfile_V6.binx"),
-                             txtProgressBar = FALSE),
+                             verbose = FALSE),
                   class = "Risoe.BINfileData")
 
   ## V6 - show method
@@ -35,9 +35,10 @@ test_that("test the import of various BIN-file versions", {
 
   ## V7
   expect_s4_class(read_BIN2R(test_path("_data/BINfile_V7.binx"),
-                             txtProgressBar = FALSE),
+                             verbose = FALSE),
                   class = "Risoe.BINfileData")
 
+  SW({
   ## V8 - as part of the package
   bin.v8 <- system.file("extdata/BINfile_V8.binx", package = "Luminescence")
   expect_s4_class(read_BIN2R(bin.v8, txtProgressBar = FALSE),
@@ -83,17 +84,22 @@ test_that("test the import of various BIN-file versions", {
                          txtProgressBar = FALSE, n.records = 1,
                          fastForward = TRUE, verbose = FALSE),
               "list")
+  })
 
    ## check for broken files
    t <- tempfile(pattern = "zero", fileext = ".binx")
    write(raw(), t)
-   expect_error(read_BIN2R(t), regexp = "\\[read\\_BIN2R\\(\\)\\] Found BIN\\/BINX-format version \\(..\\) is not supported or the BIN/BINX-file is broken! Supported version numbers are: 03, 04, 05, 06, 07, 08.")
+   expect_error(read_BIN2R(t, verbose = FALSE),
+                "Found BIN/BINX-format version (0a) is not supported",
+                fixed = TRUE)
    file.remove(t)
 
+   SW({
    ## check ignore RECTYPE settings
-   t <- expect_s4_class(read_BIN2R(bin.v8, txtProgressBar = FALSE,
+   t <- expect_s4_class(read_BIN2R(bin.v8, verbose = TRUE,
                                    ignore.RECTYPE = 1),
                         class = "Risoe.BINfileData")
+   })
 
     ## should be zero now
     expect_length(t@DATA, n = 0)

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -90,8 +90,7 @@ test_that("test the import of various BIN-file versions", {
    t <- tempfile(pattern = "zero", fileext = ".binx")
    write(raw(), t)
    expect_error(read_BIN2R(t, verbose = FALSE),
-                "Found BIN/BINX-format version (0a) is not supported",
-                fixed = TRUE)
+                "Found BIN/BINX-format version \\(..\\) is not supported")
    file.remove(t)
 
    SW({


### PR DESCRIPTION
This silences the last few test outputs, especially those from `read_SPE2R()` which required a special treatment. Now the test output is totally clean! Fixes #120.