### PR TITLE
Make .Risoe.BINfileData2RLum.Data.Curve() work without the id argument

### DIFF
--- a/R/Risoe.BINfileData2RLum.Data.Curve.R
+++ b/R/Risoe.BINfileData2RLum.Data.Curve.R
@@ -76,11 +76,9 @@
   # grep id of record -------------------------------------------------------
   ##if id is set, no input for pos and run is necessary
   if (missing(id)) {
-    id <- METADATA[METADATA[["POSITION"]] == pos &
-                     METADATA[["SET"]] == set &
-                     METADATA[["RUN"]] == run,
-                   "ID"]
-
+    id <- METADATA$ID[METADATA[["POSITION"]] == pos &
+                      METADATA[["SET"]] == set &
+                      METADATA[["RUN"]] == run]
   }
 
   ##grep info elements

--- a/tests/testthat/test_Risoe.BINfileData2RLum.Data.Curve.R
+++ b/tests/testthat/test_Risoe.BINfileData2RLum.Data.Curve.R
@@ -1,0 +1,18 @@
+test_that("check functionality", {
+  testthat::skip_on_cran()
+
+  data(ExampleData.BINfileData, envir = environment())
+
+  res <- .Risoe.BINfileData2RLum.Data.Curve(CWOSL.SAR.Data, id = 1)
+  expect_s4_class(res, "RLum.Data.Curve")
+  expect_length(res@data, 500)
+  expect_length(res@info, 44)
+  expect_equal(res@originator, ".Risoe.BINfileData2RLum.Data.Curve")
+
+  res1 <- .Risoe.BINfileData2RLum.Data.Curve(CWOSL.SAR.Data,
+                                             pos = 1, set = 2, run = 1)
+  expect_s4_class(res1, "RLum.Data.Curve")
+  expect_equal(res1@data, res@data)
+  expect_equal(res1@info, res@info)
+  expect_equal(res1@originator, res@originator)
+})


### PR DESCRIPTION
If `id` is not passed as an argument, the function tries to resolve it by using the `pos`, `run` and `set` arguments, but this error would occur:

```R
.Risoe.BINfileData2RLum.Data.Curve(CWOSL.SAR.Data, pos = 1, set = 2, run = 1)
# Error in METADATA[METADATA[["POSITION"]] == pos & METADATA[["SET"]] == :
#   incorrect number of dimensions
```
As `METADATA` is converted from data.frame to a list a few lines before, it cannot be accessed any longer with the data.frame indexing, but is should use the standard list accessor.

This was an ancient bug introduced in bb8cf69, but totally harmless since it's in an internal function that is never called without the `id` argument.