### PR TITLE
Don't use the bbmle::profile() try_harder option in calc_MinDose()

### DIFF
--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -661,7 +661,7 @@ calc_MinDose <- function(
       bbmle::profile(ests,
                      which = which,
                      std.err = as.vector(coef_err),
-                     try_harder = TRUE,
+                     # try_harder = TRUE,
                      quietly = TRUE,
                      maxsteps = maxsteps,
                      tol.newmin = Inf,

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -63,6 +63,8 @@ test_that("check class and length of output", {
   expect_message(calc_MinDose(data.na, sigmab = 0.1, verbose = FALSE),
                  "Input data contained NA/NaN values, which were removed")
 
+  ## no converging fit
+  skip_on_os("windows")
   set.seed(1)
   data.nofit <- data.frame(rep(4, 5), rnorm(5, 5))
   SW({

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -62,6 +62,13 @@ test_that("check class and length of output", {
   data.na[1, 1] <- NA
   expect_message(calc_MinDose(data.na, sigmab = 0.1, verbose = FALSE),
                  "Input data contained NA/NaN values, which were removed")
+
+  set.seed(1)
+  data.nofit <- data.frame(rep(4, 5), rnorm(5, 5))
+  SW({
+  expect_error(calc_MinDose(data.nofit, sigmab = 0.9, par=4),
+               "Couldn't find a converging fit for the profile log-likelihood")
+  })
 })
 
 test_that("check values from output example", {


### PR DESCRIPTION
This makes it fail much faster when a converging fit for the profile log-likelihood cannot be found. Fixes #234.