### PR TITLE
Remove unexplained term from error calculation in calc_Lamothe2003()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -51,6 +51,11 @@ prevent "Figure margins too large" errors.
 (#245, fixed in #246).
 * Several edge cases that led to crashes have been fixed (#147, fixed in #247).
 
+### `calc_Lamothe2003()`
+* We addressed a long-standing issue (#96) regarding the calculation of the
+calculation of the `Ln/Tn` error after fading correction, which led to smaller
+than expected errors (fixed in #296).
+
 ### `get_RLum()`
 * When the function was used on a list of `RLum.Analysis-class` objects with the argument `null.rm = TRUE` it would 
 remove all `NULL` objects, but not elements that became `list()` (empty list) during the selection; fixed.

--- a/R/calc_Lamothe2003.R
+++ b/R/calc_Lamothe2003.R
@@ -281,14 +281,8 @@ calc_Lamothe2003 <- function(
   # apply to input data
   data[[2]][1] <-  data[[2]][1] / Fading_C
   data[[3]][1] <-  sqrt((data[[3]][1]/data[[2]][1])^2 +
-                            ((1/Fading_C - 1) * sFading_C/Fading_C)^2) * data[[2]][1]
+                        (sFading_C/Fading_C)^2) * data[[2]][1]
 
-  ##TODO discuss with Norbert
-  # data[[3]][1] <-  sqrt((data[[3]][1]/data[[2]][1])^2 +
-  #                         (sFading_C/Fading_C)^2) * data[[2]][1]
-  #
-  # print(LnTn_BEFORE.ERROR/LnTn_BEFORE)
-  # print(data[[3]][1]/ data[[2]][1] )
 
   # Fitting ---------------------------------------------------------------------------------
   ##set arguments


### PR DESCRIPTION
We could not find a justification for the presence of the `(1/Fading_C -1)` term and reverted to a more mathematically obvious formulation of the error term. Fixes #96.