### PR TITLE
Improve validation of choices for character arguments

### DIFF
--- a/R/Second2Gray.R
+++ b/R/Second2Gray.R
@@ -99,7 +99,9 @@ Second2Gray <- function(
   data,
   dose.rate,
   error.propagation = "omit"
-){
+) {
+  .set_function_name("Second2Gray")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity tests -----------------------------------------------------------------------------
 
@@ -126,9 +128,10 @@ Second2Gray <- function(
       stop("[Second2Gray()] the data frames in 'data' and 'dose.rate' need to be of similar length!")
 
     }
-
   }
 
+  error.propagation <- .match_args(error.propagation,
+                                   c("omit", "gaussian", "absolute"))
 
   ##(4) check for right orginator
   if(is(dose.rate, "RLum.Results")){
@@ -152,9 +155,7 @@ Second2Gray <- function(
         dose.rate <- get_RLum(dose.rate, data.object = "dose.rate")
 
       }
-
     }
-
   }
 
 
@@ -204,11 +205,6 @@ Second2Gray <- function(
       De.error.gray <- round(abs(dose.rate[1] * De.error.seconds) + abs(De.seconds * dose.rate[2]), digits=3)
 
     }
-
-  }else{
-
-    stop("[Second2Gray()] unsupported error propagation method!" )
-
   }
 
   # Return --------------------------------------------------------------------------------------

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -247,6 +247,11 @@ analyse_FadingMeasurement <- function(
   }
 
 
+  if (!is(t_star, "function")) {
+    t_star <- .match_args(t_star, c("half", "half_complex", "end"),
+                          extra = "a function")
+  }
+
   # Prepare data --------------------------------------------------------------------------------
   if(!is.null(object)){
     originators <- unique(unlist(lapply(object, slot, name = "originator")))
@@ -356,9 +361,6 @@ analyse_FadingMeasurement <- function(
       }else if (t_star == "end"){
         ##set t_start as t_1 (so after the end of irradiation)
         t_star <- t1
-
-      }else{
-        .throw_error("Invalid input for t_star.")
       }
     }
 

--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -536,6 +536,9 @@ analyse_IRSAR.RF<- function(
     .throw_error("'sequence_structure' must be of type 'character'")
   }
 
+  ## method
+  method <- .match_args(method, c("FIT", "SLIDE", "VSLIDE"))
+
   ## n.MC
   .validate_positive_scalar(n.MC, int = TRUE, null.ok = TRUE)
 
@@ -1340,9 +1343,6 @@ analyse_IRSAR.RF<- function(
       De.lower <- De - quantile(De.diff, 0.975, na.rm = TRUE)
       De.upper <- De - quantile(De.diff, 0.025, na.rm = TRUE)
     }
-
-  }else{
-    .throw_warning("Analysis skipped: Unknown method or threshold of test parameter exceeded.")
   }
 
   ##===============================================================================================#

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -175,6 +175,7 @@ analyse_SAR.TL <- function(
     .throw_error("No value set for 'signal.integral.max'")
   }
 
+  integral_input <- .match_args(integral_input, c("channel", "temperature"))
 
   # Protocol Integrity Checks --------------------------------------------------
 

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -796,10 +796,7 @@ analyse_baSAR <- function(
   # nocov end
 
   ## fit.method
-  if (!fit.method %in% c("EXP", "EXP+LIN", "LIN")) {
-    .throw_error("'fit.method' not recognised, supported methods are: ",
-                 "'EXP', 'EXP+LIN' and 'LIN'")
-  }
+  fit.method <- .match_args(fit.method, c("EXP", "EXP+LIN", "LIN"))
 
   .validate_positive_scalar(n.MCMC, int = TRUE)
 

--- a/R/apply_CosmicRayRemoval.R
+++ b/R/apply_CosmicRayRemoval.R
@@ -104,7 +104,9 @@ apply_CosmicRayRemoval <- function(
   verbose = FALSE,
   plot = FALSE,
   ...
-){
+) {
+  .set_function_name("apply_CosmicRayRemoval")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Self-call ----------------------------------------------------------------------------------
   ##Black magic: The function recalls itself until all RLum.Data.Spectrum objects have been treated
@@ -182,6 +184,8 @@ apply_CosmicRayRemoval <- function(
     stop(paste0("[apply_CosmicRayRemoval()] An object of class '",class(object)[1], "' is not supported as input; please read the manual!"), call. = FALSE)
 
   }
+
+  .match_args(method, c("smooth", "smooth.spline", "Pych"))
 
   ##deal with addition arguments
   extraArgs <- list(...)
@@ -355,12 +359,6 @@ apply_CosmicRayRemoval <- function(
       return(object.data.temp[,x])
 
     })#end loop
-
-
-  }else{
-
-    stop("[apply_CosmicRayRemoval()] Unknown method for cosmic ray removal.")
-
   }
 
   # Correct row and column names --------------------------------------------

--- a/R/calc_CobbleDoseRate.R
+++ b/R/calc_CobbleDoseRate.R
@@ -81,12 +81,25 @@
 #'@md
 #'@export
 calc_CobbleDoseRate <- function(input,conversion = "Guerinetal2011"){
+  .set_function_name("calc_CobbleDoseRate")
+  on.exit(.unset_function_name(), add = TRUE)
 
   # Integrity tests ---------------------------------------------------------
   if ((max(input[,1])>input$CobbleDiameter[1]*10) ||
       ((max(input[,1]) + input[length(input[,1]),3]) > input$CobbleDiameter[1]*10))
     stop("[calc_CobblDoseRate()] Slices outside of cobble. Please check your distances and make sure they are in mm and diameter is in cm!", call. = FALSE)
 
+
+  ## conversion factors: we do not use BaseDataSet.ConversionFactors directly
+  ## as it is in alphabetical level, but we want to have 'Guerinetal2011'
+  ## in first position, as that is our default value
+  load(system.file("data", "BaseDataSet.ConversionFactors.rda",
+                   package = "Luminescence"))
+  valid_conversion_factors <- c("Guerinetal2011", "Cresswelletal2018",
+                                "AdamiecAitken1998", "Liritzisetal2013")
+  stopifnot(all(names(BaseDataSet.ConversionFactors) %in%
+                valid_conversion_factors))
+  conversion <- .match_args(conversion, valid_conversion_factors)
 
   # Calculate Dose Rate -----------------------------------------------------
   SedDoseData <- matrix(data = NA, nrow = 1, ncol = 10)

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -194,7 +194,9 @@ calc_FiniteMixture <- function(
   plot.proportions = TRUE,
   plot=TRUE,
   ...
-){
+) {
+  .set_function_name("calc_FiniteMixture")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## CONSISTENCY CHECK OF INPUT DATA --------
   ##============================================================================##
@@ -217,10 +219,8 @@ calc_FiniteMixture <- function(
     stop("[calc_FiniteMixture()] At least two components need to be fitted",
          call. = FALSE)
   }
-  if (pdf.sigma != "se" && pdf.sigma != "sigmab") {
-    stop("Only 'se' or 'sigmab' allowed for the pdf.sigma argument",
-         call. = FALSE)
-  }
+  pdf.sigma <- .match_args(pdf.sigma, c("sigmab", "se"))
+  pdf.colors <- .match_args(pdf.colors, c("gray", "colors", "none"))
 
   ## set expected column names
   colnames(data)[1:2] <- c("ED", "ED_Error")

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -304,9 +304,7 @@ calc_Huntley2006 <- function(
   ## Validate Input ------------------------------------------------------------
 
   ## Check fit method
-  if (!fit.method[1] %in% c("EXP", "GOK"))
-    .throw_error("Invalid fit option '", fit.method[1],
-                 "'. Only 'EXP' and 'GOK' allowed for argument 'fit.method'.")
+  fit.method <- .match_args(fit.method, c("EXP", "GOK"))
 
   ## Check length of lower.bounds
   if (fit.method[1] == "GOK" && length(lower.bounds) != 4)

--- a/R/calc_SourceDoseRate.R
+++ b/R/calc_SourceDoseRate.R
@@ -140,8 +140,9 @@ calc_SourceDoseRate <- function(
   source.type = "Sr-90",
   dose.rate.unit = "Gy/s",
   predict = NULL
-){
-
+) {
+  .set_function_name("calc_SourceDoseRate")
+  on.exit(.unset_function_name(), add = TRUE)
 
   if (is(measurement.date, "character")) {
         measurement.date <- as.Date(measurement.date)
@@ -151,6 +152,11 @@ calc_SourceDoseRate <- function(
   if(is(calib.date, "character")) {
     calib.date <- as.Date(calib.date)
   }
+
+  ## source type and dose rate unit
+  source.type <- .match_args(source.type,
+                             c("Sr-90", "Am-214", "Co-60", "Cs-137"))
+  dose.rate.unit <- .match_args(dose.rate.unit, c("Gy/s", "Gy/min"))
 
   # --- if predict is set
   if(!is.null(predict) && predict > 1){
@@ -173,10 +179,6 @@ calc_SourceDoseRate <- function(
     "Cs-137" = 30.08
     )
 
-  if(is.null(halflife.years))
-    stop("[calc_SourceDoseRate()] Source type unknown or currently not supported!", call. = FALSE)
-
-
   halflife.days  <- halflife.years * 365
 
   # N(t) = N(0)*e^((lambda * t) with lambda = log(2)/T1.2)
@@ -196,7 +198,6 @@ calc_SourceDoseRate <- function(
   }else if(dose.rate.unit == "Gy/s"){
     source.dose.rate <- measurement.dose.rate
     source.dose.rate.error <- measurement.dose.rate.error
-
   }
 
 

--- a/R/calc_Statistics.R
+++ b/R/calc_Statistics.R
@@ -18,8 +18,8 @@
 #' To plot several data sets in one plot the data sets must be provided 
 #' as `list`, e.g. `list(data.1, data.2)`.
 #'
-#' @param weight.calc [character]: 
-#' type of weight calculation. One out of `"reciprocal"` (weight is 1/error), 
+#' @param weight.calc [character]:
+#' type of weight calculation. One out of `"reciprocal"` (weight is 1/error),
 #' `"square"` (weight is 1/error^2). Default is `"square"`.
 #'
 #' @param digits [integer] (*with default*): 
@@ -70,6 +70,8 @@ calc_Statistics <- function(
   n.MCM = NULL,
   na.rm = TRUE
 ) {
+  .set_function_name("calc_Statistics")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## Check input data
   if(is(data, "RLum.Results") == FALSE &
@@ -100,12 +102,11 @@ calc_Statistics <- function(
     data[,2] <- rep(x = 10^-9, length(data[,2]))
   }
 
+  weight.calc <- .match_args(weight.calc, c("square", "reciprocal"))
   if(weight.calc == "reciprocal") {
     S.weights <- 1 / data[,2]
   } else if(weight.calc == "square") {
     S.weights <- 1 / data[,2]^2
-  } else {
-    stop ("[calc_Statistics()] Weight calculation type not supported!", call. = FALSE)
   }
 
   S.weights <- S.weights / sum(S.weights)

--- a/R/calc_gSGC.R
+++ b/R/calc_gSGC.R
@@ -94,8 +94,7 @@ calc_gSGC<- function(
     .throw_error("'data' must be a data.frame")
   if (ncol(data) != 5)
     .throw_error("'data' is expected to have 5 columns")
-  if (!is.character(gSGC.type))
-    .throw_error("'gSGC.type' must be of type 'character'")
+  gSGC.type <- .match_args(gSGC.type, c("0-250", "0-450"))
 
   ##rename columns for consistency reasons
   colnames(data) <- c('LnTn', 'LnTn.error', 'Lr1Tr1', 'Lr1Tr1.error', 'Dr1')
@@ -147,9 +146,6 @@ calc_gSGC<- function(
         Y0.error <- 0.00490
 
         range <- c(0.1,250)
-
-      }else{
-        .throw_error("Unknown 'gSGC.type'")
       }
     }
 

--- a/R/convert_Activity2Concentration.R
+++ b/R/convert_Activity2Concentration.R
@@ -104,7 +104,10 @@ convert_Activity2Concentration <- function(
   input_unit = "activity",
   verbose = TRUE
 
-){
+) {
+  .set_function_name("convert_Activity2Concentration")
+  on.exit(.unset_function_name(), add = TRUE)
+
   # Integrity checks ----------------------------------------------------------------------------
   if(missing(data))
     stop("[convert_Activity2Concentration()] I'm still waiting for input data ...", call. = FALSE)
@@ -135,10 +138,9 @@ convert_Activity2Concentration <- function(
 
   ## check input unit
   ## we silently let the old input values unflagged for back compatibility reasons
-  input_unit <- tolower(input_unit[1])
-  if(!input_unit[1] %in% c("activity", "abundance", "bq/kg", "ppm/%"))
-    stop("[convert_Activity2Concentrations()] Input for parameter 'input_unit' invalid. Valid are 'activity' or 'abundance'!",
-         call. = FALSE)
+  if (!tolower(input_unit[1]) %in% c("bq/kg", "ppm/%")) {
+    input_unit <- .match_args(tolower(input_unit), c("activity", "abundance"))
+  }
 
   # Set conversion factors ----------------------------------------------------------------------
 

--- a/R/convert_Concentration2DoseRate.R
+++ b/R/convert_Concentration2DoseRate.R
@@ -102,8 +102,9 @@
 convert_Concentration2DoseRate <- function(
   input,
   conversion = "Guerinetal2011"
-){
-
+) {
+  .set_function_name("convert_Concentration2DoseRate")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Alternate mode ----------------------------------------------------------
   if(missing(input)){
@@ -148,9 +149,14 @@ convert_Concentration2DoseRate <- function(
     stop("[convert_Concentration2DoseRate()] number of rows/columns in input does not match the requirements. See manual!",
          call. = FALSE)
 
-  if(!conversion[1] %in% names(BaseDataSet.ConversionFactors))
-    stop("[convert_Concentration2DoseRate()] You have not entered a valid conversion. Please check your spelling and consult the documentation!",
-         call. = FALSE)
+  ## conversion factors: we do not use BaseDataSet.ConversionFactors directly
+  ## as it is in alphabetical level, but we want to have 'Guerinetal2011'
+  ## in first position, as that is our default value
+  valid_conversion_factors <- c("Guerinetal2011", "Cresswelletal2018",
+                                "AdamiecAitken1998", "Liritzisetal2013")
+  stopifnot(all(names(BaseDataSet.ConversionFactors) %in%
+                valid_conversion_factors))
+  conversion <- .match_args(conversion, valid_conversion_factors)
 
   if(!any(input[,1] %in% c("FS","Q")))
     stop("[convert_Concentration2DoseRate()] As mineral only 'FS' or 'Q' is supported!", call. = FALSE)

--- a/R/fit_CWCurve.R
+++ b/R/fit_CWCurve.R
@@ -236,6 +236,7 @@ fit_CWCurve<- function(
 
   }
 
+  fit.method <- .match_args(fit.method, c("port", "LM"))
 
   # Deal with extra arguments -----------------------------------------------
 

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -296,6 +296,9 @@ fit_EmissionSpectra <- function(
   if(!inherits(object, "matrix"))
     .throw_error("Objects of type '", is(object)[1], "' are not supported")
 
+  input_scale <- .match_args(input_scale, c("wavelength", "energy"),
+                             null.ok = TRUE)
+
   ##extract matrix for everything below
   m <- object[,1:2]
 

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -294,6 +294,9 @@ fit_LMCurve<- function(
       }
   }
 
+  input.dataType <- .match_args(input.dataType, c("LM", "pLM"))
+  fit.method <- .match_args(fit.method, c("port", "LM"))
+
   ## Set plot format parameters -----------------------------------------------
   extraArgs <- list(...) # read out additional arguments list
 
@@ -562,9 +565,6 @@ fit_LMCurve<- function(
             trace = fit.trace,
             control = minpack.lm::nls.lm.control(maxiter = 500)
           ), silent = TRUE)
-
-        }else{
-          .throw_error("Unknown method for 'fit.method'")
         }
 
       }#endifelse::fit.advanced

--- a/R/merge_RLum.Data.Curve.R
+++ b/R/merge_RLum.Data.Curve.R
@@ -8,11 +8,7 @@
 #'
 #' **Supported merge operations are [RLum.Data.Curve-class]**
 #'
-#' `"sum"`
-#'
-#' All count values will be summed up using the function [rowSums].
-#'
-#' `"mean"`
+#' `"mean"` (default)
 #'
 #' The mean over the count values is calculated using the function
 #' [rowMeans].
@@ -21,6 +17,10 @@
 #'
 #' The median over the count values is calculated using the function
 #' [matrixStats::rowMedians].
+#'
+#' `"sum"`
+#'
+#' All count values will be summed up using the function [rowSums].
 #'
 #' `"sd"`
 #'
@@ -64,7 +64,8 @@
 #' list of S4 objects of class `RLum.Curve`.
 #'
 #' @param merge.method [character] (**required**):
-#' method for combining of the objects, e.g.  `'mean'`, `'sum'`, see details for
+#' method for combining of the objects, e.g. `'mean'` (default), `'median'`,
+#' `'sum'`, see details for
 #' further information and allowed methods.  Note: Elements in slot info will
 #' be taken from the first curve in the list.
 #'
@@ -144,6 +145,10 @@ merge_RLum.Data.Curve<- function(
     .throw_error("Only similar record types are supported; you are trying to merge: ",
                  paste0("'", record.types, "'", collapse = ", "))
   }
+
+  merge.method <- .match_args(merge.method,
+                              c("mean", "median", "sum", "sd", "var", "max",
+                                "min", "append", "-", "*", "/"))
 
 # Merge objects ----------------------------------------------------------------
   ##merge data objects
@@ -230,8 +235,6 @@ merge_RLum.Data.Curve<- function(
       .throw_warning(length(id.inf),
                      " 'inf' values have been replaced by 0 in the matrix.")
     }
-  }else{
-    .throw_error("Unsupported or unknown merge method")
   }
 
   ##add first column

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -99,9 +99,10 @@
 #'
 #' @param dispersion [character] (*with default*):
 #' measure of dispersion, used for drawing the scatter polygon. One out of
-#' - `"qr"` (quartile range),
+#' - `"qr"` (quartile range, default),
 #' - `"pnn"` (symmetric percentile range with `nn` the lower percentile, e.g.
-#' - `"p05"` depicting the range between 5 and 95 %),
+#' `"p05"` indicating the range between 5 and 95 %, or `"p10"` indicating
+#' the range between 10 and 90 %), or
 #' - `"sd"` (standard deviation) and
 #' - `"2sd"` (2 standard deviations),
 #'
@@ -554,6 +555,17 @@ plot_AbanicoPlot <- function(
 
   ## plot.ratio must be numeric and positive
   .validate_positive_scalar(plot.ratio)
+
+  if (!is.numeric(z.0)) {
+    z.0 <- .match_args(z.0, c("mean", "mean.weighted", "median"),
+                       extra = "a numerical value")
+  }
+
+  ## the 'pnn' option need some special treatment
+  main.choices <- c("qr", "sd", "2sd")
+  extra.choice <-"a percentile of the form 'pnn' (eg. 'p05')"
+  if (!dispersion %in% main.choices && !grepl("^p[0-9][0-9]$", dispersion))
+    dispersion <- .match_args(dispersion, main.choices, extra = extra.choice)
 
   ## save original plot parameters and restore them upon end or stop
   par.old.full <- par(no.readonly = TRUE)
@@ -1694,8 +1706,6 @@ plot_AbanicoPlot <- function(
         ci.lower <- mean(data[[i]][,1]) - 2 * sd(data[[i]][,1])
         ci.upper <- mean(data[[i]][,1]) + 2 * sd(data[[i]][,1])
       }
-    } else {
-      .throw_error("Measure of dispersion not supported.")
     }
 
     if(log.z == TRUE) {

--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -220,6 +220,10 @@ plot_DetPlot <- function(
   .validate_positive_scalar(background.integral.min, int = TRUE)
   .validate_positive_scalar(background.integral.min, int = TRUE)
 
+  ## analyse_function
+  analyse_function <- .match_args(analyse_function,
+                                  c("analyse_SAR.CWOSL", "analyse_pIRIRSequence"))
+
 # Set parameters ------------------------------------------------------------------------------
   ##set n.channels
   if(is.null(n.channels)){
@@ -301,9 +305,6 @@ plot_DetPlot <- function(
       results <- merge_RLum(result.temp.list)
     }
     rm(result.temp.list)
-  }
-  else{
-   .throw_error("Unknown 'analyse_function'")
   }
 
 

--- a/R/plot_GrowthCurve.R
+++ b/R/plot_GrowthCurve.R
@@ -334,14 +334,9 @@ plot_GrowthCurve <- function(
   )
 
   ##2. Check supported fit methods
+  mode <- .match_args(mode, c("interpolation", "extrapolation", "alternate"))
   fit.method_supported <- c("LIN", "QDR", "EXP", "EXP OR LIN", "EXP+LIN", "EXP+EXP", "GOK", "LambertW")
-  if (!fit.method[1] %in% fit.method_supported) {
-    stop(paste0(
-      "[plot_GrowthCurve()] Fit method not supported, supported methods are: ",
-      paste(fit.method_supported, collapse = ", ")
-    ),
-    call. = FALSE)
-  }
+  fit.method <- .match_args(fit.method, fit.method_supported)
 
   ##2. check if sample contains a least three rows
   if(length(sample[[1]]) < 3 && fit.method != "LIN")

--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -19,8 +19,9 @@
 #' @param log [character] (*optional*):
 #' logarithmic axes (`c("x", "y", "xy")`).
 #'
-#' @param smooth [character] (*optional*):
-#' apply data smoothing. Use `"rmean"` to calculate the rolling where `k`
+#' @param smooth [character] (*with default*):
+#' apply data smoothing. If `"none"` (default), no data smoothing is applied.
+#' Use `"rmean"` to calculate the rolling where `k`
 #' determines the width of the rolling window (see [zoo::rollmean]). `"spline"`
 #' applies a smoothing spline to each curve (see [stats::smooth.spline])
 #'
@@ -157,6 +158,8 @@ plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k
     .throw_error("'data' is expected to be a list, matrix, data.frame or ",
                  "'RLum.Analysis' object")
   }
+
+  smooth <- .match_args(smooth, c("none", "spline", "rmean"))
 
   ## BASIC SETTINGS ------
   natural <- curves[[1]]

--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -51,10 +51,11 @@
 #' in fewer curves plotted as specified. This parameter has only
 #' an effect for  n > 2.
 #'
-#' @param curve.transformation [character] (*optional*):
+#' @param curve.transformation [character] (*with default*):
 #' allows transforming CW-OSL and CW-IRSL curves to pseudo-LM curves via
 #' transformation functions. Allowed values are: `CW2pLM`, `CW2pLMi`,
-#' `CW2pHMi` and `CW2pPMi`. See details.
+#' `CW2pHMi` and `CW2pPMi`, see details. If set to `None` (default), no
+#' transformation is applied.
 #'
 #' @param plot.single [logical] (*with default*):
 #' global par settings are considered, normally this should end in one plot per page
@@ -125,7 +126,7 @@ plot_RLum.Analysis <- function(
   abline = NULL,
   combine = FALSE,
   records_max = NULL,
-  curve.transformation,
+  curve.transformation = "None",
   plot.single = FALSE,
   ...
 ) {
@@ -231,6 +232,9 @@ plot_RLum.Analysis <- function(
     }
   }
 
+  curve.transformation <- .match_args(curve.transformation,
+                                      c("CW2pLM", "CW2pLMi",
+                                        "CW2pHMi", "CW2pPMi", "None"))
 
   # Plotting ------------------------------------------------------------------
   ##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -307,8 +311,8 @@ plot_RLum.Analysis <- function(
       if(is(temp[[i]], "RLum.Data.Curve") == TRUE){
 
         ##set curve transformation if wanted
-        if((grepl("IRSL", temp[[i]]@recordType) | grepl("OSL", temp[[i]]@recordType)) &
-           !missing(curve.transformation)){
+        if (grepl("IRSL", temp[[i]]@recordType) ||
+            grepl("OSL", temp[[i]]@recordType)) {
 
           if(curve.transformation=="CW2pLM"){
             temp[[i]] <- CW2pLM(temp[[i]])
@@ -321,10 +325,6 @@ plot_RLum.Analysis <- function(
 
           }else if(curve.transformation=="CW2pPMi"){
             temp[[i]] <- CW2pPMi(temp[[i]])
-
-          }else{
-            .throw_warning("Function for 'curve.transformation' is unknown, ",
-                           "no transformation performed")
           }
         }
 
@@ -529,11 +529,6 @@ plot_RLum.Analysis <- function(
         records_show <- ceiling(seq(1,length(object.list), length.out = records_max))
         object.list[(1:length(object.list))[-records_show]] <- NULL
 
-      }
-
-      ##prevent problems for non set argument
-      if (missing(curve.transformation)) {
-        curve.transformation <- "None"
       }
 
       ##transform values to data.frame and norm values

--- a/R/plot_RLum.Data.Image.R
+++ b/R/plot_RLum.Data.Image.R
@@ -71,7 +71,9 @@ plot_RLum.Data.Image <- function(
   par.local = TRUE,
   plot.type = "plot.raster",
   ...
-){
+) {
+  .set_function_name("plot_RLum.Data.Image")
+  on.exit(.unset_function_name(), add = TRUE)
 
 # Integrity check -----------------------------------------------------------
   ##check if object is of class RLum.Data.Image
@@ -104,6 +106,8 @@ plot_RLum.Data.Image <- function(
 
   return(x)
 }
+
+ plot.type <- .match_args(plot.type, c("plot.raster", "contour"))
 
 # Plot settings -----------------------------------------------------------
 plot_settings <- modifyList(x = list(
@@ -244,12 +248,6 @@ plot_settings <- modifyList(x = list(
       ylab[c(1,length(ylab))] <- c(0,dim(x)[1])
       yat <- seq(0,1,length.out = length(ylab))
       graphics::axis(side = 2, at = yat, labels = ylab)
-
     }
-
-  }else{
-    stop("[plot_RLum.Data.Image()] Unknown plot type.", call. = FALSE)
-
   }
-
 }

--- a/R/read_SPE2R.R
+++ b/R/read_SPE2R.R
@@ -117,10 +117,7 @@ read_SPE2R <- function(
   # Consistency check -------------------------------------------------------
 
   valid.output.object <- c("RLum.Data.Image", "RLum.Data.Spectrum", "matrix")
-  if (!output.object %in% valid.output.object) {
-    .throw_error("'output.object' not supported, valid options are ",
-                 paste(valid.output.object, collapse = ", "))
-  }
+  .match_args(output.object, valid.output.object)
 
   ##check if file exists
   if(!file.exists(file)){

--- a/R/scale_GammaDose.R
+++ b/R/scale_GammaDose.R
@@ -245,7 +245,10 @@ scale_GammaDose <- function(
   verbose = TRUE,
   plot = TRUE,
   plot_single = TRUE,
-  ...) {
+  ...
+) {
+  .set_function_name("scale_GammaDose")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ## HELPER FUNCTION ----
   # Wrapper for formatC to enforce precise digit printing
@@ -308,23 +311,20 @@ scale_GammaDose <- function(
   if (data$sample_offset[which(!is.na(data$sample_offset))] > data$thickness[which(!is.na(data$sample_offset))])
     stop("Impossible! Sample offset larger than the target-layer's thickness!", call. = FALSE)
 
-  # conversion factors
-  if (length(conversion_factors) != 1 || !is.character(conversion_factors))
-    stop("'conversion_factors' must be an object of length 1 and of class 'character'.",
-         call. = FALSE)
-  if (!conversion_factors %in% names(BaseDataSet.ConversionFactors))
-    stop("Invalid 'conversion_factors'. Valid options: ",
-         paste(names(BaseDataSet.ConversionFactors), collapse = ", "), ".",
-         call. = FALSE)
+  ## conversion factors: we do not use BaseDataSet.ConversionFactors directly
+  ## as it is in alphabetical level, but we want to have 'Cresswelletal2018'
+  ## in first position, as that is our default value
+  valid_conversion_factors <- c("Cresswelletal2018", "Guerinetal2011",
+                                "AdamiecAitken1998", "Liritzisetal2013")
+  stopifnot(all(names(BaseDataSet.ConversionFactors) %in%
+                valid_conversion_factors))
+  conversion_factors <- .match_args(conversion_factors,
+                                    valid_conversion_factors)
 
-  # tables for gamma dose fractions
-  if (length(fractional_gamma_dose) != 1 || !is.character(fractional_gamma_dose))
-    stop("'fractional_gamma_dose' must be an object of length 1 and of class 'character'.",
-         call. = FALSE)
-  if (!fractional_gamma_dose %in% names(BaseDataSet.FractionalGammaDose))
-    stop("Invalid 'fractional_gamma_dose'. Valid options: ",
-         paste(names(BaseDataSet.FractionalGammaDose), collapse = ", "), ".",
-         call. = FALSE)
+  ## fractional gamma dose
+  fractional_gamma_dose <- .match_args(fractional_gamma_dose,
+                                       names(BaseDataSet.FractionalGammaDose))
+
 
   ## ------------------------------------------------------------------------ ##
   ## Select tables

--- a/R/template_DRAC.R
+++ b/R/template_DRAC.R
@@ -112,16 +112,7 @@ template_DRAC <- function(
   ## PRESETS ----
   valid_presets <- c("quartz_coarse", "quartz_fine", "feldspar_coarse", "polymineral_fine",
                      "DRAC-example_quartz", "DRAC-example_feldspar", "DRAC-example_polymineral")
-
-  if (!is.null(preset)) {
-    if (length(preset) != 1 || !is.character(preset))
-      stop("\n[template_DRAC()]: Argument 'preset' must be a 'character' of length 1.",
-           call. = FALSE)
-
-    if (!preset %in% valid_presets)
-      stop("\n[template_DRAC()]: Invalid preset. Please use on of the following: ",
-           paste(valid_presets, collapse = ", "), call. = FALSE)
-  }
+  preset <- .match_args(preset, valid_presets, null.ok = TRUE)
 
   ## LEGAL NOTICE ----
   messages <- list("\n",

--- a/R/use_DRAC.R
+++ b/R/use_DRAC.R
@@ -169,6 +169,10 @@ use_DRAC <- function(
   if (nrow(input.raw) > 5000)
     .throw_error("The limit of allowed datasets is 5000!")
 
+  citation_style <- .match_args(citation_style,
+                                c("text", "Bibtex", "citation", "html",
+                                  "latex", "R"))
+
   # Settings ------------------------------------------------------------------------------------
   settings <- list(
     name = ifelse(missing(name),

--- a/R/verify_SingleGrainData.R
+++ b/R/verify_SingleGrainData.R
@@ -146,8 +146,9 @@ verify_SingleGrainData <- function(
     verbose = TRUE,
     plot = FALSE,
     ...
-){
-
+) {
+  .set_function_name("verify_SingleGrainData")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##three types of input are allowed:
   ##(1) RisoeBINfileData
@@ -178,6 +179,10 @@ verify_SingleGrainData <- function(
     }
 
   }
+
+  ## ------------------------------------------------------------------------
+  ## input validation
+  cleanup_level <- .match_args(cleanup_level, c("aliquot", "curve"))
 
   ##++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   ##RisoeBINfileData

--- a/man/merge_RLum.Data.Curve.Rd
+++ b/man/merge_RLum.Data.Curve.Rd
@@ -11,7 +11,8 @@ merge_RLum.Data.Curve(object, merge.method = "mean", method.info)
 list of S4 objects of class \code{RLum.Curve}.}
 
 \item{merge.method}{\link{character} (\strong{required}):
-method for combining of the objects, e.g.  \code{'mean'}, \code{'sum'}, see details for
+method for combining of the objects, e.g. \code{'mean'} (default), \code{'median'},
+\code{'sum'}, see details for
 further information and allowed methods.  Note: Elements in slot info will
 be taken from the first curve in the list.}
 
@@ -34,11 +35,7 @@ the 2nd column of the data matrix of the object.
 
 \strong{Supported merge operations are \linkS4class{RLum.Data.Curve}}
 
-\code{"sum"}
-
-All count values will be summed up using the function \link{rowSums}.
-
-\code{"mean"}
+\code{"mean"} (default)
 
 The mean over the count values is calculated using the function
 \link{rowMeans}.
@@ -47,6 +44,10 @@ The mean over the count values is calculated using the function
 
 The median over the count values is calculated using the function
 \link[matrixStats:rowMedians]{matrixStats::rowMedians}.
+
+\code{"sum"}
+
+All count values will be summed up using the function \link{rowSums}.
 
 \code{"sd"}
 

--- a/man/plot_AbanicoPlot.Rd
+++ b/man/plot_AbanicoPlot.Rd
@@ -60,9 +60,10 @@ Default is \code{"mean.weighted"}.}
 \item{dispersion}{\link{character} (\emph{with default}):
 measure of dispersion, used for drawing the scatter polygon. One out of
 \itemize{
-\item \code{"qr"} (quartile range),
+\item \code{"qr"} (quartile range, default),
 \item \code{"pnn"} (symmetric percentile range with \code{nn} the lower percentile, e.g.
-\item \code{"p05"} depicting the range between 5 and 95 \%),
+\code{"p05"} indicating the range between 5 and 95 \%, or \code{"p10"} indicating
+the range between 10 and 90 \%), or
 \item \code{"sd"} (standard deviation) and
 \item \code{"2sd"} (2 standard deviations),
 }

--- a/man/plot_NRt.Rd
+++ b/man/plot_NRt.Rd
@@ -21,8 +21,9 @@ X,Y data of measured values (time and counts). See details on individual data st
 \item{log}{\link{character} (\emph{optional}):
 logarithmic axes (\code{c("x", "y", "xy")}).}
 
-\item{smooth}{\link{character} (\emph{optional}):
-apply data smoothing. Use \code{"rmean"} to calculate the rolling where \code{k}
+\item{smooth}{\link{character} (\emph{with default}):
+apply data smoothing. If \code{"none"} (default), no data smoothing is applied.
+Use \code{"rmean"} to calculate the rolling where \code{k}
 determines the width of the rolling window (see \link[zoo:rollmean]{zoo::rollmean}). \code{"spline"}
 applies a smoothing spline to each curve (see \link[stats:smooth.spline]{stats::smooth.spline})}
 

--- a/man/plot_RLum.Analysis.Rd
+++ b/man/plot_RLum.Analysis.Rd
@@ -12,7 +12,7 @@ plot_RLum.Analysis(
   abline = NULL,
   combine = FALSE,
   records_max = NULL,
-  curve.transformation,
+  curve.transformation = "None",
   plot.single = FALSE,
   ...
 )
@@ -50,10 +50,11 @@ the other number of curves to be shown a distributed evenly, this may result
 in fewer curves plotted as specified. This parameter has only
 an effect for  n > 2.}
 
-\item{curve.transformation}{\link{character} (\emph{optional}):
+\item{curve.transformation}{\link{character} (\emph{with default}):
 allows transforming CW-OSL and CW-IRSL curves to pseudo-LM curves via
 transformation functions. Allowed values are: \code{CW2pLM}, \code{CW2pLMi},
-\code{CW2pHMi} and \code{CW2pPMi}. See details.}
+\code{CW2pHMi} and \code{CW2pPMi}, see details. If set to \code{None} (default), no
+transformation is applied.}
 
 \item{plot.single}{\link{logical} (\emph{with default}):
 global par settings are considered, normally this should end in one plot per page}

--- a/tests/testthat/test_Second2Gray.R
+++ b/tests/testthat/test_Second2Gray.R
@@ -25,7 +25,7 @@ test_that("check class and length of output", {
   expect_error(Second2Gray(ExampleData.DeValues$BT998,
                            dose.rate = results,
                            error.propagation = "test"),
-               "unsupported error propagation method")
+               "'error.propagation' should be one of 'omit', 'gaussian'")
   dose.rate@originator <- "unexpected-originator"
   expect_error(Second2Gray(ExampleData.DeValues$BT998, dose.rate = dose.rate),
                "Wrong originator for dose.rate 'RLum.Results' object")

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -13,6 +13,12 @@ test_that("input validation", {
       "'object' must be an 'RLum.Analysis' object or a 'list' of such objects")
   expect_error(analyse_FadingMeasurement(cbind(fading_data, fading_data[, 1])),
                "if you provide a data.frame as input, the number of columns")
+
+  ## check various for t_star
+  ## stop t_star
+  expect_error(analyse_FadingMeasurement(fading_data, t_star = "error"),
+               "'t_star' should be one of 'half', 'half_complex', 'end' or a function")
+
 })
 
 test_that("general test", {
@@ -100,13 +106,6 @@ test_that("test XSYG file fading data", {
     structure = "Lx"
   ), "RLum.Results")
   })
-
-  ## check various for t_star
-  ## stop t_star
-  expect_error(analyse_FadingMeasurement(
-    object,
-    t_star = "error",
-  ), "\\[analyse_FadingMeasurement\\(\\)\\] Invalid input for t_star.")
 
   SW({
   expect_s4_class(analyse_FadingMeasurement(

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -11,6 +11,8 @@ test_that("input validation", {
                "'sequence_structure' must be of type 'character'")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, n.MC = 0),
                "'n.MC' must be a positive integer scalar")
+  expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method = "error"),
+               "'method' should be one of 'FIT', 'SLIDE', 'VSLIDE'")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method.control = 3),
                "'method.control' has to be of type 'list'")
 
@@ -34,9 +36,6 @@ test_that("input validation", {
   expect_message(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
                                   method.control = list(cores = "4")),
                  "Invalid value for control argument 'cores'")
-
-  expect_warning(analyse_IRSAR.RF(IRSAR.RF.Data, method = "UNKNOWN"),
-                 "Analysis skipped: Unknown method or threshold of test")
   })
 })
 

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -25,6 +25,12 @@ test_that("input validation", {
                               signal.integral.max = 220,
                               sequence.structure = c("SIGNAL", "BACKGROUND")),
                "Length of 'dose.points' not compatible with number of signals")
+  expect_error(analyse_SAR.TL(object, signal.integral.min = 1,
+                              signal.integral.max = 2,
+                              sequence.structure = c("SIGNAL", "BACKGROUND"),
+                              integral_input = "error"),
+               "[analyse_SAR.TL()] 'integral_input' should be one of ",
+               fixed = TRUE)
 })
 
 test_that("Test examples", {

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -24,7 +24,8 @@ test_that("input validation", {
   expect_error(analyse_baSAR(CWOSL.sub, verbose = FALSE),
                "'source_doserate' is missing, but the current implementation")
   expect_error(analyse_baSAR(CWOSL.sub, fit.method = "error"),
-               "'fit.method' not recognised, supported methods are")
+               "'fit.method' should be one of 'EXP', 'EXP+LIN', 'LIN'",
+               fixed = TRUE)
   expect_error(analyse_baSAR(CWOSL.sub, verbose = FALSE,
                              source_doserate = c(0.04, 0.001)),
                'argument "signal.integral" is missing, with no default')

--- a/tests/testthat/test_apply_CosmicRayRemoval.R
+++ b/tests/testthat/test_apply_CosmicRayRemoval.R
@@ -1,15 +1,19 @@
-test_that("check function", {
+## load data
+data(ExampleData.XSYG, envir = environment())
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
-  ##load data
-  data(ExampleData.XSYG, envir = environment())
-
-  ##crash the function
   expect_error(
     apply_CosmicRayRemoval("error"),
     regexp = "An object of class 'character' is not supported as input; please read the manual!")
   expect_error(apply_CosmicRayRemoval(TL.Spectrum, method = "error"),
-               "Unknown method for cosmic ray removal")
+               "'method' should be one of 'smooth', 'smooth.spline', 'Pych'",
+               fixed = TRUE)
+})
+
+test_that("check function", {
+  testthat::skip_on_cran()
 
   ##run basic tests
   expect_silent(apply_CosmicRayRemoval(TL.Spectrum, method = "Pych"))

--- a/tests/testthat/test_calc_CobbleDoseRate.R
+++ b/tests/testthat/test_calc_CobbleDoseRate.R
@@ -10,4 +10,7 @@ test_that("basic checks", {
   df$Distance[[14]] <- 50000
   expect_error(calc_CobbleDoseRate(df),
                "Slices outside of cobble. Please check your distances and make sure they are in mm and diameter is in cm!")
+
+  expect_error(calc_CobbleDoseRate(ExampleData.CobbleData, conversion = "error"),
+               "'conversion' should be one of 'Guerinetal2011', 'Cresswelletal2018'")
 })

--- a/tests/testthat/test_calc_FiniteMixture.R
+++ b/tests/testthat/test_calc_FiniteMixture.R
@@ -21,8 +21,11 @@ test_that("check class and length of output", {
                                   n.components = 1),
                "At least two components need to be fitted")
   expect_error(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.2,
-                                  n.components = 2, pdf.sigma = "test"),
-               "Only 'se' or 'sigmab' allowed for the pdf.sigma argument")
+                                  n.components = 2, pdf.sigma = "error"),
+               "'pdf.sigma' should be one of 'sigmab', 'se'")
+  expect_error(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.2,
+                                  n.components = 2, pdf.colors = "error"),
+               "'pdf.colors' should be one of 'gray', 'colors', 'none'")
 
   ## simple run
   SW({

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -32,7 +32,7 @@ test_that("input validation", {
                "'data' must be a data frame")
 
   expect_error(calc_Huntley2006(data, fit.method = "test"),
-               "Invalid fit option 'test'")
+               "'fit.method' should be one of 'EXP', 'GOK'")
   expect_error(calc_Huntley2006(data, fit.method = "GOK", lower.bounds = 0),
                "Argument 'lower.bounds' must be of length 4")
 

--- a/tests/testthat/test_calc_SourceDoseRate.R
+++ b/tests/testthat/test_calc_SourceDoseRate.R
@@ -45,11 +45,15 @@ test_that("General tests", {
     measurement.date = "2018-01-02",
     calib.date = "2014-12-19",
     calib.dose.rate = 0.0438,
-    calib.error = 0.0019, source.type = "SK"
-  ))
+    calib.error = 0.0019, source.type = "error"),
+    "'source.type' should be one of 'Sr-90', 'Am-214', 'Co-60', 'Cs-137'")
 
-
-
+  expect_error(calc_SourceDoseRate(
+    measurement.date = "2018-01-02",
+    calib.date = "2014-12-19",
+    calib.dose.rate = 0.0438,
+    calib.error = 0.0019, dose.rate.unit = "error"),
+    "'dose.rate.unit' should be one of 'Gy/s', 'Gy.min'")
 })
 
 test_that("check class and length of output", {

--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -40,8 +40,8 @@ test_that("check error messages", {
   expect_error(calc_Statistics(data = matrix(0,2)),
                regexp = "[calc_Statistics()] Input data is neither of type 'data.frame' nor 'RLum.Results'",
                fixed = TRUE)
-  expect_error(calc_Statistics(data = df, weight.calc = "test"))
-
+  expect_error(calc_Statistics(data = df, weight.calc = "error"),
+               "'weight.calc' should be one of 'square', 'reciprocal'")
 })
 
 

--- a/tests/testthat/test_calc_gSGC.R
+++ b/tests/testthat/test_calc_gSGC.R
@@ -10,9 +10,9 @@ test_that("input validation", {
   expect_error(calc_gSGC(data.frame(a = 1, b = 1, c = 1, d = 1, e = 1, f = 1)),
                "'data' is expected to have 5 columns")
   expect_error(calc_gSGC(df, gSGC.type = 3),
-               "'gSGC.type' must be of type 'character'")
+               "'gSGC.type' should be one of '0-250', '0-450'")
   expect_error(calc_gSGC(df, gSGC.type = "error"),
-               "Unknown 'gSGC.type'")
+               "'gSGC.type' should be one of '0-250', '0-450'")
 })
 
 test_that("check functionality", {

--- a/tests/testthat/test_convert_Activity2Concentration.R
+++ b/tests/testthat/test_convert_Activity2Concentration.R
@@ -26,7 +26,7 @@ test_that("check class and length of output", {
 
   expect_error(
     object = convert_Activity2Concentration(data = data_activity, input_unit = "stop"),
-    regexp = "\\[convert\\_Activity2Concentrations\\(\\)\\] Input for parameter 'input_unit' invalid.")
+    "'input_unit' should be one of 'activity', 'abundance'")
 
   ## check for standard input
   SW({

--- a/tests/testthat/test_convert_Concentration2DoseRate.R
+++ b/tests/testthat/test_convert_Concentration2DoseRate.R
@@ -13,9 +13,9 @@ test_that("basic checks", {
   expect_error(convert_Concentration2DoseRate(input = data.frame(x = 1, y = 2)),
                regexp = "number of rows/columns in input does not match the requirements. See manual!")
 
-  expect_error(
-    convert_Concentration2DoseRate(suppressMessages(convert_Concentration2DoseRate()), conversion = "fail"),
-    regexp = "You have not entered a valid conversion. Please check your spelling and consult the documentation!")
+  expect_error(convert_Concentration2DoseRate(
+      suppressMessages(convert_Concentration2DoseRate()), conversion = "error"),
+    "'conversion' should be one of 'Guerinetal2011', 'Cresswelletal2018'")
 
   template[[1]] <- "fail"
   expect_error(convert_Concentration2DoseRate(template), regexp = "As mineral only 'FS' or 'Q' is supported!")

--- a/tests/testthat/test_fit_CWCurve.R
+++ b/tests/testthat/test_fit_CWCurve.R
@@ -6,7 +6,7 @@ test_that("input validation", {
   expect_error(fit_CWCurve("error"),
                "Input object is not of type 'RLum.Data.Curve' or 'data.frame'")
   expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve, fit.method = "error"),
-               "'fit.method' unknown")
+               "'fit.method' should be one of 'port', 'LM'")
 })
 
 test_that("check class and length of output", {

--- a/tests/testthat/test_fit_EmissionSpectra.R
+++ b/tests/testthat/test_fit_EmissionSpectra.R
@@ -12,6 +12,10 @@ test_that("standard check", {
   expect_error(fit_EmissionSpectra(list(TL.Spectrum, "fail")),
                "\\[fit\\_EmissionSpectra\\(\\)\\] List elements of different class detected!")
 
+  ## input scale
+  expect_error(fit_EmissionSpectra(TL.Spectrum, input_scale = "error"),
+               "'input_scale' should be one of 'wavelength', 'energy' or NULL")
+
   ## wrong frame range -------
   expect_error(fit_EmissionSpectra(TL.Spectrum, frame = 1000),
                "\\[fit\\_EmissionSpectra\\(\\)\\] 'frame' invalid. Allowed range min: 1 and max: 24")

--- a/tests/testthat/test_fit_LMCurve.R
+++ b/tests/testthat/test_fit_LMCurve.R
@@ -17,8 +17,10 @@ test_that("input validation", {
                "Invalid method for background subtraction")
   expect_error(fit_LMCurve(values.curve, n.components = "error"),
                "'n.components' must be a positive integer scalar")
+  expect_error(fit_LMCurve(values.curve, input.dataType = "error"),
+               "'input.dataType' should be one of 'LM', 'pLM'")
   expect_error(fit_LMCurve(values.curve, fit.method = "error"),
-               "Unknown method for 'fit.method'")
+               "'fit.method' should be one of 'port', 'LM'")
 
   ## warning for failed confint ...skip on windows because with R >= 4.2 is does not fail anymore
   if (!grepl(pattern = "mingw", sessionInfo()$platform) && !grepl(pattern = "linux", sessionInfo()$platform))

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -189,6 +189,56 @@ test_that("Test internals", {
   expect_error(SW(.throw_error("error message")),
                "error message")
 
+  ## .match_args() ----------------------------------------------------------
+  fun1 <- function(arg) {
+    .match_args(arg, c("val1", "val2", "val3"), null.ok = TRUE)
+  }
+  expect_silent(fun1(NULL))
+  expect_equal(fun1(arg = "val1"), "val1")
+  expect_equal(fun1(arg = c("val1", "val2")), "val1")
+  expect_equal(fun1(arg = c("val3", "val2")), "val3")
+  expect_error(fun1(arg = c("error", "val1")),
+               "[test()] 'arg' contains multiple values but not all of them",
+               fixed = TRUE)
+  expect_error(fun1(arg = "error"),
+               "[test()] 'arg' should be one of 'val1', 'val2', 'val3' or NULL",
+               fixed = TRUE)
+
+  fun2 <- function(arg = c("val1", "val2", "val3")) {
+    .match_args(arg, c("val1", "val2", "val3"), name = "other_name")
+  }
+  expect_equal(fun2(), "val1")
+  expect_error(fun2(arg = NULL),
+               "[test()] 'other_name' should be one of 'val1', 'val2', 'val3'",
+               fixed = TRUE)
+  expect_error(fun2(arg = "error"),
+               "[test()] 'other_name' should be one of 'val1', 'val2', 'val3'",
+               fixed = TRUE)
+
+  fun3 <- function(arg) {
+    .match_args(arg, c("val1", "val2"),
+                extra = "'other.val'", null.ok = FALSE)
+  }
+  expect_error(fun3(arg = "error"),
+               "[test()] 'arg' should be one of 'val1', 'val2' or 'other.val'",
+               fixed = TRUE)
+
+  fun4 <- function(arg) {
+    .match_args(arg, c("val1", "val2"),
+                extra = "'other.val'", null.ok = TRUE)
+  }
+  expect_error(fun4(arg = "error"),
+               "[test()] 'arg' should be one of 'val1', 'val2' or 'other.val' or NULL",
+               fixed = TRUE)
+
+  fun.err <- function(arg) {
+    .match_args(arg)
+  }
+  expect_error(fun.err("val1"),
+               "[test()] 'choices' must be provided",
+               fixed = TRUE)
+
+
   ## .validate_positive_scalar() --------------------------------------------
   expect_silent(.validate_positive_scalar(1.3))
   expect_silent(.validate_positive_scalar(2, int = TRUE))

--- a/tests/testthat/test_merge_RLum.Data.Curve.R
+++ b/tests/testthat/test_merge_RLum.Data.Curve.R
@@ -18,7 +18,7 @@ test_that("Merge tests", {
                "At least object 1 is not of class 'RLum.Data.Curve'")
   expect_error(merge_RLum.Data.Curve(list(TL.curve.1, TL.curve.3),
                                      merge.method = "error"),
-               "Unsupported or unknown merge method")
+               "'merge.method' should be one of 'mean', 'median', 'sum', 'sd'")
   expect_error(merge_RLum.Data.Curve(list(TL.curve.1, TL.curve.3_types)),
                "Only similar record types are supported")
 

--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -23,9 +23,15 @@ test_that("input validation", {
   expect_error(plot_AbanicoPlot(ExampleData.DeValues, xlab = "x"),
                "'xlab' must have length 2")
   expect_error(plot_AbanicoPlot(ExampleData.DeValues, z.0 = "error"),
-               "Value for 'z.0' not supported")
+               "'z.0' should be one of 'mean', 'mean.weighted', 'median' or")
   expect_error(plot_AbanicoPlot(ExampleData.DeValues, dispersion = "error"),
-               "Measure of dispersion not supported")
+               "'dispersion' should be one of 'qr', 'sd', '2sd' or a percentile")
+  expect_error(plot_AbanicoPlot(ExampleData.DeValues, dispersion = "p5"),
+               "'dispersion' should be one of 'qr', 'sd', '2sd' or a percentile")
+  expect_error(plot_AbanicoPlot(ExampleData.DeValues, dispersion = "p5a"),
+               "'dispersion' should be one of 'qr', 'sd', '2sd' or a percentile")
+  expect_error(plot_AbanicoPlot(ExampleData.DeValues, dispersion = "p500"),
+               "'dispersion' should be one of 'qr', 'sd', '2sd' or a percentile")
 
   ## zero-error values
   data.zeros <- ExampleData.DeValues

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -17,7 +17,7 @@ test_that("input validation", {
                             background.integral.max = 1000,
                             analyse_function = "error",
                             verbose = FALSE),
-               "Unknown 'analyse_function'")
+               "'analyse_function' should be one of 'analyse_SAR.CWOSL'")
 })
 
 test_that("plot_DetPlot", {

--- a/tests/testthat/test_plot_GrowthCurve.R
+++ b/tests/testthat/test_plot_GrowthCurve.R
@@ -4,10 +4,11 @@ test_that("plot_GrowthCurve", {
   ## load data
   data(ExampleData.LxTxData, envir = environment())
 
-  ##fit.method
+  ## fit.method
   expect_error(
-    object = plot_GrowthCurve(LxTxData, fit.method = "FAIL"),
-    regexp = "\\[plot\\_GrowthCurve\\(\\)\\] Fit method not supported, supported.+")
+    plot_GrowthCurve(LxTxData, fit.method = "error"),
+    "[plot_GrowthCurve()] 'fit.method' should be one of 'LIN', 'QDR', 'EXP'",
+    fixed = TRUE)
 
   ## input object
   expect_error(
@@ -19,10 +20,11 @@ test_that("plot_GrowthCurve", {
     object = plot_GrowthCurve(LxTxData[1:2,]),
     regexp = "\\[plot\\_GrowthCurve\\(\\)\\] At least three regeneration points are required!")
 
-  ## wrong argument for mode
+  ## mode
   expect_error(
-    object = plot_GrowthCurve(LxTxData, mode = "fail"),
-    regexp = "\\[plot\\_GrowthCurve\\(\\)\\] Unknown input for argument 'mode'")
+    plot_GrowthCurve(LxTxData, mode = "error"),
+    "[plot_GrowthCurve()] 'mode' should be one of 'interpolation', 'extrapolation'",
+    fixed = TRUE)
 
   ## wrong combination of fit.method and mode
   expect_error(

--- a/tests/testthat/test_plot_NRt.R
+++ b/tests/testthat/test_plot_NRt.R
@@ -14,6 +14,8 @@ test_that("input validation", {
                 "The provided list only contains curve data of the natural signal")
   expect_error(plot_NRt(curves[[1]]@data),
                "The provided matrix only contains curve data of the natural signal")
+  expect_error(plot_NRt(curves, smooth = "error"),
+               "'smooth' should be one of 'none', 'spline', 'rmean'")
 
   data(ExampleData.XSYG, envir = environment())
   obj.mixed <- merge_RLum.Analysis(list(obj, TL.Spectrum))

--- a/tests/testthat/test_plot_RLum.Analysis.R
+++ b/tests/testthat/test_plot_RLum.Analysis.R
@@ -38,8 +38,8 @@ test_that("input validation", {
   expect_match(warnings, all = FALSE, fixed = TRUE,
                "max('ylim') > y-value range for curve #1, reset to maximum")
 
-  expect_warning(plot_RLum.Analysis(c1, curve.transformation = "error"),
-                 "Function for 'curve.transformation' is unknown")
+  expect_error(plot_RLum.Analysis(c1, curve.transformation = "error"),
+               "'curve.transformation' should be one of 'CW2pLM', 'CW2pLMi'")
   expect_warning(.warningCatcher(
       plot_RLum.Analysis(temp, subset = list(recordType = "TL"),
                          norm = TRUE, log = "y")),

--- a/tests/testthat/test_plot_RLum.Data.Image.R
+++ b/tests/testthat/test_plot_RLum.Data.Image.R
@@ -1,16 +1,19 @@
-test_that("Test image plotting", {
+## create dataset to test
+image <- as(array(rnorm(1000), dim = c(10,10,10)), "RLum.Data.Image")
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
-    ## create dataset to test
-    image <- as(array(rnorm(1000), dim = c(10,10,10)), "RLum.Data.Image")
+  expect_error(plot_RLum.Data.Image("image"),
+               "[plot_RLum.Data.Image()] Input object is not of type RLum.Data.Image",
+               fixed = TRUE)
+  expect_error(plot_RLum.Data.Image(image, plot.type = "error"),
+               "[plot_RLum.Data.Image()] 'plot.type' should be one of 'plot.raster'",
+               fixed = TRUE)
+})
 
-    ## crash function ----
-    ### wrong input -----
-    expect_error(plot_RLum.Data.Image("image"),
-                 "\\[plot_RLum.Data.Image\\(\\)\\] Input object is not of type RLum.Data.Image.")
-    expect_error(plot_RLum.Data.Image(image, plot.type = "error"),
-                 "\\[plot_RLum.Data.Image\\(\\)\\] Unknown plot type.")
-
+test_that("Test image plotting", {
+  testthat::skip_on_cran()
 
     ## plot.raster ---
     expect_silent(plot_RLum.Data.Image(image, plot.type = "plot.raster"))

--- a/tests/testthat/test_read_SPE2R.R
+++ b/tests/testthat/test_read_SPE2R.R
@@ -23,7 +23,7 @@ test_that("input validation", {
                  "Error: File does not exist, NULL returned")
   expect_error(read_SPE2R(file.path(github.url, "SPEfile.SPE"),
                           output.object = "error"),
-               "'output.object' not supported, valid options are")
+               "'output.object' should be one of 'RLum.Data.Image'")
 
   SW({
   expect_message(expect_null(read_SPE2R("http://httpbun.org/status/404")),

--- a/tests/testthat/test_scale_GammaDose.R
+++ b/tests/testthat/test_scale_GammaDose.R
@@ -122,34 +122,18 @@ test_that("check input data", {
   },
   "Impossible! Sample offset larger than the target-layer's thickness!"
   )
-  expect_error({
-    scale_GammaDose(d, conversion_factors = c("a", "b"), plot = FALSE, verbose = TRUE)
-  },
-  "must be an object of length 1 and of class 'character'."
-  )
-  expect_error({
-    scale_GammaDose(d, conversion_factors = 1, plot = FALSE, verbose = TRUE)
-  },
-  "must be an object of length 1 and of class 'character'."
-  )
-  expect_error({
-    scale_GammaDose(d, conversion_factors = "HansGuenter2020", plot = FALSE, verbose = TRUE)
-  },
-  "Invalid 'conversion_factors'. Valid options:"
-  )
-  expect_error({
-    scale_GammaDose(d, fractional_gamma_dose = c("a", "b"), plot = FALSE, verbose = TRUE)
-  },
-  "must be an object of length 1 and of class 'character'."
-  )
-  expect_error({
-    scale_GammaDose(d, fractional_gamma_dose = 1, plot = FALSE, verbose = TRUE)
-  },
-  "must be an object of length 1 and of class 'character'."
-  )
-  expect_error({
-    scale_GammaDose(d, fractional_gamma_dose = "momgetthecameraiamontheinternet1995", plot = FALSE, verbose = TRUE)
-  },
-  "Invalid 'fractional_gamma_dose'. Valid options:"
-  )
+
+  expect_error(scale_GammaDose(d, conversion_factors = c("a", "b")),
+               "'conversion_factors' contains multiple values but not all of")
+  expect_error(scale_GammaDose(d, conversion_factors = 1),
+               "'conversion_factors' should be one of 'Cresswelletal2018'")
+  expect_error(scale_GammaDose(d, conversion_factors = "HansGuenter2020"),
+               "'conversion_factors' should be one of 'Cresswelletal2018'")
+
+  expect_error(scale_GammaDose(d, fractional_gamma_dose = c("a", "b")),
+               "'fractional_gamma_dose' contains multiple values but not all")
+  expect_error(scale_GammaDose(d, fractional_gamma_dose = 1),
+               "'fractional_gamma_dose' should be one of 'Aitken1985'")
+  expect_error(scale_GammaDose(d, fractional_gamma_dose = "error"),
+               "'fractional_gamma_dose' should be one of 'Aitken1985'")
 })

--- a/tests/testthat/test_template_DRAC.R
+++ b/tests/testthat/test_template_DRAC.R
@@ -37,9 +37,9 @@ test_that("Check template creation ", {
   expect_warning(template_DRAC(nrow = 5001, notification = FALSE),
                  regexp = "\\[template_DRAC\\(\\)\\] More than 5000 datasets might not be supported!")
   expect_error(template_DRAC(preset = "does_not_exist"),
-               "Invalid preset")
+               "'preset' should be one of 'quartz_coarse', 'quartz_fine'")
   expect_error(template_DRAC(preset = c("does_not_exist", "neither_this_one")),
-               "'preset' must be a 'character' of length 1")
+               "'preset' contains multiple values but not all of them match 'choices'")
   expect_error(template_DRAC(preset = 999),
-               "'preset' must be a 'character' of length 1")
+               "'preset' should be one of 'quartz_coarse', 'quartz_fine'")
 })

--- a/tests/testthat/test_use_DRAC.R
+++ b/tests/testthat/test_use_DRAC.R
@@ -1,3 +1,29 @@
+test_that("input validation", {
+  testthat::skip_on_cran()
+
+  ## wrong file name
+  expect_error(use_DRAC("error"),
+               "[use_DRAC()] It seems that the file doesn't exist",
+               fixed = TRUE)
+  expect_error(use_DRAC(NA),
+               "The provided data object is not a valid DRAC template")
+
+  ## exceed allowed limit
+  SW({
+  expect_warning(input <- template_DRAC(preset = "DRAC-example_quartz",
+                                        nrow = 5001),
+                 "More than 5000 datasets might not be supported")
+  })
+  expect_error(use_DRAC(input), "The limit of allowed datasets is 5000")
+
+  ## citation style
+  expect_error(use_DRAC(template_DRAC(preset = "DRAC-example_quartz",
+                                      notification = FALSE),
+                        citation_style = "error"),
+               "[use_DRAC()] 'citation_style' should be one of",
+               fixed = TRUE)
+})
+
 ##Full check
 test_that("Test DRAC", {
   testthat::skip_on_cran()
@@ -61,18 +87,4 @@ test_that("Test DRAC", {
  fake.xls <- system.file("extdata/clippy.xls", package = "readxl")
  expect_error(use_DRAC(fake.xls),
               "you are not using the original DRAC v1.1 XLSX template")
-
- ## crash function
- ## wrong file name
- expect_error(use_DRAC("error"), "\\[use_DRAC\\(\\)\\] It seems that the file doesn't exist!")
- expect_error(use_DRAC(NA),
-              "The provided data object is not a valid DRAC template")
-
- ## exceed allowed limit
- SW({
- expect_warning(input <- template_DRAC(preset = "DRAC-example_quartz",
-                                       nrow = 5001),
-                "More than 5000 datasets might not be supported")
- })
- expect_error(use_DRAC(input), "The limit of allowed datasets is 5000!")
 })

--- a/tests/testthat/test_verify_SingleGrainData.R
+++ b/tests/testthat/test_verify_SingleGrainData.R
@@ -1,12 +1,18 @@
-test_that("Various function test", {
+data(ExampleData.XSYG, envir = environment())
+object <- get_RLum(OSL.SARMeasurement$Sequence.Object,
+                   recordType = "OSL (UVVIS)", drop = FALSE)
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
   expect_error(verify_SingleGrainData("test"),
                "Input type 'character' is not allowed for this function")
+  expect_error(verify_SingleGrainData(object, cleanup_level = "error"),
+               "'cleanup_level' should be one of 'aliquot', 'curve'")
+})
 
-  data(ExampleData.XSYG, envir = environment())
-  object <- get_RLum(
-    OSL.SARMeasurement$Sequence.Object, recordType = "OSL (UVVIS)", drop = FALSE)
+test_that("check functionality", {
+  testthat::skip_on_cran()
 
   ## RLum.Analysis object
   expect_warning(output <- verify_SingleGrainData(object),


### PR DESCRIPTION
This adds the new internal function `.match_args()`, which allows us to validate character arguments against a set of available choices. This is largely inspired by `base::match.arg()`, but the latter requires that all choices are specified in the function formal arguments, which Luminescence almost never does.

Our own version returns a slightly better error message:
```R
## base::match.arg()
Error in match.arg(cleanup_level) : 
  'arg' should be one of “aliquot”, “curve”

## .match_args()
Error: [verify_SingleGrainData()] 'cleanup_level' should be one of 'aliquot', 'curve' 
```
and it also accepts `NULL` if `null.ok = TRUE`.

Fixes #146.