### PR TITLE
Add the expect_snapshot_RLum() test helper and start using it

### DIFF
--- a/tests/testthat/_snaps/analyse_SAR.TL.md
+++ b/tests/testthat/_snaps/analyse_SAR.TL.md
@@ -1,0 +1,763 @@
+# Test examples
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["data", "LnLxTnTx.table", "rejection.criteria"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "RC.Status"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": ["NA", "NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA", "NA"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["OK", "OK"]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Name", "Repeated", "Dose", "LnLx", "LnLx.BG", "TnTx", "TnTx.BG", "net_LnLx", "net_LnLx.Error", "net_TnTx", "net_TnTx.Error", "LxTx", "LxTx.Error"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Natural", "R1", "R2", "R3", "R4", "R5", "R6", "Natural", "R1", "R2", "R3", "R4", "R5", "R6"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [false, false, false, false, false, false, false, false, false, false, false, false, false, false]
+                },
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [582, 2325, 6078, 10815, 16099, 52, 6046, 582, 2325, 6078, 10815, 16099, 52, 6046]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [63, 65, 62, 77, 66, 51, 49, 63, 65, 62, 77, 66, 51, 49]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [2224, 2508, 2502, 2637, 2687, 2519, 2612, 2224, 2508, 2502, 2637, 2687, 2519, 2612]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [80, 55, 55, 37, 61, 69, 54, 80, 55, 55, 37, 61, 69, 54]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [519, 2260, 6016, 10738, 16033, 1, 5997, 519, 2260, 6016, 10738, 16033, 1, 5997]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [99.02862112, 245.85558854, 480.2851737, 3944.37019033, 858.86689566, 0.2495671, 432.70605783, 99.02862112, 245.85558854, 480.2851737, 3944.37019033, 858.86689566, 0.2495671, 432.70605783]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [2144, 2453, 2447, 2600, 2626, 2450, 2558, 2144, 2453, 2447, 2600, 2626, 2450, 2558]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [322.15784951, 315.36962441, 220.21876464, 1987.54338496, 152.20183667, 451.9334645, 167.47955058, 322.15784951, 315.36962441, 220.21876464, 1987.54338496, 152.20183667, 451.9334645, 167.47955058]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.2420709, 0.92132083, 2.45852064, 4.13, 6.10548363, 0.00040816, 2.3444097, 0.2420709, 0.92132083, 2.45852064, 4.13, 6.10548363, 0.00040816, 2.3444097]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.08256234, 0.21867599, 0.41753067, 4.67420168, 0.68093401, 0.00017715, 0.32265314, 0.08256234, 0.21867599, 0.41753067, 4.67420168, 0.68093401, 0.00017715, 0.32265314]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["citeria", "value", "threshold", "status"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["recuperation rate", "recuperation rate", "recuperation rate", "recuperation rate"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["+/- 0.1", " 0.1", "+/- 0.1", " 0.1"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": [null, "OK", null, "OK"]
+                }
+              ]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["analyse_SAR.TL"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["info", "info"]
+            }
+          },
+          "value": [
+            {
+              "type": "language",
+              "attributes": {
+                "srcref": {
+                  "type": "integer",
+                  "attributes": {
+                    "srcfile": {
+                      "type": "environment",
+                      "attributes": {
+                        "class": {
+                          "type": "character",
+                          "attributes": {},
+                          "value": ["srcfilecopy", "srcfile"]
+                        }
+                      },
+                      "value": {}
+                    },
+                    "class": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["srcref"]
+                    }
+                  },
+                  "value": [136, 7, 147, 7, 7, 7, 136, 147]
+                }
+              },
+              "value": ["analyse_SAR.TL(object = o, object.background = object.background, ", "    signal.integral.min = signal.integral.min, signal.integral.max = signal.integral.max, ", "    integral_input = integral_input, sequence.structure = sequence.structure, ", "    rejection.criteria = rejection.criteria, dose.points = dose.points, ", "    log = log, ...)"]
+            },
+            {
+              "type": "language",
+              "attributes": {
+                "srcref": {
+                  "type": "integer",
+                  "attributes": {
+                    "srcfile": {
+                      "type": "environment",
+                      "attributes": {
+                        "class": {
+                          "type": "character",
+                          "attributes": {},
+                          "value": ["srcfilecopy", "srcfile"]
+                        }
+                      },
+                      "value": {}
+                    },
+                    "class": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["srcref"]
+                    }
+                  },
+                  "value": [136, 7, 147, 7, 7, 7, 136, 147]
+                }
+              },
+              "value": ["analyse_SAR.TL(object = o, object.background = object.background, ", "    signal.integral.min = signal.integral.min, signal.integral.max = signal.integral.max, ", "    integral_input = integral_input, sequence.structure = sequence.structure, ", "    rejection.criteria = rejection.criteria, dose.points = dose.points, ", "    log = log, ...)"]
+            }
+          ]
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["data", "LnLxTnTx.table", "rejection.criteria"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "RC.Status"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["OK"]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Name", "Repeated", "Dose", "LnLx", "LnLx.BG", "TnTx", "TnTx.BG", "net_LnLx", "net_LnLx.Error", "net_TnTx", "net_TnTx.Error", "LxTx", "LxTx.Error"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Natural", "R1", "R2", "R3", "R4", "R5", "R6"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [false, false, false, false, false, false, false]
+                },
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [143976, 46982, 116969, 202244, 288938, 1072, 104093]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1264, 945, 1448, 1930, 2688, 906, 1573]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [46845, 46693, 48323, 48617, 47368, 44496, 44685]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [970, 960, 1145, 1312, 1490, 1040, 1127]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [142712, 46037, 115521, 200314, 286250, 166, 102520]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [23471.76514974, 516.71547437, 17093.06753332, 45355.24022785, 90210.69966717, 17.36079828, 20554.16013632]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [45875, 45733, 47178, 47305, 45878, 43456, 43558]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [9831.88240676, 505.28303788, 8827.98669696, 15756.02600879, 26083.14939525, 3959.18877496, 12188.88207632]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [3.11088828, 1.00664728, 2.44862012, 4.23452066, 6.23937399, 0.00381996, 2.35364342]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1.17836846, 0.02242051, 0.82049797, 2.36918841, 5.51360616, 0.00074753, 1.13050283]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["citeria", "value", "threshold", "status"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["recuperation rate", "recuperation rate"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["+/- 0.1", " 0.1"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": [null, "OK"]
+                }
+              ]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["analyse_SAR.TL"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["info"]
+            }
+          },
+          "value": [
+            {
+              "type": "language",
+              "attributes": {
+                "srcref": {
+                  "type": "integer",
+                  "attributes": {
+                    "srcfile": {
+                      "type": "environment",
+                      "attributes": {
+                        "class": {
+                          "type": "character",
+                          "attributes": {},
+                          "value": ["srcfilecopy", "srcfile"]
+                        }
+                      },
+                      "value": {}
+                    },
+                    "class": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["srcref"]
+                    }
+                  },
+                  "value": [136, 7, 147, 7, 7, 7, 136, 147]
+                }
+              },
+              "value": ["analyse_SAR.TL(object = o, object.background = object.background, ", "    signal.integral.min = signal.integral.min, signal.integral.max = signal.integral.max, ", "    integral_input = integral_input, sequence.structure = sequence.structure, ", "    rejection.criteria = rejection.criteria, dose.points = dose.points, ", "    log = log, ...)"]
+            }
+          ]
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["data", "LnLxTnTx.table", "rejection.criteria"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "RC.Status"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["OK"]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Name", "Repeated", "Dose", "LnLx", "LnLx.BG", "TnTx", "TnTx.BG", "net_LnLx", "net_LnLx.Error", "net_TnTx", "net_TnTx.Error", "LxTx", "LxTx.Error"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["Natural", "R1", "R2", "R3", "R4", "R0", "R6"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [false, false, false, false, false, false, true]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0, 136, 317, 544, 815, 0, 317]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [23, 75, 130, 148, 196, 27, 131]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [99, 98, 97, 85, 80, 76, 90]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.23232323, 0.76530612, 1.34020619, 1.74117647, 2.45, 0.35526316, 1.45555556]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["citeria", "value", "threshold", "status"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2]
+                }
+              },
+              "value": [
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["R6/R2", "recuperation rate"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1.08606838, 1.5292]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["+/- 0.1", " 0.1"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["OK", "OK"]
+                }
+              ]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["analyse_SAR.TL"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["info"]
+            }
+          },
+          "value": [
+            {
+              "type": "language",
+              "attributes": {
+                "srcref": {
+                  "type": "integer",
+                  "attributes": {
+                    "srcfile": {
+                      "type": "environment",
+                      "attributes": {
+                        "class": {
+                          "type": "character",
+                          "attributes": {},
+                          "value": ["srcfilecopy", "srcfile"]
+                        }
+                      },
+                      "value": {}
+                    },
+                    "class": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["srcref"]
+                    }
+                  },
+                  "value": [6, 3, 6, 30, 3, 30, 6, 6]
+                }
+              },
+              "value": ["analyse_SAR.TL(object, signal.integral.min = 2, signal.integral.max = 3, ", "    sequence.structure = c(\"SIGNAL\", \"EXCLUDE\"))"]
+            }
+          ]
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,9 @@
+## --------------------------------------------------------------------------
+## helper functions for snapshotting
+##
+
+expect_snapshot_RLum <- function(object) {
+  object@.uid <- NA_character_
+  object@.pid <- NA_character_
+  expect_snapshot_value(object, style = "json2")
+}

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -26,6 +26,8 @@ test_that("Test examples", {
   skip_on_cran()
 
   ##perform analysis
+  ## FIXME(mcol): this example doesn't work with snapshotting, presumably
+  ## due to setting the `fit.method = "EXP OR LIN"` option
   SW({
   expect_s4_class(
     analyse_SAR.TL(
@@ -38,31 +40,34 @@ test_that("Test examples", {
     "RLum.Results"
   )
 
-  expect_s4_class(
+  expect_snapshot_RLum(
     analyse_SAR.TL(
         list(object, object),
         signal.integral.min = 210,
         signal.integral.max = 220,
         dose.points = 1:7,
         integral_input = "temperature",
-        sequence.structure = c("SIGNAL", "BACKGROUND")),
-    "RLum.Results"
+        sequence.structure = c("SIGNAL", "BACKGROUND"))
   )
 
   expect_warning(
+  expect_snapshot_RLum(
     analyse_SAR.TL(
         list(object),
         signal.integral.min = 210,
         signal.integral.max = 220,
         dose.points = 1:7,
         log = "x",
-        sequence.structure = c("SIGNAL", "BACKGROUND")),
+        sequence.structure = c("SIGNAL", "BACKGROUND"))
+    ),
     "log-scale needs positive values; log-scale disabled"
   )
 
   expect_warning(
+  expect_snapshot_RLum(
     analyse_SAR.TL(object, signal.integral.min = 2, signal.integral.max = 3,
-                   sequence.structure = c("SIGNAL", "EXCLUDE")),
-    "'fit.weights' ignored since the error column is invalid or 0")
+                   sequence.structure = c("SIGNAL", "EXCLUDE"))
+    ),
+  "'fit.weights' ignored since the error column is invalid or 0")
   })
 })


### PR DESCRIPTION
This adds some snapshot tests for `analyse_SAR.TL()`, as I'm working on some changes to that function, and luckily there are just a few tests.

I've written the `expect_snapshot_RLum()` helper as we have to ignore the `.uid` and `.pid` fields, which would never match. The expected output is saved in the `tests/testthat/_snaps/analyse_SAR.TL.md` and contains a JSON representation of the output `RLum.Results` object.

We need to see how CI reacts to that, there may be tolerances that need to be set to satisfy different machine configurations. :crossed_fingers: 

This is the start of #243.