### PR TITLE
Add full support for single-column data frames to plot_RadialPlot()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -85,9 +85,13 @@ fixed in #194, @mcol).
 to an object of unexpected type or when there is a mismatch in time values
 (#177, fixed with #179 by @mcol).
 
+### `plot_RadialPlot()`
+* The function doesn't crash anymore when a single-column data frame is
+provided (#191, fixed in #212).
+
 ### `plot_RLum.Data.Analysis()`
 * The function now supports all arguments from `plot_RLum.Data.Spectrum()`; before it 
-had only basic functionality for `RLum.Data.Spectrum-class` data. 
+had only basic functionality for `RLum.Data.Spectrum-class` data.
 
 ### `plot_RLum.Data.Spectrum()`
 * The plot function can now handle non-increasing column values for plotting (with a warning).

--- a/R/plot_RadialPlot.R
+++ b/R/plot_RadialPlot.R
@@ -38,7 +38,9 @@
 #' - `"skewness"` (skewness).
 #'
 #' @param data [data.frame] or [RLum.Results-class] object (**required**):
-#' for `data.frame` two columns: De (`data[,1]`) and De error (`data[,2]`).
+#' for `data.frame`: either two columns: De (`data[,1]`) and De error
+#' (`data[,2]`), or one: De (`values[,1]`). If a single-column data frame
+#' is provided, De error is assumed to be 10^-9 for all measurements.
 #' To plot several data sets in one plot, the data sets must be provided as
 #' `list`, e.g. `list(data.1, data.2)`.
 #'
@@ -306,8 +308,20 @@ plot_RadialPlot <- function(
         data[[i]] <- get_RLum(data[[i]], "data")
       }
 
-      ##use only the first two columns
-      data[[i]] <- data[[i]][,1:2]
+      ## ensure that the dataset it not degenerate
+      if (nrow(data[[i]]) == 0) {
+       .throw_error("Input data ", i, " has 0 rows")
+      }
+
+      ## if `data[[i]]` is a single-column data frame, append a second
+      ## column with a small non-zero value (10^-9 for consistency with
+      ## what `calc_Statistics() does)
+      if (ncol(data[[i]]) < 2) {
+        data[[i]] <- data.frame(data[[i]], 10^-9)
+      } else if (ncol(data[[i]]) > 2) {
+        ## keep only the first two columns
+        data[[i]] <- data[[i]][, 1:2]
+      }
     }
   }
 

--- a/man/plot_RadialPlot.Rd
+++ b/man/plot_RadialPlot.Rd
@@ -30,7 +30,9 @@ plot_RadialPlot(
 }
 \arguments{
 \item{data}{\link{data.frame} or \linkS4class{RLum.Results} object (\strong{required}):
-for \code{data.frame} two columns: De (\code{data[,1]}) and De error (\code{data[,2]}).
+for \code{data.frame}: either two columns: De (\code{data[,1]}) and De error
+(\code{data[,2]}), or one: De (\code{values[,1]}). If a single-column data frame
+is provided, De error is assumed to be 10^-9 for all measurements.
 To plot several data sets in one plot, the data sets must be provided as
 \code{list}, e.g. \code{list(data.1, data.2)}.}
 

--- a/tests/testthat/test_plot_RadialPlot.R
+++ b/tests/testthat/test_plot_RadialPlot.R
@@ -14,6 +14,8 @@ test_that("input validation", {
                "'data' is an empty list")
   expect_error(plot_RadialPlot(df[, 1]),
                "Input data must be 'data.frame' or 'RLum.Results'")
+  expect_error(plot_RadialPlot(df[0, ]),
+               "Input data 1 has 0 rows")
   expect_error(plot_RadialPlot(df, xlab = "x"),
                "'xlab' must have length 2")
   expect_error(plot_RadialPlot(df, centrality = "error"),
@@ -70,6 +72,10 @@ test_that("dedicated test for the radialplot", {
       data = df,
       centrality = -1,
       log.z = FALSE))
+
+  ## single-column data frame
+  expect_message(plot_RadialPlot(df[, 1, drop = FALSE]),
+                 "Attention, small standardised estimate scatter")
 
   ## more coverage
   expect_type(plot_RadialPlot(df, main = "Title", sub = "Subtitle", rug = TRUE,


### PR DESCRIPTION
This also adds an early return in case the input data frame has no rows. Fixes #191.