### PR TITLE
Fix crash in analyse_FadingMeasurement() on an RLum.Analysis object with plot = TRUE

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -32,8 +32,10 @@ above, the function now only accepts CSV files as input (#237, fixed in #270).
 
 ### `analyse_FadingMeasurement()`
 * The function now checks for the version of the BIN-file that originated the
-`RLum.Analysis` given as input, and reports a message if a version older than 05
-was used (#281, fixed in #282).
+`RLum.Analysis` given as input, and reports a message if a version older than
+5 was used (#281, fixed in #282).
+* The function doesn't crash anymore on some `RLum.Analysis` input files
+(#283, fixed in #288).
 
 ### `analyse_pIRIRSequence()`
 * The function crashed with a object merge error if run in a loop because of a `merge_RLum()` error. This

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -652,7 +652,7 @@ analyse_FadingMeasurement <- function(
             combine = length(records) > 1,
             col = c(col[1:5], rep(
               rgb(0, 0, 0, 0.3), abs(length(TIMESINCEIRR) - 5)
-            )),
+            ))[1:length(records)],
             records_max = 10,
             plot.single = TRUE,
             legend.text = c(paste(round(irradiation_times.unique, 1), "s")),

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -660,7 +660,7 @@ analyse_FadingMeasurement <- function(
             xlim = plot_settings$xlim,
             log = plot_settings$log,
             legend.pos = "outside",
-            main = expression(paste(L[x], " - curves")),
+            main = bquote(expression(paste(L[x], " - curves"))),
             mtext = plot_settings$mtext
           )
 

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -651,10 +651,11 @@ analyse_FadingMeasurement <- function(
 
         if (is(plot.single, "logical") ||
             (is(plot.single, "numeric") & 1 %in% plot.single)) {
+          records <- object_clean[seq(1, length(object_clean), by = 2)]
           plot_RLum(
             set_RLum(class = "RLum.Analysis",
-                     records = object_clean[seq(1, length(object_clean), by = 2)]),
-            combine = TRUE,
+                     records = records),
+            combine = length(records) > 1,
             col = c(col[1:5], rep(
               rgb(0, 0, 0, 0.3), abs(length(TIMESINCEIRR) - 5)
             )),
@@ -681,10 +682,11 @@ analyse_FadingMeasurement <- function(
         # plot Tx-curves ----
         if (is(plot.single, "logical") ||
             (is(plot.single, "numeric") & 2 %in% plot.single)) {
+          records <- object_clean[seq(2, length(object_clean), by = 2)]
           plot_RLum(
             set_RLum(class = "RLum.Analysis",
-                     records = object_clean[seq(2, length(object_clean), by = 2)]),
-            combine = TRUE,
+                     records = records),
+            combine = length(records) > 1,
             records_max = 10,
             plot.single = TRUE,
             legend.text = paste(round(irradiation_times.unique, 1), "s"),

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -361,7 +361,7 @@ analyse_FadingMeasurement <- function(
     }
 
     ##overwrite TIMESINCEIRR
-    TIMESINCEIRR <- t_star
+    TIMESINCEIRR <- pmax(t_star, 1e-6)
     rm(t_star)
 
     # Calculation ---------------------------------------------------------------------------------
@@ -430,9 +430,7 @@ analyse_FadingMeasurement <- function(
     LxTx_table <- LxTx_table[-rm_id,]
     TIMESINCEIRR <- TIMESINCEIRR[-rm_id]
     rm(rm_id)
-
   }
-
 
   ##normalise
   if(length(structure) == 2 | is.null(object)){
@@ -441,16 +439,14 @@ analyse_FadingMeasurement <- function(
     LxTx_NORM.ERROR <-
       LxTx_table[["LxTx.Error"]] / LxTx_table[["LxTx"]][which(TIMESINCEIRR == tc)[1]]
 
-
   }else{
     LxTx_NORM <-
       LxTx_table[["Net_LnLx"]] / LxTx_table[["Net_LnLx"]][which(TIMESINCEIRR== tc)[1]]
     LxTx_NORM.ERROR <-
        LxTx_table[["Net_LnLx.Error"]] / LxTx_table[["Net_LnLx"]][which(TIMESINCEIRR == tc)[1]]
-
   }
 
-  ##normalise time since irradtion
+  ## normalise time since irradiation
   TIMESINCEIRR_NORM <- TIMESINCEIRR/tc
 
   ##add dose and time since irradiation
@@ -628,7 +624,6 @@ analyse_FadingMeasurement <- function(
       log = "",
       mtext = "",
       plot.trend = TRUE
-
     )
 
     ##modify on request
@@ -642,7 +637,6 @@ analyse_FadingMeasurement <- function(
       irradiation_times.unique <-
         irradiation_times.unique[seq(1, length(irradiation_times.unique),
                                      length.out = 5)]
-
     }
 
     ## plot Lx-curves -----
@@ -676,7 +670,6 @@ analyse_FadingMeasurement <- function(
             object_clean[[1]][range(background.integral), 1]),
             lty = c(2,2,2,2),
             col = c("green", "green", "red", "red"))
-
         }
 
         # plot Tx-curves ----

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -138,11 +138,6 @@ test_that("test XSYG file fading data", {
   expect_warning(analyse_FadingMeasurement(object, signal.integral = 1:2,
                                            background.integral = 3),
                  "Lx and Tx have different sizes: skipped sample 2")
-
-  expect_warning(analyse_FadingMeasurement(object, signal.integral = 1:2,
-                                           background.integral = 3,
-                                           structure = c("Lx", "error")),
-                 "Nothing to combine, object contains a single curve")
   })
 })
 

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -61,6 +61,7 @@ test_that("test XSYG file fading data", {
   # Create artificial object ------------------------------------------------
   l <- list()
   time <- 0
+  set.seed(0)
   for(x in runif(3, 120,130)) {
     ## set irr
     irr  <-
@@ -148,4 +149,12 @@ test_that("test BIN file while fading data", {
   d1 <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
   expect_error(analyse_FadingMeasurement(d1),
                "BIN-file has version 03, but only versions from 05 on are supported")
+
+  v5 <- read_BIN2R(test_path("_data/BINfile_V5.binx"), verbose = FALSE)
+  SW({
+  d2 <- Risoe.BINfileData2RLum.Analysis(v5)
+  })
+  expect_output(analyse_FadingMeasurement(d2, signal.integral = 1:2,
+                                          background.integral = 10:30,
+                                          plot = TRUE))
 })


### PR DESCRIPTION
This addresses a number of small issues revealed by the example from #283 as well as the main crash. Fixes #283.