### PR TITLE
Fix crash in analyse_FadingMeasurement() with BIN version older than 05

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -30,6 +30,11 @@ from XLS files by Excel or similar applications, or by reading them with
 * Argument `XLS_file` has been replaced by `CSV_file` and, as mentioned
 above, the function now only accepts CSV files as input (#237, fixed in #270).
 
+### `analyse_FadingMeasurement()`
+* The function now checks for the version of the BIN-file that originated the
+`RLum.Analysis` given as input, and reports a message if a version older than 05
+was used (#281, fixed in #282).
+
 ### `analyse_pIRIRSequence()`
 * The function crashed with a object merge error if run in a loop because of a `merge_RLum()` error. This
 was caused by a regression while implementing the `n_N` calculation in `plot_GrowthCurve()`. Potentially

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -279,6 +279,11 @@ analyse_FadingMeasurement <- function(
 
       ##assign object, unlist and drop it
       object_clean <- unlist(get_RLum(object))
+      bin.version <- object_clean[[1]]@info$VERSION
+      if (as.integer(bin.version) < 5) {
+        .throw_error("BIN-file has version ", bin.version,
+                     ", but only versions from 05 on are supported")
+      }
 
       ##set TIMESINCEIRR vector
       TIMESINCEIRR <- vapply(object_clean, function(o){
@@ -306,13 +311,11 @@ analyse_FadingMeasurement <- function(
         }else{
           object_clean[TIMESINCEIRR < 0] <- NULL
           TIMESINCEIRR <- TIMESINCEIRR[!TIMESINCEIRR < 0]
-
         }
 
         ##return warning
         .throw_warning(rm_records, " records 'time since irradiation' value removed from the dataset")
         rm(rm_records)
-
       }
 
       ##set irradiation times

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -18,7 +18,6 @@ test_that("input validation", {
   ## stop t_star
   expect_error(analyse_FadingMeasurement(fading_data, t_star = "error"),
                "'t_star' should be one of 'half', 'half_complex', 'end' or a function")
-
 })
 
 test_that("general test", {
@@ -145,4 +144,13 @@ test_that("test XSYG file fading data", {
                                            structure = c("Lx", "error")),
                  "Nothing to combine, object contains a single curve")
   })
+})
+
+test_that("test BIN file while fading data", {
+  testthat::skip_on_cran()
+
+  data(ExampleData.BINfileData, envir = environment())
+  d1 <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
+  expect_error(analyse_FadingMeasurement(d1),
+               "BIN-file has version 03, but only versions from 05 on are supported")
 })


### PR DESCRIPTION
We stop early if the `RLum.Analysis` input object originated from a BIN-file with version older than 05, as that's the version that introduced the `TIMESINCEIRR` field being used in the function.

Fixes #281.