### PR TITLE
Fix crash in plot_DetPlot(..., analyse_function = "analyse_pIRIRSequence")

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -70,10 +70,12 @@ which would generate unexpected warnings (#163, @mcol).
 * Argument `signal.integral.max` is now enforced to be greater than
 `signal.integral.min`, as otherwise the computation of the number of channels
 would produce `Inf` (#203, fixed in #206).
+* Fix a crash when using option `analyse_function = "analyse_pIRIRSequence"`
+(#210, fixed in #211).
 
 ### `plot_GrowthCurve()`
 * The function now calculates the relative saturation (`n/N`) using the ration of the two integrates.
-The values is part of the output table. 
+The values is part of the output table.
 
 ### `plot_KDE()`
 * It now officially supports numeric vectors and single-column data frames,

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -693,8 +693,9 @@ error.list <- list()
 
     ##combine in the data frame
     temp.LnLxTnTx <- data.frame(
-      Name = factor(x = temp.DoseName[,"Name"], levels = temp.DoseName[,"Name"]),
-      Repeated = as.logical(temp.DoseName[,"Repeated"]))
+        Name = factor(x = temp.DoseName[, "Name"],
+                      levels = unique(temp.DoseName[, "Name"])),
+        Repeated = as.logical(temp.DoseName[, "Repeated"]))
 
     LnLxTnTx <- cbind(temp.LnLxTnTx,LnLxTnTx)
     LnLxTnTx[,"Name"] <- as.character(LnLxTnTx[,"Name"])

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -566,7 +566,7 @@ analyse_pIRIRSequence <- function(
 
       ##check whether NULL was return
       if (is.null(temp.results)) {
-        try(stop("[plot_pIRIRSequence()] An error occurred, analysis skipped. Check your sequence!", call. = FALSE))
+        message("[plot_pIRIRSequence()] An error occurred, analysis skipped. Check your sequence!")
         return(NULL)
       }
 

--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -274,13 +274,11 @@ plot_DetPlot <- function(
         plot.single = analyse_function.settings$plot.single,
         verbose = verbose
       )
-
     }))
-
 
   }
   else if(analyse_function  == "analyse_pIRIRSequence"){
-    results <- merge_RLum(lapply(1:n.channels, function(x){
+    result.temp.list <- lapply(1:n.channels, function(x) {
       analyse_pIRIRSequence(
         object = object,
         signal.integral.min = if(method == "shift"){signal_integral.seq[x]}else{signal_integral.seq[1]},
@@ -293,11 +291,21 @@ plot_DetPlot <- function(
         plot.single = analyse_function.settings$plot.single,
         sequence.structure = analyse_function.settings$sequence.structure,
         verbose = verbose
-
       )
+    })
 
-    }))
-
+    ## as the analyse_pIRIRSequence() may fail, we see how many results
+    ## we've actually managed to produce
+    num.valid.results <- sum(!sapply(result.temp.list, is.null))
+    if (num.valid.results == 0) {
+      .throw_error("No valid results produced")
+    }
+    if (num.valid.results == 1) {
+      results <- results.temp.list
+    } else {
+      results <- merge_RLum(result.temp.list)
+    }
+    rm(results.temp.list)
   }
   else{
    .throw_error("Unknown 'analyse_function'")

--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -305,7 +305,7 @@ plot_DetPlot <- function(
     } else {
       results <- merge_RLum(result.temp.list)
     }
-    rm(results.temp.list)
+    rm(result.temp.list)
   }
   else{
    .throw_error("Unknown 'analyse_function'")

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -115,4 +115,22 @@ test_that("plot_DetPlot", {
     n.channels = 1)),
     "RLum.Results")
 
+  SW({
+  suppressWarnings( # ignore additional warnings from plot_GrowthCurve()
+  expect_error(
+      expect_warning(plot_DetPlot(
+          object,
+          signal.integral.min = 1,
+          signal.integral.max = 2,
+          background.integral.min = 900,
+          background.integral.max = 1000,
+          analyse_function = "analyse_pIRIRSequence",
+          analyse_function.control = list(
+              fit.method = "LIN"),
+          verbose = FALSE,
+          n.channels = 1),
+          "An error occurred, analysis skipped"),
+      "No valid results produced")
+  )
+  })
 })

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -116,6 +116,21 @@ test_that("plot_DetPlot", {
     "RLum.Results")
 
   SW({
+  ## analyse_pIRIRSequence
+  tmp <- subset(object, recordType != "IRSL" & ID != 1)
+  plot_DetPlot(
+      tmp,
+      signal.integral.min = 1,
+      signal.integral.max = 2,
+      background.integral.min = 900,
+      background.integral.max = 1000,
+      analyse_function = "analyse_pIRIRSequence",
+      analyse_function.control = list(
+          sequence.structure = c("TL", "IR50"),
+          fit.method = "LIN"),
+      n.channels = 2)
+
+  ## analyse_pIRIRSequence on an inconsistent object
   suppressWarnings( # ignore additional warnings from plot_GrowthCurve()
   expect_error(
       expect_warning(plot_DetPlot(


### PR DESCRIPTION
This now checks that we have enough valid results from the calls to `analyse_pIRIRSequence()` before continuing. Fixes #210.