### PR TITLE
Correct the rejection.criteria data frame created by analyse_SAR.TL()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -21,6 +21,10 @@ affected was also `analyse_SAR.CWOSL()`.
 it shows a warning with instructions and set `plot = FALSE`. This should prevent "Figure margins too large" errors. 
 * The function will not crash anymore during the plotting in another edge case related to single grain data. 
 
+### `analyse_SAR.TL()`
+* The function now produces a more correct `rejection.criteria` data frame
+(#245, fixed in #246).
+
 ### `get_RLum()`
 * When the function was used on a list of `RLum.Analysis-class` objects with the argument `null.rm = TRUE` it would 
 remove all `NULL` objects, but not elements that became `list()` (empty list) during the selection; fixed.
@@ -35,8 +39,4 @@ remove all `NULL` objects, but not elements that became `list()` (empty list) du
 * Two new internal functions `.throw_warning()` and `.throw_error()` sometimes flushed the
 terminal with messages if call (internally) in particular circumstances. Now the functions
 make only two attempts to get the name of their called and then return an `unknown()` as function name. 
-
-## Internals
-
-
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,11 @@
 - The function will not crash anymore during the plotting in another
   edge case related to single grain data.
 
+### `analyse_SAR.TL()`
+
+- The function now produces a more correct `rejection.criteria` data
+  frame (#245, fixed in \#246).
+
 ### `get_RLum()`
 
 - When the function was used on a list of `RLum.Analysis-class` objects
@@ -45,5 +50,3 @@
   particular circumstances. Now the functions make only two attempts to
   get the name of their called and then return an `unknown()` as
   function name.
-
-## Internals

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -354,7 +354,7 @@ analyse_SAR.TL <- function(
                    "recuperation rate"),
     value = c(RecyclingRatio,Recuperation),
     threshold = c(
-      rep(paste("±", rejection.criteria$recycling.ratio/100)
+      rep(paste("\u00b1", rejection.criteria$recycling.ratio/100)
           ,length(RecyclingRatio)),
       rejection.criteria$recuperation.rate/100
     ),

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -310,7 +310,7 @@ analyse_SAR.TL <- function(
   LnLxTnTx[,"Name"]<-as.character(LnLxTnTx[,"Name"])
 
   # Calculate Recycling Ratio -----------------------------------------------
-  RecyclingRatio <- NA
+  RecyclingRatio <- NA_real_
   if(length(LnLxTnTx[LnLxTnTx[,"Repeated"]==TRUE,"Repeated"])>0){
 
     ##identify repeated doses
@@ -341,7 +341,7 @@ analyse_SAR.TL <- function(
   }
 
   # Calculate Recuperation Rate ---------------------------------------------
-  Recuperation <- NA
+  Recuperation <- NA_real_
   if("R0" %in% LnLxTnTx[,"Name"]==TRUE){
     Recuperation<-round(LnLxTnTx[LnLxTnTx[,"Name"]=="R0","LxTx"]/
                           LnLxTnTx[LnLxTnTx[,"Name"]=="Natural","LxTx"],digits=4)
@@ -350,12 +350,13 @@ analyse_SAR.TL <- function(
   # Combine and Evaluate Rejection Criteria ---------------------------------
 
   RejectionCriteria <- data.frame(
-    citeria = c(colnames(RecyclingRatio), "recuperation rate"),
+    criterion = c(if (is.na(RecyclingRatio)) "recycling ratio" else colnames(RecyclingRatio),
+                   "recuperation rate"),
     value = c(RecyclingRatio,Recuperation),
     threshold = c(
-      rep(paste("+/-", rejection.criteria$recycling.ratio/100)
+      rep(paste("±", rejection.criteria$recycling.ratio/100)
           ,length(RecyclingRatio)),
-      paste("", rejection.criteria$recuperation.rate/100)
+      rejection.criteria$recuperation.rate/100
     ),
     status = c(
 
@@ -366,9 +367,9 @@ analyse_SAR.TL <- function(
             "FAILED"
           }else{"OK"}})}else{NA},
 
-      if(is.na(Recuperation)==FALSE &
-           Recuperation>rejection.criteria$recuperation.rate){"FAILED"}else{"OK"}
-
+      if(is.na(Recuperation)==FALSE) {
+        if (Recuperation > rejection.criteria$recuperation.rate / 100) "FAILED" else "OK"
+      } else NA_character_
     ))
 
   ##============================================================================##

--- a/tests/testthat/_snaps/analyse_SAR.TL.md
+++ b/tests/testthat/_snaps/analyse_SAR.TL.md
@@ -143,7 +143,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["citeria", "value", "threshold", "status"]
+                  "value": ["criterion", "value", "threshold", "status"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -160,22 +160,22 @@
                 {
                   "type": "character",
                   "attributes": {},
-                  "value": ["recuperation rate", "recuperation rate", "recuperation rate", "recuperation rate"]
+                  "value": ["recycling ratio", "recuperation rate", "recycling ratio", "recuperation rate"]
                 },
                 {
-                  "type": "logical",
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA", "NA", "NA", "NA"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["± 0.1", "0.1", "± 0.1", "0.1"]
+                },
+                {
+                  "type": "character",
                   "attributes": {},
                   "value": [null, null, null, null]
-                },
-                {
-                  "type": "character",
-                  "attributes": {},
-                  "value": ["+/- 0.1", " 0.1", "+/- 0.1", " 0.1"]
-                },
-                {
-                  "type": "character",
-                  "attributes": {},
-                  "value": [null, "OK", null, "OK"]
                 }
               ]
             }
@@ -416,7 +416,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["citeria", "value", "threshold", "status"]
+                  "value": ["criterion", "value", "threshold", "status"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -433,22 +433,22 @@
                 {
                   "type": "character",
                   "attributes": {},
-                  "value": ["recuperation rate", "recuperation rate"]
+                  "value": ["recycling ratio", "recuperation rate"]
                 },
                 {
-                  "type": "logical",
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA", "NA"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["± 0.1", "0.1"]
+                },
+                {
+                  "type": "character",
                   "attributes": {},
                   "value": [null, null]
-                },
-                {
-                  "type": "character",
-                  "attributes": {},
-                  "value": ["+/- 0.1", " 0.1"]
-                },
-                {
-                  "type": "character",
-                  "attributes": {},
-                  "value": [null, "OK"]
                 }
               ]
             }
@@ -564,7 +564,7 @@
                 {
                   "type": "character",
                   "attributes": {},
-                  "value": ["OK"]
+                  "value": ["FAILED"]
                 }
               ]
             },
@@ -661,7 +661,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["citeria", "value", "threshold", "status"]
+                  "value": ["criterion", "value", "threshold", "status"]
                 },
                 "class": {
                   "type": "character",
@@ -688,12 +688,12 @@
                 {
                   "type": "character",
                   "attributes": {},
-                  "value": ["+/- 0.1", " 0.1"]
+                  "value": ["± 0.1", "0.1"]
                 },
                 {
                   "type": "character",
                   "attributes": {},
-                  "value": ["OK", "OK"]
+                  "value": ["OK", "FAILED"]
                 }
               ]
             }


### PR DESCRIPTION
This addresses all correctness issues pointed out in #245. Having the snapshot was invaluable to find the problems, and now it makes it visually easier to see what has actually changed.

Much of this code is overly complicated, but I'm cleaning it up separately. 
Note: I've used `NA_real_` and `NA_character_` as I'm going to use `data.table` to simplify it, and for that it really matter that the column have the correct type, otherwise it's not possible to bind them together.

Fixes #245.