### PR TITLE
Remove the windows-2019 (oldrel) instance from the CI actions

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -25,7 +25,6 @@ jobs:
           - {os: windows-latest, r: 'oldrel', not_cran: 'true'}
           - {os: windows-latest, r: 'release', not_cran: 'true'}
           - {os: windows-latest, r: 'devel', not_cran: 'true'}
-          - {os: windows-2019, r: 'oldrel', not_cran: 'true'}
           - {os: macos-13,   r: 'release', not_cran: 'true'}
           - {os: macos-12,   r: 'oldrel', not_cran: 'true'}
           - {os: ubuntu-latest,   r: 'devel', not_cran: 'true'}


### PR DESCRIPTION
We no longer need this.