### PR TITLE
Improve consistency check in extract_IrradiationTime()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -51,6 +51,11 @@ data frames as input (#200).
 crashing, although if the object contains only one data point it will stop
 immediately to avoid problems with `nls()` (#199, fixed in #219).
 
+### `extract_IrradiationTimes()`
+* If a BIX-file is provided, the function will now check that it contains the
+same amount of data as the corresponding XSYG file a bit earlier than before,
+thus avoiding a possible crash (#228, fixed in #229).
+
 ### `fit_CWCurve()`
 * Argument `output.path` has been removed, and a warning is raised when
 attempting to use it (#207, fixed in #209).

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,13 @@
   stop immediately to avoid problems with `nls()` (#199, fixed in
   \#219).
 
+### `extract_IrradiationTimes()`
+
+- If a BIX-file is provided, the function will now check that it
+  contains the same amount of data as the corresponding XSYG file a bit
+  earlier than before, thus avoiding a possible crash (#228, fixed in
+  \#229).
+
 ### `fit_CWCurve()`
 
 - Argument `output.path` has been removed, and a warning is raised when

--- a/R/extract_IrradiationTimes.R
+++ b/R/extract_IrradiationTimes.R
@@ -381,33 +381,31 @@ extract_IrradiationTimes <- function(
     ##(1) remove all irradiation steps as there is no record in the BINX file and update information
     results.BINX <- results[-which(results[,"STEP"] == "irradiation (NA)"),]
 
-    ##(1a)  update information on the irradiation time
-    temp.BINX@METADATA[["IRR_TIME"]] <- results.BINX[["IRR_TIME"]]
+    ## (2) compare entries in the BINX-file with the entries in the table
+    ## to make sure that both have the same length
+    if(nrow(results.BINX) == nrow(temp.BINX@METADATA)){
 
-    ##(1b) update information on the time since irradiation by using the Risoe definition of thi
-    ##parameter, to make the file compatible to the Analyst
-    temp.BINX@METADATA[["TIMESINCEIRR"]] <- results.BINX[["IRR_TIME"]] + results.BINX[["TIMESINCEIRR"]]
+      ## (1a) update information on the irradiation time
+      temp.BINX@METADATA[["IRR_TIME"]] <- results.BINX[["IRR_TIME"]]
 
-    ##(2) compare entries in the BINX-file with the entries in the table to make sure
-    ## that both have the same length
-    if(!missing(file.BINX)){
-      if(nrow(results.BINX) == nrow(temp.BINX@METADATA)){
+      ## (1b) update information on the time since irradiation by using the
+      ## Risoe definition of the parameter, to make the file compatible to
+      ## the Analyst
+      temp.BINX@METADATA[["TIMESINCEIRR"]] <- results.BINX[["IRR_TIME"]] + results.BINX[["TIMESINCEIRR"]]
 
-        ##update BINX-file
-        try <- write_R2BIN(temp.BINX, version = "06",
-                   file = paste0(file.BINX,"_extract_IrradiationTimes.BINX"),
-                   compatibility.mode =  compatibility.mode,
-                   txtProgressBar = txtProgressBar)
+      ## update BINX-file
+      try <- write_R2BIN(temp.BINX, version = "06",
+                         file = paste0(file.BINX,"_extract_IrradiationTimes.BINX"),
+                         compatibility.mode = compatibility.mode,
+                         txtProgressBar = txtProgressBar)
 
-        ##set message on the format definition
-        if(!inherits(x = try, 'try-error')){
-          message("[extract_IrradiationTimes()] 'Time Since Irradiation' was redefined in the exported BINX-file to: 'Time Since Irradiation' plus the 'Irradiation Time' to be compatible with the Analyst.")
-        }
-
+      ##set message on the format definition
+      if(!inherits(x = try, 'try-error')){
+        message("[extract_IrradiationTimes()] 'Time Since Irradiation' was redefined in the exported BINX-file to: 'Time Since Irradiation' plus the 'Irradiation Time' to be compatible with the Analyst.")
       }
-    }else{
+    } else {
       message("[extract_IrradiationTimes()] XSYG-file and BINX-file ",
-              "did not contain similar entries. BINX-file update skipped!")
+              "do not contain similar entries, BINX-file update skipped")
     }
   }
 

--- a/tests/testthat/test_extract_IrradiationTimes.R
+++ b/tests/testthat/test_extract_IrradiationTimes.R
@@ -10,15 +10,11 @@ test_that("input validation", {
                "neither of type 'character' nor of type 'RLum.Analysis")
   expect_error(extract_IrradiationTimes(xsyg, file.BINX = "fail"),
                "Wrong BINX file name or file does not exist!")
-
-  SW({
-  ## FIXME(mcol): catch this error properly
-  expect_error(extract_IrradiationTimes(xsyg, file.BINX = binx,
-                                        txtProgressBar = FALSE),
-               "replacement has 3 rows, data has 2")
+  expect_message(extract_IrradiationTimes(xsyg, file.BINX = binx,
+                                          txtProgressBar = FALSE),
+                 "XSYG-file and BINX-file do not contain similar entries")
   expect_warning(extract_IrradiationTimes(list(xsyg), file.BINX = binx),
                  "'file.BINX' is not supported in self-call mode")
-  })
 })
 
 test_that("Test the extraction of irradiation times", {


### PR DESCRIPTION
This moves an existing check a few lines up. The actual change is quite small, but there is a lot of indentation changes because I removed a duplicated `if(!missing(file.BINX))` check inside a block that had already checked for that. Fixes #228.