### PR TITLE
Exclude untestable functions from coverage

### DIFF
--- a/R/addins_RLum.R
+++ b/R/addins_RLum.R
@@ -23,7 +23,6 @@
 ##    package 'rstudioapi', 'devtools' and get happy.
 
 
-
 #'Install package development version
 #'
 #'The function uses the GitHub APconnection provided by Christoph Burow
@@ -32,8 +31,7 @@
 #'
 #'@noRd
 .installDevelopmentVersion <- function(){
-  install_DevelopmentVersion(force_install = TRUE)
-
+  install_DevelopmentVersion(force_install = TRUE) # nocov
 }
 
 #'Search for TODOs in the source code and list them in the terminal
@@ -45,10 +43,9 @@
 #'
 #'@noRd
 .listTODO <- function(){
-
+  # nocov start
   ##check if package is installed
   if(!requireNamespace("rstudioapi", quietly = TRUE)){
-    # nocov start
     message("Package 'rstudioapi' is not installed but needed to search for TODOs, do you want to install it?\n\n",
             " [n/N]: No (default)\n",
             " [y/Y]: Yes\n")
@@ -59,7 +56,6 @@
     if(tolower(answer) == "y"){
       utils::install.packages("rstudioapi", dependencies = TRUE)
     }
-    # nocov end
   }else{
 
   ##parse code
@@ -72,9 +68,7 @@
   cat("\n", "[", length(id), " issue(s)]\n", sep = "")
    for(i in id){
     cat(" line ", i, ": ->", code[i], "\n", sep = "")
-
    }
-
- }
-
+  }
+  # nocov end
 }

--- a/R/install_DevelopmentVersion.R
+++ b/R/install_DevelopmentVersion.R
@@ -37,7 +37,7 @@
 #' @md
 #' @export
 install_DevelopmentVersion <- function(force_install = FALSE) {
-
+  # nocov start
   message("\n[install_DevelopmentVersion]\n")
 
   # check which branches are currently available
@@ -96,11 +96,9 @@ install_DevelopmentVersion <- function(force_install = FALSE) {
 
     # check if 'devtools' is available and install if not
     if (!requireNamespace("devtools", quietly = TRUE)) {
-      # nocov start
       message("Please install the 'devtools' package first by running the following command:\n",
               "install.packages('devtools')")
       return(NULL)
-      # nocov end
     }
 
     # detach the 'Luminescence' package
@@ -113,7 +111,6 @@ install_DevelopmentVersion <- function(force_install = FALSE) {
 
     # install the development version
     devtools::install_github(paste0("r-lum/luminescence@", branch))
-
   }
-
+  # nocov end
 }


### PR DESCRIPTION
This excludes the bodies of `addins_RLum()` and `install_DevelopmentVersion()` from coverage as they cannot be tested with testthat (part of #121).