### PR TITLE
Add snapshot tests for plot_GrowthCurve()

### DIFF
--- a/R/read_XSYG2R.R
+++ b/R/read_XSYG2R.R
@@ -85,9 +85,9 @@
 #' (see details for more information) Note: The option overwrites the time vs.
 #' count TL curve. Select `FALSE` to import the raw data delivered by the
 #' lexsyg. Works for TL curves and spectra.
-#' 
+#'
 #' @param n_records [numeric] (*with default*): set the number of records to be imported; by default
-#' the function attempts ot import all records
+#' the function attempts to import all records
 #'
 #' @param fastForward [logical] (*with default*):
 #' if `TRUE` for a more efficient data processing only a list of [RLum.Analysis-class]
@@ -382,7 +382,7 @@ read_XSYG2R <- function(
     ## set n_records
     if(is.null(n_records))
       n_records <- XML::xmlSize(temp)
-    
+
     ##loop over the entire sequence by sequence
     output <- lapply(1:min(XML::xmlSize(temp),n_records[1]), function(x){
       ##read sequence header
@@ -426,7 +426,7 @@ read_XSYG2R <- function(
         lapply(1:XML::xmlSize(temp[[x]][[i]]), function(j){
           ##get values
           temp.sequence.object.curveValue <- temp[[x]][[i]][[j]]
-          
+
           ##get curveType
           temp.sequence.object.curveType <- as.character(
             XML::xmlAttrs(temp[[x]][[i]][[j]])["curveType"])

--- a/man/read_XSYG2R.Rd
+++ b/man/read_XSYG2R.Rd
@@ -29,7 +29,7 @@ count TL curve. Select \code{FALSE} to import the raw data delivered by the
 lexsyg. Works for TL curves and spectra.}
 
 \item{n_records}{\link{numeric} (\emph{with default}): set the number of records to be imported; by default
-the function attempts ot import all records}
+the function attempts to import all records}
 
 \item{fastForward}{\link{logical} (\emph{with default}):
 if \code{TRUE} for a more efficient data processing only a list of \linkS4class{RLum.Analysis}

--- a/tests/testthat/_snaps/plot_GrowthCurve.md
+++ b/tests/testthat/_snaps/plot_GrowthCurve.md
@@ -1,0 +1,1176 @@
+# snapshot tests
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1737.88094437]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [47.22586057]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1766.07421865]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [70.37433503]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.52713521]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1756.23503279]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["EXP"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1699.30176636]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1719.71740889]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1665.09177077]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1827.86513688]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1684.85735459, 1763.54183457, 1762.187853, 1850.03438636, 1774.63110596, 1703.33986596, 1793.5411331, 1717.19383989, 1760.88144126, 1752.14151321]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1811.33104805]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [40.56920434]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.50995774]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1839.83430692]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["LIN"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1787.21551381]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1882.6877783]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1758.1801344]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1923.04203442]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1848.89549991, 1846.15066074, 1893.0524396, 1868.55650236, 1796.110008, 1901.66508559, 1788.41533458, 1789.27853976, 1835.17171587, 1831.04728281]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["LIN"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [-0.56341651]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.55674886]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [-1.11016389]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1.10349624]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1792.84642796]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [86.47327657]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.55451842]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1803.21631787]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["EXP+LIN"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1710.77610672]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1914.52462249]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1623.60534998]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1975.4391272]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1914.24507169, 1828.69651434, 1745.45958838, 1778.69356335, 1893.51533194, 1672.19640451, 1796.04639439, 1911.58346151, 1688.02254728, 1803.70430134]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1787.14784685]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [39.0205444]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [3521.17]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [3591614.20373586]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [549.02]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [387.36156052]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.55106277]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1811.36154986]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["EXP+EXP"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": ["NA", 1824.8371709, "NA", 1830.71377093, 1776.78064125, 1864.234325, 1746.9287764, 1831.20796013, 1804.82820438, "NA"]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1666.20445767]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [56.6268594]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.48867007]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1654.19502336]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["QDR"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1582.80598467]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1664.18544782]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1543.17772435]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1768.20963115]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1610.90625651, 1571.71222246, 1605.16197247, 1740.38278054, 1618.06265129, 1702.16986024, 1616.05022924, 1701.93514277, 1668.3974487, 1707.17166934]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1786.19063906]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [48.55301238]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [31521.72579394]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1172919.42271981]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.54991226]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1776.80632145]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["GOK"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1709.52405078]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1815.21374651]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1687.30519429]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1884.87286414]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1808.35894275, 1836.22119257, 1727.57455606, 1758.36721033, 1768.18562486, 1868.39982966, 1747.13953135, 1738.69135603, 1722.99453709, 1792.13043382]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["De", "De.MC"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U"]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                }
+              },
+              "value": [
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1784.77518933]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [77.95285537]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [7033.69444514]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.55002393]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1753.44276397]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["LambertW"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1699.32043814]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1861.38817349]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1580.77946599]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1889.17121384]
+                }
+              ]
+            },
+            {
+              "type": "double",
+              "attributes": {},
+              "value": [1799.42248907, 1829.68778811, 1776.23866755, 1754.03040759, 1792.50205253, 1781.25824859, 1691.51738922, 1604.2103926, 1847.21826033, 1658.34194408]
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["plot_GrowthCurve"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,6 +12,8 @@ expect_snapshot_RLum <- function(object, ...) {
       object@data$fit <- NULL
     if ("data" %in% names(object@data))
       object@data$data$UID <- NULL
+    if ("Fit" %in% names(object@data))
+      object@data$Fit <- NULL
     if ("Formula" %in% names(object@data))
       object@data$Formula <- NULL
     if ("LnLxTnTx.table" %in% names(object@data))

--- a/tests/testthat/test_plot_GrowthCurve.R
+++ b/tests/testthat/test_plot_GrowthCurve.R
@@ -136,6 +136,11 @@ test_that("input validation", {
 test_that("snapshot tests", {
   testthat::skip_on_cran()
 
+  ## see https://github.com/R-Lum/Luminescence/pull/308
+  skip_on_os("windows")
+  skip_on_os("mac")
+  skip_if(getRversion() < "4.4")
+
   snapshot.tolerance <- 1.5e-6
 
   set.seed(1)
@@ -192,7 +197,6 @@ test_that("snapshot tests", {
       NumberIterations.MC = 10
   ), tolerance = snapshot.tolerance)
 
-
   expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "GOK",
@@ -221,7 +225,10 @@ test_that("snapshot tests", {
       NumberIterations.MC = 10
   )
   })
+})
 
+test_that("additional tests", {
+  testthat::skip_on_cran()
 
 # Check more output -------------------------------------------------------
   data(ExampleData.LxTxData, envir = environment())
@@ -295,6 +302,14 @@ temp_LambertW <-
     NumberIterations.MC = 10
   )
   })
+
+  expect_s3_class(temp_EXP$Fit, class = "nls")
+  expect_s3_class(temp_LIN$Fit, class = "lm")
+  expect_s3_class(temp_EXPLIN$Fit, class = "nls")
+  expect_s3_class(temp_EXPEXP$Fit, class = "nls")
+  expect_s3_class(temp_QDR$Fit, class = "lm")
+  expect_s3_class(temp_GOK$Fit, class = "nls")
+  expect_s3_class(temp_LambertW$Fit, class = "nls")
 
    expect_equal(round(temp_EXP$De[[1]], digits = 2), 1737.88)
    expect_equal(round(sum(temp_EXP$De.MC, na.rm = TRUE), digits = 0), 17562)

--- a/tests/testthat/test_plot_GrowthCurve.R
+++ b/tests/testthat/test_plot_GrowthCurve.R
@@ -1,8 +1,8 @@
-test_that("plot_GrowthCurve", {
-  testthat::skip_on_cran()
+## load data
+data(ExampleData.LxTxData, envir = environment())
 
-  ## load data
-  data(ExampleData.LxTxData, envir = environment())
+test_that("input validation", {
+  testthat::skip_on_cran()
 
   ## fit.method
   expect_error(
@@ -131,29 +131,32 @@ test_that("plot_GrowthCurve", {
     class = "RLum.Results")
 
   expect_true(is.na(t$De[[1]]))
+})
 
-# Check output for regression ---------------------------------------------
+test_that("snapshot tests", {
+  testthat::skip_on_cran()
+
+  snapshot.tolerance <- 1.5e-6
+
   set.seed(1)
-  data(ExampleData.LxTxData, envir = environment())
   SW({
-  temp_EXP <-
-    plot_GrowthCurve(
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "EXP",
       output.plot = FALSE,
       verbose = FALSE,
       NumberIterations.MC = 10
-    )
-  temp_LIN <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "LIN",
       output.plot = FALSE,
       verbose = FALSE,
       NumberIterations.MC = 10
-    )
-  temp_LIN <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "LIN",
       mode = "extrapolation",
@@ -161,9 +164,9 @@ test_that("plot_GrowthCurve", {
       output.plot = FALSE,
       verbose = FALSE,
       NumberIterations.MC = 10
-    )
-  temp_EXPLIN <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "EXP+LIN",
       fit.bounds = FALSE,
@@ -171,25 +174,44 @@ test_that("plot_GrowthCurve", {
       output.plot = FALSE,
       verbose = FALSE,
       NumberIterations.MC = 10
-    )
-  temp_EXPEXP <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "EXP+EXP",
       output.plot = FALSE,
       verbose = TRUE,
       NumberIterations.MC = 10
-    )
-  temp_QDR <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
       LxTxData,
       fit.method = "QDR",
       output.plot = FALSE,
       verbose = TRUE,
       NumberIterations.MC = 10
-    )
-  temp_QDR <-
-    plot_GrowthCurve(
+  ), tolerance = snapshot.tolerance)
+
+
+  expect_snapshot_RLum(plot_GrowthCurve(
+      LxTxData,
+      fit.method = "GOK",
+      output.plot = FALSE,
+      verbose = FALSE,
+      NumberIterations.MC = 10
+  ), tolerance = snapshot.tolerance)
+
+  expect_snapshot_RLum(plot_GrowthCurve(
+      LxTxData,
+      fit.method = "LambertW",
+      output.plot = FALSE,
+      verbose = FALSE,
+      NumberIterations.MC = 10
+  ), tolerance = snapshot.tolerance)
+
+  ## FIXME(mcol): expect_snapshot_RLum() produced an error on this test:
+  ##              object could not be safely serialized with `style = "json2"`
+  temp_QDR <- plot_GrowthCurve(
       LxTxData,
       fit.method = "QDR",
       output.plot = FALSE,
@@ -197,49 +219,9 @@ test_that("plot_GrowthCurve", {
       fit.force_through_origin = TRUE,
       verbose = TRUE,
       NumberIterations.MC = 10
-    )
-  temp_GOK <-
-    plot_GrowthCurve(
-      LxTxData,
-      fit.method = "GOK",
-      output.plot = FALSE,
-      verbose = FALSE,
-      NumberIterations.MC = 10
-    )
-  temp_LambertW <-
-    plot_GrowthCurve(
-      LxTxData,
-      fit.method = "LambertW",
-      output.plot = FALSE,
-      verbose = FALSE,
-      NumberIterations.MC = 10
-    )
+  )
   })
 
-  expect_s4_class(temp_EXP, class = "RLum.Results")
-    expect_s3_class(temp_EXP$Fit, class = "nls")
-
-  expect_s4_class(temp_LIN, class = "RLum.Results")
-    expect_s3_class(temp_LIN$Fit, class = "lm")
-
-  expect_s4_class(temp_EXPLIN, class = "RLum.Results")
-   expect_s3_class(temp_EXPLIN$Fit, class = "nls")
-
-  expect_s4_class(temp_EXPEXP, class = "RLum.Results")
-    expect_s3_class(temp_EXPEXP$Fit, class = "nls")
-
-  expect_s4_class(temp_QDR, class = "RLum.Results")
-    expect_s3_class(temp_QDR$Fit, class = "lm")
-
-  expect_s4_class(temp_GOK, class = "RLum.Results")
-    expect_s3_class(temp_GOK$Fit, class = "nls")
-
-  expect_s4_class(temp_LambertW, class = "RLum.Results")
-    expect_s3_class(temp_LambertW$Fit, class = "nls")
-
-  ## check n_N calculation
-  expect_equal(round(temp_EXP$De$n_N, 1), 0.5)
-  expect_equal(round(temp_LambertW$De$n_N, 1), 0.6)
 
 # Check more output -------------------------------------------------------
   data(ExampleData.LxTxData, envir = environment())


### PR DESCRIPTION
One test involving method `QDR` with `mode = "extrapolation"` could not be turned into a snapshot test, I'll investigate that later so see why that should be the case.

Part of #143.