### PR TITLE
Validate the norm argument in plot_RLum.Data.Curve()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -38,6 +38,11 @@ the function returned the `RLum.Data.Curve-class` object *regardless* of the sel
 If a user tried `recordType = "TL"` on an `RLum.Analysis-class` object that contained only a single IRSL curve, the
 function would still return that single IRSL curve instead of an empty element. The reason for this behaviour was a poor attempt to deal with `NA` in the `recordType` name that led to missing values and unexpected behaviour for a logical comparison. Now, before the subset happens, `NA` values in `recordType` are converted to `"NA"` (a character) and the wiggling around that was causing the lousy subsetting was removed. 
 
+### `plot_RLum.Data.Curve()`
+* Argument `norm` is now better validated so that specifying an incorrect
+value returns an error instead of silently skip curve normalisation (#250,
+fixed in #263).
+
 ### `plot_RLum.Data.Spectrum()`
 * Add support for `lphi` and `ltheta` light direction arguments for `plot.type = "persp"`. 
 * Fix the reason for the unclear warning `In col.unique == col :  longer object length is not a multiple of shorter object length`

--- a/man/plot_RLum.Data.Curve.Rd
+++ b/man/plot_RLum.Data.Curve.Rd
@@ -20,9 +20,9 @@ S4 object of class \code{RLum.Data.Curve}}
 use local graphical parameters for plotting, e.g. the plot is shown in one
 column and one row. If \code{par.local = FALSE}, global parameters are inherited.}
 
-\item{norm}{\link{logical} \link{character} (\emph{with default}): allows curve normalisation to the
-highest count value ('default'). Alternatively, the function offers the
-modes \code{"max"}, \code{"min"} and \code{"huot"} for a background corrected normalisation, see details.}
+\item{norm}{\link{logical} \link{character} (\emph{with default}): whether curve
+normalisation should occur (\code{FALSE} by default). Alternatively, the function
+offers modes \code{"max"} (used with \code{TRUE}), \code{"last"} and \code{"huot"}, see details.}
 
 \item{smooth}{\link{logical} (\emph{with default}):
 provides automatic curve smoothing based on the internal function \code{.smoothing}}
@@ -49,7 +49,7 @@ options are supported:
 \code{norm = TRUE} or \code{norm = "max"}: Curve values are normalised to the highest
 count value in the curve
 
-\code{norm = "last"}: Curves values are normalised to the last count value
+\code{norm = "last"}: Curve values are normalised to the last count value
 (this can be useful in particular for radiofluorescence curves)
 
 \code{norm = "huot"}: Curve values are normalised as suggested by Sébastien Huot

--- a/tests/testthat/test_plot_RLum.Data.Curve.R
+++ b/tests/testthat/test_plot_RLum.Data.Curve.R
@@ -1,26 +1,30 @@
-test_that("Test the basic plot functionality", {
+## create dataset
+data(ExampleData.CW_OSL_Curve, envir = environment())
+temp <- as(ExampleData.CW_OSL_Curve, "RLum.Data.Curve")
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
-  ## create dataset
-  #load Example data
-  data(ExampleData.CW_OSL_Curve, envir = environment())
-  temp <- as(ExampleData.CW_OSL_Curve, "RLum.Data.Curve")
+  expect_error(plot_RLum.Data.Curve("error"),
+               "Input object is not of type RLum.Data.Curve")
+  expect_error(plot_RLum.Data.Curve(temp, norm = "error"),
+               "'norm' should be one of 'max', 'last', 'huot'")
+
   temp_NA <- temp
   temp_NA@data[] <- suppressWarnings(NA_real_)
-
-  ## break function
-  expect_error(plot_RLum.Data.Curve("temp"), regexp = "Input object is not of type RLum.Data.Curve")
-
-  ## trigger warning
   expect_warning(expect_null(plot_RLum.Data.Curve(temp_NA)),
                  "Curve contains only NA-values, nothing plotted")
-  expect_warning(plot_RLum.Data.Curve(set_RLum("RLum.Data.Curve"), norm = TRUE), "Normalisation led to Inf or NaN values. Values replaced by 0")
+  expect_warning(plot_RLum.Data.Curve(set_RLum("RLum.Data.Curve"), norm = TRUE),
+                 "Normalisation led to Inf or NaN values. Values replaced by 0")
+})
+
+test_that("check functionality", {
+  testthat::skip_on_cran()
 
   ## run function with various conditions
   expect_silent(plot_RLum.Data.Curve(temp))
   expect_silent(plot_RLum.Data.Curve(temp, norm = TRUE))
   expect_silent(plot_RLum.Data.Curve(temp, norm = "max"))
-  expect_silent(plot_RLum.Data.Curve(temp, norm = "min"))
   expect_silent(plot_RLum.Data.Curve(temp, norm = "last"))
   expect_silent(plot_RLum.Data.Curve(temp, norm = "huot"))
   expect_silent(plot_RLum.Data.Curve(temp, smooth = TRUE))


### PR DESCRIPTION
This now returns an error when an incorrect value is provided instead of silently skipping curve normalisation. Docs have been also clarified a bit. Fixes #250.