### PR TITLE
Increase coverage in analyse_pIRIRSequence.R

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -22,9 +22,10 @@ header-includes:
 ### `analyse_pIRIRSequence()`
 * The function crashed with a object merge error if run in a loop because of a `merge_RLum()` error. This
 was caused by a regression while implementing the `n_N` calculation in `plot_GrowthCurve()`. Potentially
-affected was also `analyse_SAR.CWOSL()`. 
-* The functions tries to be more soft on the user when plot output on a too small device is attempted. Now 
-it shows a warning with instructions and set `plot = FALSE`. This should prevent "Figure margins too large" errors. 
+affected was also `analyse_SAR.CWOSL()`.
+* The function now shows a warning and sets `plot = FALSE` when option
+`plot.single = TRUE` is set but the device size is too small. This should
+prevent "Figure margins too large" errors.
 * The function will not crash anymore during the plotting in another edge case related to single grain data. 
 
 ### `analyse_SAR.TL()`

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -286,11 +286,12 @@ analyse_pIRIRSequence <- function(
 
   ## CHECK FOR PLOT ...we safe users the pain by checking whether plot device has the
   ## required size.
-    if(plot[1] & all(grDevices::dev.size("in") < 20)) {
+    if (plot[1] && plot.single && all(grDevices::dev.size("in") < 20)) {
       plot <- FALSE
-      .throw_warning("Argument 'plot' reset to 'FALSE'. The smallest plot size required is 20 x 20 in!
-                        -> Consider plotting via pdf(..., height = 20, width = 20).")
-
+      .throw_warning("Argument 'plot' reset to 'FALSE'. The smallest plot ",
+                     "size required is 20 x 20 in.\n",
+                     "Consider plotting via `pdf(..., height = 20, width = 20)` ",
+                     "or setting `plot.single = FALSE`")
     }
 
 # Deal with extra arguments -------------------------------------------------------------------

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -183,21 +183,20 @@ analyse_pIRIRSequence <- function(
   on.exit(.unset_function_name(), add = TRUE)
 
   if (missing("object"))
-    stop("[analyse_pIRIRSequence()] No value set for 'object'!")
+    .throw_error("No value set for 'object'")
 
 # SELF CALL -----------------------------------------------------------------------------------
  if(is.list(object)){
     ##make live easy
     if(missing("signal.integral.min")){
       signal.integral.min <- 1
-      warning("[analyse_pIRIRSequence()] 'signal.integral.min' missing, set to 1", call. = FALSE)
+      .throw_warning("'signal.integral.min' missing, set to 1")
     }
 
     if(missing("signal.integral.max")){
       signal.integral.max <- 2
-      warning("[analyse_pIRIRSequence()] 'signal.integral.max' missing, set to 2", call. = FALSE)
+      .throw_warning("'signal.integral.max' missing, set to 2")
     }
-
 
     ##now we have to extend everything to allow list of arguments ... this is just consequent
     signal.integral.min <- rep(list(signal.integral.min), length = length(object))
@@ -229,12 +228,10 @@ analyse_pIRIRSequence <- function(
         main_list <- as.list(main_list)
 
       }
-
     }
 
     ##run analysis
     temp <- lapply(1:length(object), function(x){
-
       analyse_pIRIRSequence(object[[x]],
                         signal.integral.min = signal.integral.min[[x]],
                         signal.integral.max = signal.integral.max[[x]],
@@ -267,8 +264,7 @@ analyse_pIRIRSequence <- function(
   ##GENERAL
     ##INPUT OBJECTS
     if(is(object, "RLum.Analysis")==FALSE){
-      stop("[analyse_pIRIRSequence()] Input object is not of type 'RLum.Analyis'!",
-           call. = FALSE)
+      .throw_error("Input object is not of type 'RLum.Analysis'")
     }
 
     ##CHECK ALLOWED VALUES IN SEQUENCE STRUCTURE
@@ -280,8 +276,8 @@ analyse_pIRIRSequence <- function(
       collapse = ", ")
 
     if(temp.collect.invalid.terms != ""){
-      stop("[analyse_pIRIRSequence()] ",
-        temp.collect.invalid.terms, " not allowed in 'sequence.structure'!")
+      .throw_error("'", temp.collect.invalid.terms,
+                   "' not allowed in 'sequence.structure'")
     }
 
   ## CHECK FOR PLOT ...we safe users the pain by checking whether plot device has the
@@ -329,14 +325,9 @@ analyse_pIRIRSequence <- function(
         drop = FALSE
       )
 
-  ##compile warning message
-  temp.sequence.rm.warning <- paste(
-    temp.sequence.structure[temp.sequence.rm.id, "recordType"], collapse = ", ")
-
-  temp.sequence.rm.warning <- paste(
-    "Record types are unrecognised and have been removed:", temp.sequence.rm.warning)
-
-  warning(temp.sequence.rm.warning, call. = FALSE)
+  .throw_warning("The following unrecognised record types have been removed: ",
+                 paste(temp.sequence.structure[temp.sequence.rm.id,
+                                               "recordType"], collapse = ", "))
   }
 
   ##(2) Apply user sequence structure
@@ -346,8 +337,8 @@ analyse_pIRIRSequence <- function(
 
     ##try to account for a very common mistake
     if(any(grepl(sequence.structure, pattern = "TL", fixed = TRUE)) && !any(grepl(temp.sequence.structure[["recordType"]], pattern = "TL", fixed = TRUE))){
-      warning("[analyse_pIRIRSequence()] Your sequence does not contain 'TL' curves, trying to adapt 'sequence.structure' for you ...",
-              call. = FALSE, immediate. = TRUE)
+      .throw_warning("Your sequence does not contain 'TL' curves, trying ",
+                     "to adapt 'sequence.structure' for you ...")
       sequence.structure <- sequence.structure[!grepl(sequence.structure, pattern = "TL", fixed = TRUE)]
     }
 
@@ -359,9 +350,9 @@ analyse_pIRIRSequence <- function(
       sequence.structure, nrow(temp.sequence.structure)/2/length(sequence.structure))
 
   }else{
-    try(stop("[analyse_pIRIRSequence()] Number of records is not a multiple of the defined sequence structure! NULL returned!", call. = FALSE))
+    message("[analyse_pIRIRSequence()] Error: The number of records is not a ",
+            "multiple of the defined sequence structure, NULL returned")
     return(NULL)
-
   }
 
   ##remove values that have been excluded
@@ -384,8 +375,8 @@ analyse_pIRIRSequence <- function(
       sequence.structure, nrow(temp.sequence.structure)/2/length(temp.sequence.structure))
 
     ##print warning message
-    warning("[analyse_pIRIRSequence()] ", length(temp.sequence.rm.id), " records have been removed due to EXCLUDE!", call. = FALSE)
-
+    .throw_warning(length(temp.sequence.rm.id),
+                   " records have been removed due to EXCLUDE")
   }
 
 ##============================================================================##
@@ -547,7 +538,6 @@ analyse_pIRIRSequence <- function(
 
    }else{
       temp.plot.single  <- c(2,4,6)
-
    }
 
     ##start analysis
@@ -612,10 +602,7 @@ analyse_pIRIRSequence <- function(
 
       } else{
         temp.results.final <- temp.results
-
       }
-
-
   }
 
 ##============================================================================##
@@ -816,7 +803,6 @@ if(plot){
            y = 15,
            pch = i,
            col = i)
-
   }
   }#endif
 
@@ -837,7 +823,6 @@ if(plot){
               y = 5,
               pch = i,
               col = i)
-
    }
 
    ##add 0 value
@@ -862,5 +847,4 @@ if(plot){
 ##============================================================================##
 
   return(temp.results.final)
-
 }

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -65,9 +65,9 @@ test_that("check plot stuff", {
     main = "Pseudo pIRIR data set based on quartz OSL",
     plot = TRUE,
     plot.single = TRUE,
-    verbose = FALSE
-  ), regexp = "\\[analyse\\_pIRIRSequence\\(\\)\\] Argument 'plot' reset to 'FALSE'. The smallest plot size required is 20 x 20 in!")
-
+    verbose = FALSE),
+    "[analyse_pIRIRSequence()] Argument 'plot' reset to 'FALSE'",
+    fixed = TRUE)
 })
 
 test_that("input validation", {

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -74,25 +74,74 @@ test_that("input validation", {
   expect_error(analyse_pIRIRSequence(),
                "No value set for 'object'")
   expect_error(analyse_pIRIRSequence("test"),
-               "Input object is not of type 'RLum.Analyis'")
+               "Input object is not of type 'RLum.Analysis'")
   expect_error(analyse_pIRIRSequence(list("test"),
                                      signal.integral.min = 1,
                                      signal.integral.max = 2,
                                      background.integral.min = 900,
                                      background.integral.max = 1000),
-               "Input object is not of type 'RLum.Analyis'")
+               "Input object is not of type 'RLum.Analysis'")
+  expect_error(analyse_pIRIRSequence(object,
+                                     signal.integral.min = 1,
+                                     signal.integral.max = 2,
+                                     background.integral.min = 900,
+                                     background.integral.max = 1000,
+                                     sequence.structure = "error"),
+               "'error' not allowed in 'sequence.structure'")
 
   SW({
   expect_warning(analyse_pIRIRSequence(list(object),
                                        signal.integral.max = 2,
                                        background.integral.min = 900,
-                                       background.integral.max = 1000),
+                                       background.integral.max = 1000,
+                                       plot = FALSE),
                  "'signal.integral.min' missing, set to 1")
   expect_warning(analyse_pIRIRSequence(list(object),
                                        signal.integral.min = 1,
                                        background.integral.min = 900,
-                                       background.integral.max = 1000),
+                                       background.integral.max = 1000,
+                                       plot = FALSE),
                  "'signal.integral.max' missing, set to 2")
+  expect_warning(analyse_pIRIRSequence(list(object),
+                                       signal.integral.min = 1,
+                                       signal.integral.max = 2,
+                                       background.integral.min = 900,
+                                       background.integral.max = 1000,
+                                       sequence.structure = c("TL", "IRSL",
+                                                              "EXCLUDE"),
+                                       plot = FALSE),
+                 "14 records have been removed due to EXCLUDE")
+
+  expect_message(expect_null(
+      analyse_pIRIRSequence(list(object),
+                            signal.integral.min = 1,
+                            signal.integral.max = 2,
+                            background.integral.min = 900,
+                            background.integral.max = 1000,
+                            sequence.structure = c("TL", "pseudoIRSL1"),
+                            plot = FALSE)),
+      "The number of records is not a multiple of the defined sequence structure")
+
+  object.warn <- object
+  for (i in 1:6) object.warn@records[[i]]@recordType <- "error"
+  expect_warning(analyse_pIRIRSequence(object.warn,
+                                       main = "Title",
+                                       signal.integral.min = 1,
+                                       signal.integral.max = 2,
+                                       background.integral.min = 900,
+                                       background.integral.max = 1000,
+                                       plot = FALSE),
+                 "The following unrecognised record types have been removed: error")
+
+  object.noTL <- subset(object, recordType != "TL")
+  expect_warning(analyse_pIRIRSequence(list(object.noTL),
+                                       main = "Title",
+                                       signal.integral.min = 1,
+                                       signal.integral.max = 2,
+                                       background.integral.min = 900,
+                                       background.integral.max = 1000,
+                                       plot = FALSE),
+                 "Your sequence does not contain 'TL' curves")
   })
 })
 
@@ -103,12 +152,6 @@ test_that("check class and length of output", {
     expect_equal(length(results), 4)
     expect_s3_class(results$LnLxTnTx.table, "data.frame")
     expect_s3_class(results$rejection.criteria, "data.frame")
-
-
-})
-
-test_that("check output", {
-   testthat::skip_on_cran()
 
    expect_equal(round(sum(results$data[1:2, 1:4]), 0),7584)
    expect_equal(round(sum(results$rejection.criteria$Value), 2),3338.69)


### PR DESCRIPTION
The function doesn't skip plotting anymore if the device size is too small but `plot.single = FALSE`. This recovers the coverage lost in `analyse_pIRIRSequence.R` and adds some more tests to further increase it. Fixes #253.
