### PR TITLE
Make read_BIN2R() not crash when forcing a version on an empty file

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -112,9 +112,11 @@ had only basic functionality for `RLum.Data.Spectrum-class` data.
 * `ignore.RECTYPE` now supports numeric values, e.g., 128. Records for this type
 will be ignored during import.
 * BINX-files with `RECTYPE = 128` will not crash anymore, thanks for asking Anna-Maartje Boer and replying Karsten Bracht.
+* The function now stops graciously when attempting to read an empty file
+(#225, fixed in #226).
 
 ### `read_PSL2R()`
-* The function is out of the beta status, hence the flag was removed. 
+* The function is out of the beta status, hence the flag was removed.
 * The `RLum.Analysis-class` object returned by the function gained a new element `Sequence`, which is a data frame. 
 with the measured sequence. This way, if the original sequence was lost, it can still be extracted from the `.psl` data.
 * If no `.psl` file was found the function got trapped in an infinite loop (#127); fixed with #128 (thanks to @mcol)

--- a/NEWS.md
+++ b/NEWS.md
@@ -144,6 +144,8 @@
   this type will be ignored during import.
 - BINX-files with `RECTYPE = 128` will not crash anymore, thanks for
   asking Anna-Maartje Boer and replying Karsten Bracht.
+- The function now stops graciously when attempting to read an empty
+  file (#225, fixed in \#226).
 
 ### `read_PSL2R()`
 

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -25,6 +25,18 @@ test_that("input validation", {
   write(raw(), zero)
   expect_error(read_BIN2R(zero, verbose = FALSE),
                "BIN/BINX format version \\(..\\) is not supported or file is")
+  SW({
+  expect_warning(
+      expect_message(expect_null(read_BIN2R(zero, verbose = TRUE,
+                                            forced.VersionNumber = 8)),
+                     "Record #1 skipped due to wrong record length"),
+      "0 records read, NULL returned")
+  expect_warning(
+      expect_message(expect_null(read_BIN2R(zero, verbose = TRUE,
+                                            forced.VersionNumber = 3)),
+                     "Record #1 skipped due to wrong record length"),
+      "0 records read, NULL returned")
+  })
 
   fake <- tempfile(pattern = "fake", fileext = ".binx")
   writeBin(as.raw(c(  8, 0,       # version


### PR DESCRIPTION
The relevant changes are the addition of the two `if`s and the change to `n = max(0, temp.LENGTH - 4)` to avoid `n` going negative (similarly to what was already existing for versions 6, 7, 8). Fixes #225.