### PR TITLE
Replace the implementation of .throw_error() and .throw_warning()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -48,6 +48,7 @@ file export. To avoid this now all non-ASCII characters are replaced by `_` befo
 ## Internals
 
 * Two new internal functions `.throw_warning()` and `.throw_error()` sometimes flushed the
-terminal with messages if call (internally) in particular circumstances. Now the functions
-make only two attempts to get the name of their called and then return an `unknown()` as function name. 
+terminal with messages if call (internally) in particular circumstances. Now we maintain a
+stack of function names, so that at any time we can report correctly the name of the
+function where an error or a warning is thrown (#254, fixed in #256).
 

--- a/R/CW2pHMi.R
+++ b/R/CW2pHMi.R
@@ -114,9 +114,9 @@
 #'
 #' Bulur, E., 2000. A simple transformation for converting CW-OSL curves to
 #' LM-OSL curves. Radiation Measurements, 32, 141-145.
-#' 
+#'
 #' @keywords manip
-#' 
+#'
 #' @examples
 #'
 #' ##(1) - simple transformation
@@ -197,8 +197,9 @@
 CW2pHMi<- function(
   values,
   delta
-){
-
+) {
+  .set_function_name("CW2pHMi")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##(1) data.frame or RLum.Data.Curve object?
   if(is(values, "data.frame") == FALSE & is(values, "RLum.Data.Curve") == FALSE){

--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -352,6 +352,8 @@ setMethod("get_RLum",
           function(object, record.id = NULL, recordType = NULL, curveType = NULL, RLum.type = NULL,
                    protocol = "UNKNOWN", get.index = NULL, drop = TRUE, recursive = TRUE,
                    info.object = NULL, subset = NULL, env = parent.frame(2)) {
+            .set_function_name("get_RLum")
+            on.exit(.unset_function_name(), add = TRUE)
 
             if (!is.null(substitute(subset))) {
               # To account for different lengths and elements in the @info slot we first
@@ -631,6 +633,8 @@ setMethod("get_RLum",
 setMethod("structure_RLum",
           signature= "RLum.Analysis",
           definition = function(object, fullExtent = FALSE) {
+            .set_function_name("structure_RLum")
+            on.exit(.unset_function_name(), add = TRUE)
 
             ##check if the object containing other elements than allowed
             if(!all(vapply(object@records, FUN = class, character(1)) == "RLum.Data.Curve"))

--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -385,12 +385,11 @@ setMethod("get_RLum",
               ),
               error = function(e) {
                 .throw_error("Invalid subset expression, valid terms are: ",
-                             paste(names(envir), collapse = ", "), nframe = 6)
+                             paste(names(envir), collapse = ", "))
               })
 
               if (!is.logical(sel)) {
-                .throw_error("'subset' must contain a logical expression",
-                             nframe = 2)
+                .throw_error("'subset' must contain a logical expression")
               }
 
               if (all(is.na(sel)))
@@ -418,12 +417,10 @@ setMethod("get_RLum",
                 ##check for entries
                 if(length(object@info) == 0){
                   .throw_warning("This 'RLum.Analysis' object has no info ",
-                                 "objects, NULL returned",
-                                 nframe = 3)
+                                 "objects, NULL returned")
                 }else{
                   .throw_warning("Invalid 'info.object' name, valid names are: ",
-                                 paste(names(object@info), collapse = ", "),
-                                 nframe = 3)
+                                 paste(names(object@info), collapse = ", "))
                 }
                 return(NULL)
               }
@@ -433,7 +430,7 @@ setMethod("get_RLum",
               ##check for records
               if (length(object@records) == 0) {
                 .throw_warning("This 'RLum.Analysis' object has no records, ",
-                               "NULL returned", nframe = 3)
+                               "NULL returned")
                 return(NULL)
               }
 
@@ -444,7 +441,7 @@ setMethod("get_RLum",
               } else if (!is.numeric(record.id) &
                          !is.logical(record.id)) {
                 .throw_error("'record.id' has to be of type 'numeric' or ",
-                             "'logical'", nframe = 3)
+                             "'logical'")
               }
               ##logical needs a slightly different treatment
               ##Why do we need this? Because a lot of standard R functions work with logical
@@ -468,8 +465,7 @@ setMethod("get_RLum",
                     x@recordType, character(1)))
 
               } else if (!inherits(recordType, "character")){
-                .throw_error("'recordType' has to be of type 'character'",
-                             nframe = 3)
+                .throw_error("'recordType' has to be of type 'character'")
               }
 
               ##curveType
@@ -480,8 +476,7 @@ setMethod("get_RLum",
                                                   })))
 
               } else if (!is(curveType, "character")) {
-                .throw_error("'curveType' has to be of type 'character'",
-                             nframe = 3)
+                .throw_error("'curveType' has to be of type 'character'")
               }
 
               ##RLum.type
@@ -489,8 +484,7 @@ setMethod("get_RLum",
                 RLum.type <- c("RLum.Data.Curve", "RLum.Data.Spectrum", "RLum.Data.Image")
 
               } else if (!is(RLum.type, "character")) {
-                .throw_error("'RLum.type' has to be of type 'character'",
-                             nframe = 3)
+                .throw_error("'RLum.type' has to be of type 'character'")
               }
 
               ##get.index
@@ -498,8 +492,7 @@ setMethod("get_RLum",
                 get.index <- FALSE
 
               } else if (!is(get.index, "logical")) {
-                .throw_error("'get.index' has to be of type 'logical'",
-                             nframe = 3)
+                .throw_error("'get.index' has to be of type 'logical'")
               }
 
               ##get originator
@@ -557,8 +550,7 @@ setMethod("get_RLum",
 
                 ##check if the produced object is empty and show warning message
                 if (length(temp) == 0)
-                  .throw_warning("This request produced an empty list of records",
-                                 nframe = 3)
+                  .throw_warning("This request produced an empty list of records")
 
                 ##remove list for get.index
                 if (get.index) {

--- a/R/Risoe.BINfileData2RLum.Analysis.R
+++ b/R/Risoe.BINfileData2RLum.Analysis.R
@@ -87,8 +87,9 @@ Risoe.BINfileData2RLum.Analysis<- function(
   protocol = "unknown",
   keep.empty = TRUE,
   txtProgressBar = FALSE
-){
-
+) {
+  .set_function_name("Risoe.BINfileData2RLum.Analysis")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity Check ---------------------------------------------------------
 

--- a/R/analyse_Al2O3C_ITC.R
+++ b/R/analyse_Al2O3C_ITC.R
@@ -114,8 +114,9 @@ analyse_Al2O3C_ITC <- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-){
-
+) {
+  .set_function_name("analyse_Al2O3C_ITC")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # SELF CALL -----------------------------------------------------------------------------------
   if(is.list(object)){

--- a/R/analyse_Al2O3C_Measurement.R
+++ b/R/analyse_Al2O3C_Measurement.R
@@ -147,7 +147,9 @@ analyse_Al2O3C_Measurement <- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-){
+) {
+  .set_function_name("analyse_Al2O3C_Measurement")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Self call -----------------------------------------------------------------------------------
   if(is(object, "list")){

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -196,7 +196,9 @@ analyse_FadingMeasurement <- function(
   plot = TRUE,
   plot.single = FALSE,
   ...
-){
+) {
+  .set_function_name("analyse_FadingMeasurement")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity Tests -----------------------------------------------------------------------------
   if (is(object, "list")) {

--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -424,7 +424,9 @@ analyse_IRSAR.RF<- function(
   plot = TRUE,
   plot_reduced = FALSE,
   ...
-){
+) {
+  .set_function_name("analyse_IRSAR.RF")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##TODO
   ## - if a file path is given, the function should try to find out whether an XSYG-file or

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -270,6 +270,8 @@ analyse_SAR.CWOSL<- function(
   onlyLxTxTable = FALSE,
   ...
 ) {
+  .set_function_name("analyse_SAR.CWOSL")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # SELF CALL -----------------------------------------------------------------------------------
 if(is.list(object)){

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -119,7 +119,9 @@ analyse_SAR.TL <- function(
   dose.points,
   log = "",
   ...
-){
+) {
+  .set_function_name("analyse_SAR.TL")
+  on.exit(.unset_function_name(), add = TRUE)
 
   if (missing("object")) {
     stop("[analyse_SAR.TL()] No value set for 'object'!", call. = FALSE)

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -437,7 +437,9 @@ analyse_baSAR <- function(
   plot.single = FALSE,
   verbose = TRUE,
   ...
-){
+) {
+  .set_function_name("analyse_baSAR")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##////////////////////////////////////////////////////////////////////////////////////////////////
   ##FUNCTION TO BE CALLED to RUN the Bayesian Model

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -643,14 +643,12 @@ analyse_baSAR <- function(
         .throw_error("No pre-defined model for the requested distribution. ",
                      "Please select one of '",
                      paste(rev(names(baSAR_models))[-1], collapse = "', '"),
-                     "', or define an own model using argument 'baSAR_model'",
-                     nframe = 7)
+                     "', or define an own model using argument 'baSAR_model'")
       }
 
       if (distribution == "user_defined" && is.null(baSAR_model)) {
         .throw_error("You specified a 'user_defined' distribution, ",
-                     "but did not provide a model via 'baSAR_model'",
-                     nframe = 7)
+                     "but did not provide a model via 'baSAR_model'")
       }
 
       ### Bayesian inputs

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -178,7 +178,9 @@ analyse_pIRIRSequence <- function(
   plot = TRUE,
   plot.single = FALSE,
   ...
-){
+) {
+  .set_function_name("analyse_pIRIRSequence")
+  on.exit(.unset_function_name(), add = TRUE)
 
   if (missing("object"))
     stop("[analyse_pIRIRSequence()] No value set for 'object'!")

--- a/R/analyse_portableOSL.R
+++ b/R/analyse_portableOSL.R
@@ -114,8 +114,10 @@ analyse_portableOSL <- function(
   mode = "profile",
   coord = NULL,
   plot = TRUE,
-  ...)
-  {
+  ...
+) {
+  .set_function_name("analyse_portableOSL")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## TODO
   ## - add tests for background image option

--- a/R/calc_AliquotSize.R
+++ b/R/calc_AliquotSize.R
@@ -147,7 +147,10 @@ calc_AliquotSize <- function(
   grains.counted,
   plot=TRUE,
   ...
-){
+) {
+  .set_function_name("calc_AliquotSize")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ##==========================================================================##
   ## CONSISTENCY CHECK OF INPUT DATA
   ##==========================================================================##

--- a/R/calc_AverageDose.R
+++ b/R/calc_AverageDose.R
@@ -133,7 +133,9 @@ calc_AverageDose <- function(
   plot = TRUE,
   verbose = TRUE,
   ...
-){
+) {
+  .set_function_name("calc_AverageDose")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Define internal functions ------------------------------------------------------------------
 

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -242,8 +242,7 @@ calc_FastRatio <- function(object,
     } else {
       if (any(Ch_L3 > nrow(A))) {
         .throw_error("Value in Ch_L3 (", paste(Ch_L3, collapse = ", "),
-                     ") exceeds number of available channels (", nrow(A), ")",
-                     nframe = 3) # we are inside an lapply closure
+                     ") exceeds number of available channels (", nrow(A), ")")
       }
       t_L3_start <- A[Ch_L3[1], 1]
       t_L3_end <- A[Ch_L3[2], 1]

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -123,6 +123,8 @@ calc_FastRatio <- function(object,
                            fitCW.curve = FALSE,
                            plot = TRUE,
                            ...) {
+  .set_function_name("calc_FastRatio")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## Input verification --------------------------------------------------------
   .validate_positive_scalar(Ch_L1, int = TRUE)

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -285,8 +285,7 @@
 #' }
 #' @md
 #' @export
-calc_Huntley2006 <-
-  function(
+calc_Huntley2006 <- function(
     data,
     LnTn = NULL,
     rhop,
@@ -298,7 +297,10 @@ calc_Huntley2006 <-
     summary = TRUE,
     plot = TRUE,
     ...
-){
+) {
+  .set_function_name("calc_Huntley2006")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ## Validate Input ------------------------------------------------------------
 
   ## Check fit method

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -337,7 +337,9 @@ calc_MinDose <- function(
   plot = TRUE,
   multicore = FALSE,
   ...
-){
+) {
+  .set_function_name("calc_MinDose")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## ============================================================================##
   ## CONSISTENCY CHECK OF INPUT DATA

--- a/R/calc_OSLLxTxDecomposed.R
+++ b/R/calc_OSLLxTxDecomposed.R
@@ -64,7 +64,9 @@ calc_OSLLxTxDecomposed <- function(
   OSL.component = 1L,
   sig0 = 0,
   digits = NULL
-){
+) {
+  .set_function_name("calc_OSLLxTxDecomposed")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # ToDo:
   # - Integrity checks for the component table

--- a/R/calc_ThermalLifetime.R
+++ b/R/calc_ThermalLifetime.R
@@ -150,8 +150,9 @@ calc_ThermalLifetime <- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-
-){
+) {
+  .set_function_name("calc_ThermalLifetime")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Integrity -----------------------------------------------------------------------------------
 

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -55,6 +55,8 @@ calc_WodaFuchs2008 <- function(
   plot = TRUE,
   ...
 ) {
+  .set_function_name("calc_WodaFuchs2008")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##TODO
   # - complete manual

--- a/R/calc_gSGC.R
+++ b/R/calc_gSGC.R
@@ -82,7 +82,9 @@ calc_gSGC<- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-){
+) {
+  .set_function_name("calc_gSGC")
+  on.exit(.unset_function_name(), add = TRUE)
 
 ##============================================================================##
 ##CHECK INPUT DATA

--- a/R/extract_IrradiationTimes.R
+++ b/R/extract_IrradiationTimes.R
@@ -139,7 +139,9 @@ extract_IrradiationTimes <- function(
   recordType = c("irradiation (NA)", "IRSL (UVVIS)", "OSL (UVVIS)", "TL (UVVIS)"),
   compatibility.mode = TRUE,
   txtProgressBar = TRUE
-){
+) {
+  .set_function_name("extract_IrradiationTimes")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # SELF CALL -----------------------------------------------------------------------------------
   if(is.list(object)){

--- a/R/fit_CWCurve.R
+++ b/R/fit_CWCurve.R
@@ -208,7 +208,10 @@ fit_CWCurve<- function(
   output.terminalAdvanced = TRUE,
   plot = TRUE,
   ...
-){
+) {
+  .set_function_name("fit_CWCurve")
+  on.exit(.unset_function_name(), add = TRUE)
+
   # INTEGRITY CHECKS --------------------------------------------------------
 
   ##INPUT OBJECTS

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -207,7 +207,7 @@ fit_EmissionSpectra <- function(
       }else{
         if(max(frame) > ncol(o@data)|| min(frame) < 1){
           .throw_error("'frame' invalid. Allowed range min: 1 and max: ",
-                       ncol(o@data), nframe = 3) # we are inside an lapply closure
+                       ncol(o@data))
         }
       }
 
@@ -239,7 +239,7 @@ fit_EmissionSpectra <- function(
     }else{
       if(max(frame) > (ncol(object)-1) || min(frame) < 1){
         .throw_error("'frame' invalid. Allowed range min: 1 and max: ",
-                     ncol(object) - 1, nframe = 3) # we are inside an lapply closure
+                     ncol(object) - 1)
       }
     }
 
@@ -372,7 +372,7 @@ fit_EmissionSpectra <- function(
   ## check graining parameter
   if (method_control$graining >= nrow(m))
     .throw_error("method_control$graining cannot exceed the ",
-                 "available channels (", nrow(m) ,")", nframe = 5)
+                 "available channels (", nrow(m) ,")")
 
   ##initialise objects
   success_counter <- 0

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -177,8 +177,9 @@ fit_EmissionSpectra <- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-){
-
+) {
+  .set_function_name("fit_EmissionSpectra")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##TODO: Find a way to get a significant number of components
   ## This function works only on a list of matrices, so what ever we do here, we have to

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -260,7 +260,9 @@ fit_LMCurve<- function(
   plot = TRUE,
   plot.BG = FALSE,
   ...
-){
+) {
+  .set_function_name("fit_LMCurve")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # (0) Integrity checks -------------------------------------------------------
 

--- a/R/fit_OSLLifeTimes.R
+++ b/R/fit_OSLLifeTimes.R
@@ -178,8 +178,9 @@ fit_OSLLifeTimes <- function(
   plot_simple = FALSE,
   verbose = TRUE,
   ...
-  ){
-
+) {
+  .set_function_name("fit_OSLLifeTimes")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Self-call -----------------------------------------------------------------------------------
 if(inherits(object, "list") || inherits(object, "RLum.Analysis")){

--- a/R/get_Layout.R
+++ b/R/get_Layout.R
@@ -50,6 +50,8 @@
 get_Layout <- function(
   layout
 ) {
+  .set_function_name("get_Layout")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## pre-defined layout selections
   if(is.character(layout) == TRUE & length(layout) == 1) {
@@ -57,7 +59,7 @@ get_Layout <- function(
     if(layout == "empty") {
 
       layout = list(
-        
+
         ## empty Abanico plot -------------------------------------------------
         abanico = list(
           font.type = list(

--- a/R/internal_as.latex.table.R
+++ b/R/internal_as.latex.table.R
@@ -172,6 +172,9 @@
                                        split = NULL,
                                        tabular_only = FALSE,
                                        ...) {
+  .set_function_name("as.latex.table.data.frame")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ## Integrity checks ----
   if (!is.data.frame(x))
     .throw_error("'x' must be a data frame")

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -831,6 +831,49 @@ fancy_scientific <- function(l) {
 
 }
 
+#' @title Set/unset the function name for error/warning reporting
+#'
+#' @description
+#' These utilities allow for more precise error reporting from `.throw_error()`
+#' and `.throw_warning()`. They must be called just once per function
+#' (`.set_function_name() at the start and `.unset_function_name() at the
+#' end) if the function calls either `.throw_error()` or `.throw_warning()`.
+#'
+#' @param name [character] (**required**): the name of the function
+#'
+#' @details
+#' The `.LuminescenceEnv` package environment stores a list (`fn_stack`)
+#' that is used to store the stack of function calls currently executing.
+#' The stack is at the beginning an empty list, but whenever a function is
+#' called, that function add its own name to it via `.set_function_name()`.
+#' Conversely, when the function returns, it clears the top of the stack
+#' via `.unset_function_name()`.
+#'
+#' In order to maintain the stack in a consistent state, it is important that
+#' each call to `.set_function_name()` is accompanied by a corresponding call
+#' to `.unset_function_name()`. As the stack must be updated also when a
+#' function (or any of its callees) encounters an error, the calls to
+#' `.unset_function_name()` must be delegated to `on.exit(..., add = TRUE)`.
+#'
+#' Therefore, it is suggested to put these two lines at the very beginning
+#' of each function (if one of the throwing functions is used by it):
+#'
+#'   .set_function_name("name_of_the_function")
+#'   on.exit(.unset_function_name(), add = TRUE)
+#'
+#' @md
+#' @noRd
+.set_function_name <- function(name) {
+  .LuminescenceEnv$fn_stack[length(.LuminescenceEnv$fn_stack) + 1] <- name
+}
+
+#' @rdname .set_function_name
+#' @md
+#' @noRd
+.unset_function_name <- function() {
+  .LuminescenceEnv$fn_stack[length(.LuminescenceEnv$fn_stack)] <- NULL
+}
+
 #'@title Throws a Custom Tailored Error Message
 #'
 #'@param ... the error message to throw

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -877,61 +877,23 @@ fancy_scientific <- function(l) {
 #'@title Throws a Custom Tailored Error Message
 #'
 #'@param ... the error message to throw
-#'@param nframe [numeric] (*with default*): the frame where the function
-#'       name to return in the error message should be searched: the
-#'       default value of 1 is generally fine, unless [throw_error] is
-#'       called from an internal function (whose name is not of interest
-#'       to the user), in which case a value of 2 should be used.
 #'
 #'@md
 #'@noRd
-.throw_error <- function(..., nframe = 1) {
-  ##1st try to get the name of the calling
-  f_calling <- deparse(sys.call(-nframe)[1])
-
-  ##2nd try if the length is > 1 than something went wrong
-  ##so we go one deeper
-  if(length(f_calling) > 1)
-    f_calling <- deparse(sys.call(- nframe -1)[2])
-
-  ##3rd here we stop otherwise it takes to long to go
-  ##down in the stack
-  if(length(f_calling) > 1)
-    f_calling <- "unknown()"
-
-  ## stop
-  stop(paste0("[", f_calling, "] ", ...), call. = FALSE)
-
+.throw_error <- function(...) {
+  top.idx <- length(.LuminescenceEnv$fn_stack)
+  stop("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] ", ..., call. = FALSE)
 }
 
 #'@title Throws a Custom Tailored Warning Message
 #'
 #'@param ... the warning message to throw
-#'@param nframe [numeric] (*with default*): the frame where the function
-#'       name to return in the warning message should be searched: the
-#'       default value of 1 is generally fine, unless [throw_warning] is
-#'       called from an internal function (whose name is not of interest
-#'       to the user), in which case a value of 2 should be used
 #'
 #'@md
 #'@noRd
-.throw_warning <- function(..., nframe = 1) {
-  ##1st try to get the name of the calling
-  f_calling <- deparse(sys.call(-nframe)[1])
-
-  ##2nd try if the length is > 1 than something went wrong
-  ##so we go one deeper
-  if(length(f_calling) > 1)
-    f_calling <- deparse(sys.call(- nframe -1)[2])
-
-  ##3rd here we stop otherwise it takes to long to go
-  ##down in the stack
-  if(length(f_calling) > 1)
-    f_calling <- "unknown()"
-
-  ## warning
-  warning(paste0("[", f_calling, "] ", ...), call. = FALSE)
-
+.throw_warning <- function(...) {
+  top.idx <- length(.LuminescenceEnv$fn_stack)
+  warning("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] ", ..., call. = FALSE)
 }
 
 #' @title Silence Output and Warnings during Tests
@@ -981,6 +943,6 @@ SW <- function(expr) {
     if (is.null(name))
       name <- all.vars(match.call())[1]
     .throw_error("'", name, "' must be a positive ", if (int) "integer ",
-                 "scalar", nframe = 2)
+                 "scalar")
   }
 }

--- a/R/merge_RLum.Data.Curve.R
+++ b/R/merge_RLum.Data.Curve.R
@@ -121,7 +121,9 @@ merge_RLum.Data.Curve<- function(
   object,
   merge.method = "mean",
   method.info
-){
+) {
+  .set_function_name("merge_RLum.Data.Curve")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Integrity checks ----------------------------------------------------------------------------
 

--- a/R/merge_RLum.R
+++ b/R/merge_RLum.R
@@ -57,7 +57,9 @@
 merge_RLum<- function(
   objects,
   ...
-){
+) {
+  .set_function_name("merge_RLum")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity check ----------------------------------------------------------
     if(!inherits(objects, "list"))

--- a/R/merge_RLum.Results.R
+++ b/R/merge_RLum.Results.R
@@ -22,7 +22,10 @@
 #' @md
 #' @export
 merge_RLum.Results <- function(
-    objects){
+  objects
+) {
+  .set_function_name("merge_RLum.Results")
+  on.exit(.unset_function_name(), add = TRUE)
 
             ##-------------------------------------------------------------
             ##Some integrity checks

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -467,6 +467,9 @@ plot_AbanicoPlot <- function(
   interactive = FALSE,
   ...
 ) {
+  .set_function_name("plot_AbanicoPlot")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ## check data and parameter consistency--------------------------------------
 
   ## Homogenise input data format

--- a/R/plot_DRCSummary.R
+++ b/R/plot_DRCSummary.R
@@ -82,8 +82,9 @@ plot_DRCSummary <- function(
   show_natural = FALSE,
   n = 51L,
   ...
-){
-
+) {
+  .set_function_name("plot_DRCSummary")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Self-call -----------------------------------------------------------------------------------
 if(inherits(object, "list")){

--- a/R/plot_DRTResults.R
+++ b/R/plot_DRTResults.R
@@ -192,7 +192,9 @@ plot_DRTResults <- function(
   par.local = TRUE,
   na.rm  = FALSE,
   ...
-){
+) {
+  .set_function_name("plot_DRTResults")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## Validity checks ----------------------------------------------------------
 

--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -161,7 +161,8 @@ plot_DetPlot <- function(
   plot = TRUE,
   ...
 ) {
-
+  .set_function_name("plot_DetPlot")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # SELF CALL ---------------------------------------------------------------
   if(inherits(object, "list")) {

--- a/R/plot_FilterCombinations.R
+++ b/R/plot_FilterCombinations.R
@@ -156,7 +156,11 @@ plot_FilterCombinations <- function(
   show_net_transmission = TRUE,
   interactive = FALSE,
   plot = TRUE,
-  ...) {
+  ...
+) {
+  .set_function_name("plot_FilterCombinations")
+  on.exit(.unset_function_name(), add = TRUE)
+
   # Integrity tests -----------------------------------------------------------------------------
 
   #check filters

--- a/R/plot_GrowthCurve.R
+++ b/R/plot_GrowthCurve.R
@@ -319,6 +319,8 @@ plot_GrowthCurve <- function(
   verbose = TRUE,
   ...
 ) {
+  .set_function_name("plot_GrowthCurve")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##1. Check input variable
   switch(

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -128,6 +128,8 @@ plot_Histogram <- function(
   interactive = FALSE,
   ...
 ) {
+  .set_function_name("plot_Histogram")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity tests ---------------------------------------------------------
   ## check/adjust input data structure

--- a/R/plot_KDE.R
+++ b/R/plot_KDE.R
@@ -175,6 +175,8 @@ plot_KDE <- function(
   output = TRUE,
   ...
 ) {
+  .set_function_name("plot_KDE")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## check data and parameter consistency -------------------------------------
 

--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -123,6 +123,8 @@
 #' @export
 plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k = 3,
                      legend = TRUE, legend.pos = "topright", ...) {
+  .set_function_name("plot_NRt")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## DATA INPUT EVALUATION -----
   if (inherits(data, "list")) {

--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -577,7 +577,7 @@ plot_RLum.Analysis <- function(
           if(any(is.infinite(temp.data[[2]])) || anyNA(temp.data[[2]])){
             temp.data[[2]][is.infinite(temp.data[[2]]) | is.na(temp.data[[2]])] <- 0
             .throw_warning("Normalisation led to Inf or NaN values, ",
-                           "values replaced by 0", nframe = 3)
+                           "values replaced by 0")
           }
         }
 

--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -128,7 +128,9 @@ plot_RLum.Analysis <- function(
   curve.transformation,
   plot.single = FALSE,
   ...
-){
+) {
+  .set_function_name("plot_RLum.Analysis")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity check ----------------------------------------------------------------------------
 

--- a/R/plot_RLum.Data.Spectrum.R
+++ b/R/plot_RLum.Data.Spectrum.R
@@ -251,7 +251,9 @@ plot_RLum.Data.Spectrum <- function(
   legend.text,
   plot = TRUE,
   ...
-){
+) {
+  .set_function_name("plot_RLum.Data.Spectrum")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity check -----------------------------------------------------------
 

--- a/R/plot_RLum.Results.R
+++ b/R/plot_RLum.Results.R
@@ -57,7 +57,9 @@ plot_RLum.Results<- function(
   object,
   single = TRUE,
   ...
-){
+) {
+  .set_function_name("plot_RLum.Results")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##============================================================================##
   ## CONSISTENCY CHECK OF INPUT DATA

--- a/R/plot_RadialPlot.R
+++ b/R/plot_RadialPlot.R
@@ -291,6 +291,9 @@ plot_RadialPlot <- function(
   output = FALSE,
   ...
 ) {
+  .set_function_name("plot_RadialPlot")
+  on.exit(.unset_function_name(), add = TRUE)
+
   if (is(data, "list") && length(data) == 0) {
     .throw_error("'data' is an empty list")
   }

--- a/R/plot_Risoe.BINfileData.R
+++ b/R/plot_Risoe.BINfileData.R
@@ -115,7 +115,9 @@ plot_Risoe.BINfileData<- function(
   temp.lab,
   cex.global = 1,
   ...
-){
+) {
+  .set_function_name("plot_Risoe.BINfileData")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##check if the object is of type Risoe.BINfileData
   if(!inherits(BINfileData, "Risoe.BINfileData"))

--- a/R/plot_ViolinPlot.R
+++ b/R/plot_ViolinPlot.R
@@ -90,7 +90,8 @@ plot_ViolinPlot <- function(
   na.rm = TRUE,
   ...
 ) {
-
+  .set_function_name("plot_ViolinPlot")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity tests and conversion --------------------------------------------------------------
 

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -137,7 +137,9 @@ read_BIN2R <- function(
   pattern = NULL,
   verbose = TRUE,
   ...
-){
+) {
+  .set_function_name("read_BIN2R")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Self Call -----------------------------------------------------------------------------------
   # Option (a): Input is a list, every element in the list will be treated as file connection

--- a/R/read_SPE2R.R
+++ b/R/read_SPE2R.R
@@ -110,7 +110,9 @@ read_SPE2R <- function(
   txtProgressBar = TRUE,
   verbose = TRUE,
   ...
-){
+) {
+  .set_function_name("read_SPE2R")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Consistency check -------------------------------------------------------
 

--- a/R/read_XSYG2R.R
+++ b/R/read_XSYG2R.R
@@ -182,7 +182,9 @@ read_XSYG2R <- function(
   pattern = ".xsyg",
   verbose = TRUE,
   txtProgressBar = TRUE
-){
+) {
+  .set_function_name("read_XSYG2R")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##TODO: this function should be reshaped:
   ##  - metadata from the sequence should go into the info slot of the RLum.Analysis object

--- a/R/report_RLum.R
+++ b/R/report_RLum.R
@@ -189,7 +189,10 @@ report_RLum <- function(
   css.file = NULL,
   quiet = TRUE,
   clean = TRUE,
-  ...) {
+  ...
+) {
+  .set_function_name("report_RLum")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## ------------------------------------------------------------------------ ##
   ## PRE-CHECKS ----

--- a/R/template_DRAC.R
+++ b/R/template_DRAC.R
@@ -91,7 +91,9 @@ template_DRAC <- function(
   nrow = 1L,
   preset = NULL,
   notification = TRUE
-){
+) {
+  .set_function_name("template_DRAC")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## TODO:
   # 1 - allow mineral specific presets; new argument 'mineral'

--- a/R/use_DRAC.R
+++ b/R/use_DRAC.R
@@ -115,7 +115,10 @@ use_DRAC <- function(
   print_references = TRUE,
   citation_style = "text",
   ...
-){
+) {
+  .set_function_name("use_DRAC")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ## TODO:
   ## (1) Keep the data set as unmodified as possible. Check structure and order of parameters
   ## for meaningful combination.

--- a/R/write_R2BIN.R
+++ b/R/write_R2BIN.R
@@ -92,7 +92,9 @@ write_R2BIN <- function(
   version,
   compatibility.mode = FALSE,
   txtProgressBar = TRUE
-){
+) {
+  .set_function_name("write_R2BIN")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Config ------------------------------------------------------------------
   ##set supported BIN format version

--- a/R/write_R2BIN.R
+++ b/R/write_R2BIN.R
@@ -382,7 +382,7 @@ write_R2BIN <- function(
 
   # SET FILE AND VALUES -----------------------------------------------------
   con <- file(file, "wb")
-  on.exit(close(con))
+  on.exit(close(con), add = TRUE)
 
   ##get records
   n.records <- length(object@METADATA[,"ID"])

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,6 +19,13 @@ assign("col",
        pos = ".LuminescenceEnv",
        envir = .LuminescenceEnv)
 
+## `fn_stack` is used to keep a stack of function names, managed by
+## `.[set|unset]_function_name()`, that reflects the call stack for correct
+## error/warning reporting from `.throw_error()` and `.throw_warning()`
+assign("fn_stack", list(),
+       pos = ".LuminescenceEnv",
+       envir = .LuminescenceEnv)
+
 
 ##==============================================================================
 ##on Attach

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -106,5 +106,6 @@ test_that("regression tests", {
                    signal.integral.min = 210, signal.integral.max = 220,
                    sequence.structure = c("SIGNAL", "BACKGROUND"))
   ),
-  "Error: All points have the same dose, NULL returned")
+  "[plot_GrowthCurve()] Error: All points have the same dose, NULL returned",
+  fixed = TRUE)
 })

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -1,6 +1,12 @@
 test_that("Test internals", {
   testthat::skip_on_cran()
 
+  ## since below we are testing internal functions that use `.throw_error()`
+  ## and `.throw_warning()`, we need to treat this block as a function
+  ## definition and set the function name
+  .set_function_name("test")
+  on.exit(.unset_function_name(), add = TRUE)
+
   # .expand_parameters() ------------------------------------------------------
   ##create empty function ... reminder
   ##this is an internal function, the first object is always discarded, it
@@ -138,7 +144,11 @@ test_that("Test internals", {
   expect_equal(sum(unlist(t)), expected = 110)
 
   ## .throw_error() ---------------------------------------------------------
-  fun.int <- function() .throw_error("Error message")
+  fun.int <- function() {
+    .set_function_name("fun.int")
+    on.exit(.unset_function_name(), add = TRUE)
+    .throw_error("Error message")
+  }
   fun.ext <- function() fun.int()
   fun.docall <- function() do.call(fun.ext, args = list())
   fun.docall_do <- function() fun.docall()
@@ -157,7 +167,11 @@ test_that("Test internals", {
                "[fun.ext()] Error message", fixed = TRUE)
 
   ## .throw_warning() -------------------------------------------------------
-  fun.int <- function() .throw_warning("Warning message")
+  fun.int <- function() {
+    .set_function_name("fun.int")
+    on.exit(.unset_function_name(), add = TRUE)
+    .throw_warning("Warning message")
+  }
   fun.ext <- function() fun.int()
   fun.docall <- function() do.call(fun.ext, args = list())
   fun.docall_do <- function() fun.docall()

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -161,11 +161,6 @@ test_that("Test internals", {
   expect_error(fun.docall_do(),
                "[fun.int()] Error message", fixed = TRUE)
 
-  fun.int <- function() .throw_error("Error message", nframe = 2)
-  fun.ext <- function() fun.int()
-  expect_error(fun.ext(),
-               "[fun.ext()] Error message", fixed = TRUE)
-
   ## .throw_warning() -------------------------------------------------------
   fun.int <- function() {
     .set_function_name("fun.int")
@@ -182,12 +177,7 @@ test_that("Test internals", {
   expect_warning(fun.docall(),
                  "[fun.int()] Warning message", fixed = TRUE)
   expect_warning(fun.docall_do(),
-               "[fun.int()] Warning message", fixed = TRUE)
-
-  fun.int <- function() .throw_warning("Warning message", nframe = 2)
-  fun.ext <- function() fun.int()
-  expect_warning(fun.ext(),
-                 "[fun.ext()] Warning message", fixed = TRUE)
+                 "[fun.int()] Warning message", fixed = TRUE)
 
   ## SW() ------------------------------------------------------------------
   expect_silent(SW(cat("silenced message")))

--- a/tests/testthat/test_subset_RLum.R
+++ b/tests/testthat/test_subset_RLum.R
@@ -13,7 +13,8 @@ test_that("subset RLum.Analysis", {
 
   ### errors
   expect_error(subset(temp, LTYPE == "RF"),
-               "Invalid subset expression, valid terms are") # FIXME(mcol): long function name produced by .throw_error()
+               "[get_RLum()] Invalid subset expression, valid terms are",
+               fixed = TRUE)
   SW({
   expect_message(expect_null(subset(temp, recordType == "xx")),
                  "'subset' expression produced an empty selection, NULL returned")


### PR DESCRIPTION
This adopts the last approach I mentioned in #254. It has some advantages on what we have right now:
- the function name reported is virtually always correct, as we don't rely on using `sys.call()` which as we've seen can be fragile
- the calls to the throwing functions don't need to worry anymore about setting `nframe` to pick the correct stack frame into which look for the function name
- the implementation of `.throw_error()` and `.throw_warning()` is now straightforward

There is one minor disadvantage:
- at the start of each function that uses the throwing functions, two extra lines of code need to be added in order to manage the internal stack of function names: I find this bearable given what we are gaining.

The example with `subset` discussed in #254 now returns:
```console
[get_RLum()] Invalid subset expression, valid terms are: curveType, recordType
```
which is fine, as `subset()` is just an S3 method that dispatches to `get_RLum()` for the actual subsetting.

I've broken this up in several commits for easier review. Only on the last commit we actually switch to the new approach, which means that at all points tests still pass (at least locally).

Fixes #254.