### PR TITLE
Make calc_WodaFuchs2008() work on more RLum.Results objects

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -47,6 +47,9 @@ an exponential fit is applied then this values are used as start parameters.
 data frames as input (#200).
 * The function computed the number of breaks for the histogram incorrectly
 (#197, fixed with #198).
+* The function now supports more types of `RLum.Results` objects without
+crashing, although if the object contains only one data point it will stop
+immediately to avoid problems with `nls()` (#199, fixed in #219).
 
 ### `fit_CWCurve()`
 * Argument `output.path` has been removed, and a warning is raised when

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -74,7 +74,8 @@ calc_WodaFuchs2008 <- function(
     } else {
 
       if(is(data, "RLum.Results") == TRUE) {
-        data <- get_RLum(data, "data")
+        data <- tryCatch(get_RLum(data, "data"),
+                         error = function(e) get_RLum(data))
       }
 
       ## if data is a numeric vector or a single-column data frame,

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -83,6 +83,11 @@ calc_WodaFuchs2008 <- function(
       if (NCOL(data) < 2) {
         data <- cbind(data, NA)
       }
+
+      ## with just one data point, it's possible to cause nls() to hang
+      if (nrow(data) < 2) {
+        .throw_error("Insufficient number of data points")
+      }
     }
 
   ## read additional arguments

--- a/tests/testthat/test_calc_WodaFuchs2008.R
+++ b/tests/testthat/test_calc_WodaFuchs2008.R
@@ -1,14 +1,17 @@
+data(ExampleData.DeValues, envir = environment())
+
 test_that("input validation", {
   testthat::skip_on_cran()
 
   expect_warning(expect_null(calc_WodaFuchs2008("error")),
                  "Input data must be one of 'data.frame', 'RLum.Results' or")
+  res <- calc_WodaFuchs2008(ExampleData.DeValues$CA1)
+  expect_error(calc_WodaFuchs2008(res, breaks = 4),
+               "Insufficient number of data points")
 })
 
 test_that("Test general functionality", {
   testthat::skip_on_cran()
-
-  data(ExampleData.DeValues, envir = environment())
 
   ##test arguments
   expect_s4_class(calc_WodaFuchs2008(ExampleData.DeValues$CA1),


### PR DESCRIPTION
A quick and dirty fix for the example posted in #199.

I ended up with the `tryCatch()` solution because in the tests we have already an example in which the `data` slot is present but it's not the first entry:

```R
obj <- calc_CommonDose(ExampleData.DeValues$BT998, verbose = FALSE)
expect_silent(calc_WodaFuchs2008(obj))
```
In other words, with my approach we don't change the expectation of that test.