### PR TITLE
Remove the dependency on the zoo package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,6 @@ Imports:
     shape (>= 1.4.6),
     parallel,
     XML (>= 3.99-0.16),
-    zoo (>= 1.8-12)
 Suggests:
     spelling (>= 2.3.0),
     plotly (>= 4.10.4),

--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -768,8 +768,7 @@ setMethod("names_RLum",
 #' @describeIn RLum.Analysis
 #'
 #' Smoothing of `RLum.Data` objects contained in this `RLum.Analysis` object
-#' [zoo::rollmean] or [zoo::rollmedian][zoo::rollmean]. In particular the internal
-#' function `.smoothing` is used.
+#' using the internal function `.smoothing`.
 #'
 #' @param ... further arguments passed to underlying methods
 #'

--- a/R/RLum.Data.Curve-class.R
+++ b/R/RLum.Data.Curve-class.R
@@ -446,7 +446,7 @@ setMethod(f = "bin_RLum.Data",
 
 # smooth_RLum() -------------------------------------------------------------------------------
 #' @describeIn RLum.Data.Curve
-#' Smoothing of RLum.Data.Curve objects using the function [zoo::rollmean] or [zoo::rollmedian][zoo::rollmean].
+#' Smoothing of RLum.Data.Curve objects using a rolling mean or median.
 #' In particular the internal function `.smoothing` is used.
 #'
 #' @param k [`smooth_RLum`]; [integer] (*with default*):
@@ -491,4 +491,3 @@ setMethod(
 
     }
  )
-

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -114,33 +114,33 @@
 #+ .smoothing()      +
 #+++++++++++++++++++++
 
-#' Allows smoothing of data based on the function zoo::rollmean
+#' Allows smoothing of data based on rolling means or medians
 #'
-#' The function just allows a direct and meaningful access to the functionality of the zoo::rollmean()
-#' function. Arguments of the function are only partly valid.
+#' The function just allows a direct and meaningful access to the
+#' functionality of `data.table::frollmean()` and `data.table::frollmedian()`.
+#' Arguments of the function are only partly valid.
 #'
 #' @param x [numeric] (**required**):
 #' the object for which the smoothing should be applied.
 #'
 #' @param k [integer] (*with default*):
-#' window for the rolling mean; must be odd for rollmedian.
-#' If nothing is set k is set automatically
+#' window for the rolling mean. If not set, `k` is set automatically.
 #'
 #' @param fill [numeric] (*with default*):
-#' a vector defining the left and the right hand data
+#' value used to pad the result so to have the same length as the input
 #'
 #' @param align [character] (*with default*):
-#' specifying whether the index of the result should be
-#' left- or right-aligned or centered (default) compared to the rolling window of observations,
-#' allowed `"right"`, `"center"` and `left`
+#' one of `"right"`, `"center"` or `"left"`, specifying whether the index
+#' of the result should be right-aligned (default), centered, or lef-aligned
+#' compared to the rolling window of observations
 #'
 #' @param method [method] (*with default*):
 #' defines which method should be applied for the smoothing: `"mean"` or `"median"`
 #'
 #' @return
-#' Returns the same object as the input and a warning table
+#' Returns the same object as the input
 #'
-#' @section Function version: 0.1.1
+#' @section Function version: 0.2
 #'
 #' @author Sebastian Kreutzer, Institute of Geography, Heidelberg University (Germany)
 #'
@@ -157,26 +157,25 @@
   fill = NA,
   align = "right",
   method = "mean") {
+  .set_function_name(".smoothing")
+  on.exit(.unset_function_name(), add = TRUE)
+
+  .match_args(align, c("right", "center", "left"))
+  .match_args(method, c("mean", "median"))
 
   ##set k
   if (is.null(k)){
    k <- ceiling(length(x) / 100)
-   if(method == "median" && k %%2 ==0)
-     k <- k + 1
   }
 
   ##smooth data
   if(method == "mean"){
-    zoo::rollmean(x, k = k, fill = fill, align = align)
+    data.table::frollmean(x, n = k, fill = fill, align = align)
 
   }else if(method == "median"){
-    zoo::rollmedian(x, k = k, fill = fill, align = align)
-
-  }else{
-    stop("[Luminescence:::.smoothing()] Unvalid input for 'method'!")
-
+    data.table::frollapply(x, n = k, FUN = "median",
+                           fill = fill, align = align)
   }
-
 }
 
 

--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -21,8 +21,8 @@
 #'
 #' @param smooth [character] (*with default*):
 #' apply data smoothing. If `"none"` (default), no data smoothing is applied.
-#' Use `"rmean"` to calculate the rolling where `k`
-#' determines the width of the rolling window (see [zoo::rollmean]). `"spline"`
+#' Use `"rmean"` to calculate the rolling mean, where `k` determines the
+#' width of the rolling window (see [data.table::frollmean]). `"spline"`
 #' applies a smoothing spline to each curve (see [stats::smooth.spline])
 #'
 #' @param k [integer] (*with default*):
@@ -181,8 +181,12 @@ plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k
     NR <- lapply(NR, function(nr) { smooth.spline(nr)$y })
   }
   if (smooth[1] == "rmean") {
-    NR <- lapply(NR, function(nr) { zoo::rollmean(nr, k) })
-    time <- zoo::rollmean(time, k)
+    ## here we'd like to use the smoothed values with no fill: as .smoothing()
+    ## relies on data.table::frollmean(), the only way to remove the fill
+    ## is by setting `fill = NA` (which is already the default) and then
+    ## omitting the NA values
+    NR <- lapply(NR, function(nr) na.omit(.smoothing(nr, k)))
+    time <- na.omit(.smoothing(time, k))
   }
 
   # normalise data

--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -725,8 +725,9 @@ plot_RLum.Analysis <- function(
         if(plot.settings$smooth[[k]]){
 
           k_factor <- ceiling(length(temp.data.list[[n]][, 2])/100)
-          temp.data.list[[n]][, 2] <- zoo::rollmean(temp.data.list[[n]][, 2],
-                                            k = k_factor, fill = NA)
+          temp.data.list[[n]][, 2] <- .smoothing(temp.data.list[[n]][, 2],
+                                                 k = k_factor, fill = NA,
+                                                 align = "center")
         }
 
         ##remove 0 values if plotted on a log-scale

--- a/R/plot_RLum.Data.Curve.R
+++ b/R/plot_RLum.Data.Curve.R
@@ -38,7 +38,7 @@
 #' modes `"max"`, `"min"` and `"huot"` for a background corrected normalisation, see details.
 #'
 #' @param smooth [logical] (*with default*):
-#' provides an automatic curve smoothing based on [zoo::rollmean]
+#' provides automatic curve smoothing based on the internal function `.smoothing`
 #'
 #' @param ... further arguments and graphical parameters that will be passed
 #' to the `plot` function
@@ -203,8 +203,7 @@ plot_RLum.Data.Curve<- function(
     ##smooth
     if(smooth){
       k <- ceiling(length(object@data[, 2])/100)
-      object@data[, 2] <- zoo::rollmean(object@data[, 2],
-                                        k = k, fill = NA)
+      object@data[, 2] <- .smoothing(object@data[, 2], k = k, align = "center")
     }
 
     ##plot curve

--- a/man/RLum.Analysis-class.Rd
+++ b/man/RLum.Analysis-class.Rd
@@ -178,8 +178,7 @@ Currently supported objects are: RLum.Data.Curve and RLum.Data.Spectrum
 \item \code{names_RLum(RLum.Analysis)}: Returns the names of the \linkS4class{RLum.Data} objects objects (same as shown with the show method)
 
 \item \code{smooth_RLum(RLum.Analysis)}: Smoothing of \code{RLum.Data} objects contained in this \code{RLum.Analysis} object
-\link[zoo:rollmean]{zoo::rollmean} or \link[zoo:rollmean]{zoo::rollmedian}. In particular the internal
-function \code{.smoothing} is used.
+using the internal function \code{.smoothing}.
 
 }}
 \section{Slots}{
@@ -200,7 +199,7 @@ Objects can be created by calls of the form \code{set_RLum("RLum.Analysis", ...)
 }
 
 \section{Class version}{
- 0.4.16
+ 0.4.17
 }
 
 \examples{

--- a/man/RLum.Data.Curve-class.Rd
+++ b/man/RLum.Data.Curve-class.Rd
@@ -136,7 +136,7 @@ value time/temperature of the curve (corresponding to the stimulation length)
 
 \item \code{bin_RLum.Data(RLum.Data.Curve)}: Allows binning of specific objects
 
-\item \code{smooth_RLum(RLum.Data.Curve)}: Smoothing of RLum.Data.Curve objects using the function \link[zoo:rollmean]{zoo::rollmean} or \link[zoo:rollmean]{zoo::rollmedian}.
+\item \code{smooth_RLum(RLum.Data.Curve)}: Smoothing of RLum.Data.Curve objects using a rolling mean or median.
 In particular the internal function \code{.smoothing} is used.
 
 }}

--- a/man/plot_NRt.Rd
+++ b/man/plot_NRt.Rd
@@ -23,8 +23,8 @@ logarithmic axes (\code{c("x", "y", "xy")}).}
 
 \item{smooth}{\link{character} (\emph{with default}):
 apply data smoothing. If \code{"none"} (default), no data smoothing is applied.
-Use \code{"rmean"} to calculate the rolling where \code{k}
-determines the width of the rolling window (see \link[zoo:rollmean]{zoo::rollmean}). \code{"spline"}
+Use \code{"rmean"} to calculate the rolling mean, where \code{k} determines the
+width of the rolling window (see \link[data.table:froll]{data.table::frollmean}). \code{"spline"}
 applies a smoothing spline to each curve (see \link[stats:smooth.spline]{stats::smooth.spline})}
 
 \item{k}{\link{integer} (\emph{with default}):

--- a/man/plot_RLum.Data.Curve.Rd
+++ b/man/plot_RLum.Data.Curve.Rd
@@ -25,7 +25,7 @@ highest count value ('default'). Alternatively, the function offers the
 modes \code{"max"}, \code{"min"} and \code{"huot"} for a background corrected normalisation, see details.}
 
 \item{smooth}{\link{logical} (\emph{with default}):
-provides an automatic curve smoothing based on \link[zoo:rollmean]{zoo::rollmean}}
+provides automatic curve smoothing based on the internal function \code{.smoothing}}
 
 \item{...}{further arguments and graphical parameters that will be passed
 to the \code{plot} function}

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -40,14 +40,13 @@ test_that("Test internals", {
 
   # .smoothing ----------------------------------------------------------------------------------
   expect_silent(Luminescence:::.smoothing(runif(100), k = 5, method = "median"))
-  suppressWarnings( # suppress second warning: number of items to replace
-                    #   is not a multiple of replacement length
-  expect_warning(.smoothing(runif(100), k = 4, method = "median"),
-                 "'k' must be odd")
-  )
   expect_silent(.smoothing(runif(200), method = "median"))
   expect_silent(.smoothing(runif(100), k = 4, method = "mean"))
-  expect_error(Luminescence:::.smoothing(runif(100), method = "test"))
+  expect_silent(.smoothing(runif(100), k = 4, method = "median"))
+  expect_error(.smoothing(runif(100), method = "error"),
+               "'method' should be one of 'mean', 'median'")
+  expect_error(.smoothing(runif(100), align = "error"),
+               "'align' should be one of 'right', 'center', 'left'")
 
   # fancy_scientific ()--------------------------------------------------------------------------
   plot(seq(1e10, 1e20, length.out = 10),1:10, xaxt = "n")


### PR DESCRIPTION
`zoo::rollmean()` and `zoo::rollmedian()` can be almost directly replaced by `data.table::frollmean()` and `data.table::frollapply()`. The main difference between the two sets of functions is in the default arguments:

- `k` in `rollmedian()` has to be odd for zoo (it throws a warning otherwise), but can be even for data.table
- `align` defaults to "center" for zoo, but to "right" for data.table
- `fill` defaults to NULL for zoo (meaning no filling, so the result vector can be shorter than the input), but to NA for data.table

Given that `.smoothing()` (the main user of these functions) always sets explicitly these values, there is no actual difference between the behaviour of the two packages when called via `.smoothing()`.

However, to replicate the existing behaviour, a few direct calls to `zoo::rollmean()` with no `align` argument specified have been replaced by calls to `.smoothing(..., align = "center")`; and one direct call to `zoo::rollmean()` with no `fill` argument specified has been replaced by `na.omit(.smoothing(..., fill = NA))` in order to produce a vector with no fill.

I've also used the following checks to ensure that results are consistent in a variety of settings (162 tests in total):
```R
test_that("data.table::frollmean() matches zoo::rollmean()", {
  testthat::skip_on_cran()

  ## even length input
  rr <- runif(100)
  for (n in c(1, 3, 15, 77)) {
    for (align in c("right", "center", "left")) {
      for (fill in c(0, 1, NA)) {
        expect_identical(
            data.table::frollmean(rr, n = n, align = align, fill = fill),
            zoo::rollmean(rr, k = n, align = align, fill = fill),
            label = paste("n = ", n, "align =", align, "fill =", fill)
        )
      }
     }
  }

  ## odd length input
  rr <- runif(103)
  for (n in c(1, 2, 3, 15, 77)) {
    for (align in c("right", "center", "left")) {
      for (fill in c(0, 1, NA)) {
        expect_identical(
            data.table::frollmean(rr, n = n, align = align, fill = fill),
            zoo::rollmean(rr, k = n, align = align, fill = fill),
            label = paste("n = ", n, "align =", align, "fill =", fill)
        )
      }
     }
  }
})

test_that("data.table::frollapply() matches zoo::rollmedian()", {
  testthat::skip_on_cran()

  ## even length input
  rr <- runif(100)
  for (n in c(1, 3, 15, 77)) {
    for (align in c("right", "center", "left")) {
      for (fill in c(0, 1, NA)) {
        expect_identical(
            data.table::frollapply(rr, n = n, FUN = "median",
                                   align = align, fill = fill),
            zoo::rollmedian(rr, k = n, align = align, fill = fill),
            label = paste("n = ", n, "align =", align, "fill =", fill)
        )
      }
    }
  }

  ## odd length input
  rr <- runif(103)
  for (n in c(1, 3, 15, 77)) {
    for (align in c("right", "center", "left")) {
      for (fill in c(0, 1, NA)) {
        expect_identical(
            data.table::frollapply(rr, n = n, FUN = "median",
                                   align = align, fill = fill),
            zoo::rollmedian(rr, k = n, align = align, fill = fill),
            label = paste("n = ", n, "align =", align, "fill =", fill)
        )
      }
    }
  }
})
```
Additional tests that will check that behaviour won't change have already been committed as part of #261.

Fixes #238.