### PR TITLE
Validate signal and background integral values in plot_DetPlot()

### DIFF
--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -29,7 +29,8 @@
 #' lower bound of the signal integral.
 #'
 #' @param signal.integral.max [integer] (**required**):
-#' upper bound of the signal integral.
+#' upper bound of the signal integral. Must be strictly greater than
+#' `signal.integral.min`.
 #'
 #' @param background.integral.min [integer] (**required**):
 #' lower bound of the background integral.
@@ -202,10 +203,21 @@ plot_DetPlot <- function(
 # Integrity Tests -----------------------------------------------------------------------------
   ##check input
   if(!inherits(object, "RLum.Analysis"))
-    stop("[plot_DetPlot()] input must be an RLum.Analysis object!", call. = FALSE)
+    .throw_error("Input must be an 'RLum.Analysis' object")
 
   ##get structure
   object.structure <- structure_RLum(object)
+
+  ## signal.integral
+  .validate_positive_scalar(signal.integral.min, int = TRUE)
+  .validate_positive_scalar(signal.integral.max, int = TRUE)
+  if (signal.integral.min >= signal.integral.max) {
+    .throw_error("'signal.integral.max' must be greater than 'signal.integral.min'")
+  }
+
+  ## background.integral
+  .validate_positive_scalar(background.integral.min, int = TRUE)
+  .validate_positive_scalar(background.integral.min, int = TRUE)
 
 # Set parameters ------------------------------------------------------------------------------
   ##set n.channels
@@ -213,7 +225,9 @@ plot_DetPlot <- function(
     n.channels <- ceiling(
       (background.integral.min - 1 - signal.integral.max) / (signal.integral.max - signal.integral.min)
     )
-
+    if (verbose) {
+      message("'n.channels' not specified, set to ", n.channels)
+    }
   }
 
   analyse_function.settings <- list(
@@ -240,9 +254,7 @@ plot_DetPlot <- function(
         seq(signal.integral.min,
             background.integral.min - 1,
             by = signal.integral.max - signal.integral.min)
-
     }
-
   }
 
   if(analyse_function  == "analyse_SAR.CWOSL"){
@@ -286,12 +298,9 @@ plot_DetPlot <- function(
 
     }))
 
-
-
   }
   else{
-   stop("[plot_DetPlot()] 'analyse_function' unknown!", call. = FALSE)
-
+   .throw_error("Unknown 'analyse_function'")
   }
 
 

--- a/man/plot_DetPlot.Rd
+++ b/man/plot_DetPlot.Rd
@@ -31,7 +31,8 @@ Can be provided as a \link{list} of such objects.}
 lower bound of the signal integral.}
 
 \item{signal.integral.max}{\link{integer} (\strong{required}):
-upper bound of the signal integral.}
+upper bound of the signal integral. Must be strictly greater than
+\code{signal.integral.min}.}
 
 \item{background.integral.min}{\link{integer} (\strong{required}):
 lower bound of the background integral.}

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -1,17 +1,20 @@
-test_that("plot_DetPlot", {
+data(ExampleData.BINfileData, envir = environment())
+object <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
-  ##ExampleData.BINfileData contains two BINfileData objects
-  ##CWOSL.SAR.Data and TL.SAR.Data
-  data(ExampleData.BINfileData, envir = environment())
+  expect_error(plot_DetPlot("error"),
+               "Input must be an 'RLum.Analysis' object")
+  expect_error(plot_DetPlot(object, signal.integral.min = "error"),
+               "'signal.integral.min' must be a positive integer scalar")
+  expect_error(plot_DetPlot(object, signal.integral.min = 1,
+                            signal.integral.max = 1),
+               "'signal.integral.max' must be greater than 'signal.integral.min'")
+})
 
-  ##transform the values from the first position in a RLum.Analysis object
-  object <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos=1)
-
-  ## trigger stop
-  expect_error(
-    plot_DetPlot(object = "error"),
-    regexp = "\\[plot_DetPlot\\(\\)\\] input must be an RLum\\.Analysis object\\!")
+test_that("plot_DetPlot", {
+  testthat::skip_on_cran()
 
   ## simple run with default
   SW({


### PR DESCRIPTION
By enforcing that `signal.integral.max > signal.integral.min` we also avoid that the computation of the number of channels produces ` Inf` (fixes #203).

Locally, running coverage on this produces this error from the test that uses `multicore = 1`:
```console
Error in `checkForRemoteErrors(val)`: one node produced an error:
 could not find function ".validate_positive_scalar"
```
That error would go away if I used `Luminescence:::.validate_positive_scalar`, but that seems to be against the CRAN policy. Alternatively, one could move the validation checks before the self-call.

But in the meantime, let's see if CI is happy with it as it is.