### PR TITLE
Don't crash when coercing an empty list to RLum.Data objects

### DIFF
--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -173,15 +173,12 @@ setMethod("show",
                         } else if (linebreak) {
                           last <- "\n\t .. .. : "
                           assign(x = "linebreak", value = FALSE, envir = env)
-
                         }
-
                       }
                       return(paste0(first,last))
 
                     }else{
                       return("")
-
                     }
 
               }, FUN.VALUE = vector(mode = "character", length = 1))
@@ -195,15 +192,13 @@ setMethod("show",
 
                  } else{
                    cat("\n\t .. .. : ", terminal_output, sep = "")
-
                  }
-
               })
 
             }else{
               cat("\n\t >> This is an empty object, which cannot be used for further analysis! <<")
-
             }
+            cat("\n")
           }
 )##end show method
 

--- a/R/RLum.Data.Curve-class.R
+++ b/R/RLum.Data.Curve-class.R
@@ -103,7 +103,8 @@ setClass("RLum.Data.Curve",
 #' @name as
 setAs("list", "RLum.Data.Curve",
       function(from,to){
-
+        if (length(from) == 0)
+          return(set_RLum("RLum.Data.Curve"))
         new(to,
             recordType = "unknown curve type",
             curveType = NA_character_,
@@ -115,7 +116,6 @@ setAs("list", "RLum.Data.Curve",
 setAs("RLum.Data.Curve", "list",
       function(from){
           list(x = from@data[,1], y = from@data[,2])
-
       })
 
 ##DATA.FRAME
@@ -497,10 +497,10 @@ setMethod(
 #' Melts [RLum.Data.Curve-class] objects into a flat data.frame to be used
 #' in combination with other packages such as `ggplot2`.
 #'
-#' @return 
-#' 
+#' @return
+#'
 #' **`melt_RLum`**
-#' 
+#'
 #' Flat [data.frame] with `X`, `Y`, `TYPE`, `UID`
 #'
 #' @md

--- a/R/RLum.Data.Image-class.R
+++ b/R/RLum.Data.Image-class.R
@@ -187,6 +187,7 @@ setMethod("show",
             cat("\n\t .. .. full pixel value range:", paste(format(range(object@data), scientific = TRUE, digits = 2), collapse=" : "))
             cat("\n\t additional info elements:", length(object@info))
             #cat("\n\t\t >> names:", names(object@info))
+            cat("\n")
           }
 )
 

--- a/R/RLum.Data.Image-class.R
+++ b/R/RLum.Data.Image-class.R
@@ -143,8 +143,10 @@ setAs("RLum.Data.Image", "array",
 ## from list ----
 setAs("list", "RLum.Data.Image",
       function(from, to){
-        array_list <- lapply(from, function(x) array(unlist(as.vector(x)), c(nrow(x), ncol(x), 1)))
+        if (length(from) == 0)
+          return(set_RLum("RLum.Data.Image"))
 
+        array_list <- lapply(from, function(x) array(unlist(as.vector(x)), c(nrow(x), ncol(x), 1)))
         new(to,
             recordType = "unknown curve type",
             curveType = "NA",

--- a/R/RLum.Data.Spectrum-class.R
+++ b/R/RLum.Data.Spectrum-class.R
@@ -83,15 +83,14 @@ setClass(
 #'
 #' for `[RLum.Data.Spectrum-class]`
 #'
-#'
 #' **[RLum.Data.Spectrum-class]**
 #'
 #' \tabular{ll}{
 #'   **from** \tab **to**\cr
 #'   `data.frame` \tab `data.frame`\cr
 #'   `matrix` \tab `matrix`
+#'   `list` \tab `list`
 #' }
-#'
 #'
 #' @md
 #' @name as
@@ -108,9 +107,7 @@ setAs("data.frame", "RLum.Data.Spectrum",
 setAs("RLum.Data.Spectrum", "data.frame",
       function(from){
         as.data.frame(from@data)
-
       })
-
 
 ##MATRIX
 ##COERCE RLum.Data.Spectrum >> matrix AND matrix >> RLum.Data.Spectrum
@@ -126,7 +123,24 @@ setAs("matrix", "RLum.Data.Spectrum",
 setAs("RLum.Data.Spectrum", "matrix",
       function(from){
         from@data
+      })
 
+## LIST
+## COERCE RLum.Data.Spectrum >> list AND list >> RLum.Data.Spectrum
+setAs("list", "RLum.Data.Spectrum",
+      function(from, to){
+        if (length(from) == 0)
+          return(set_RLum("RLum.Data.Spectrum"))
+        new(to,
+            recordType = NA_character_,
+            curveType = NA_character_,
+            data = matrix(unlist(from)),
+            info = list())
+      })
+
+setAs("RLum.Data.Spectrum", "list",
+      function(from){
+        apply(from@data, 2, list)
       })
 
 # show() -------------------------------------------------------------------------------------

--- a/R/RLum.Data.Spectrum-class.R
+++ b/R/RLum.Data.Spectrum-class.R
@@ -171,6 +171,7 @@ setMethod("show",
             cat("\n\t .. .. range count values:", z.range)
             cat("\n\t additional info elements:", length(object@info))
             #cat("\n\t\t >> names:", names(object@info))
+            cat("\n")
           }
 )
 

--- a/tests/testthat/test_RLum.Data.Curve.R
+++ b/tests/testthat/test_RLum.Data.Curve.R
@@ -20,27 +20,29 @@ test_that("check class", {
 
   ##check conversions
   expect_s4_class(as(object = list(1:10), Class = "RLum.Data.Curve"), "RLum.Data.Curve")
+  expect_s4_class(as(list(), "RLum.Data.Curve"),
+                  "RLum.Data.Curve")
   expect_type(as(object = object, Class = "list"), "list")
   expect_s4_class(as(object = matrix(1:10,ncol = 2), Class = "RLum.Data.Curve"), "RLum.Data.Curve")
-  
+
   ## test melt simple
   expect_type(melt_RLum(object = object), "list")
-  
+
   ## test melt more complicated
   data(ExampleData.XSYG, envir = environment())
   t <- melt_RLum(OSL.SARMeasurement[[2]][[1]])
   expect_length(t, n = 4)
-  
+
   ## provide a list
   expect_length(melt_RLum(OSL.SARMeasurement[[2]]@records[1:5]), n = 4)
-  
+
   ## test problematic records
   l <- c(OSL.SARMeasurement[[2]]@records[1:5], "non-RLum")
   expect_length(melt_RLum(l), n = 4)
-  
+
   l <- list("non-RLum")
   expect_null(melt_RLum(l))
-  
+
   l <- c(list("non-RLum"), set_RLum("RLum.Results"))
   expect_type(melt_RLum(l), "list")
 })

--- a/tests/testthat/test_RLum.Data.Image.R
+++ b/tests/testthat/test_RLum.Data.Image.R
@@ -41,6 +41,8 @@ test_that("check class ", {
   ## to and from list
   expect_s4_class(as(list(matrix(1, nrow = 10, ncol = 5), matrix(1, nrow = 10, ncol = 5)), "RLum.Data.Image"),
                   "RLum.Data.Image")
+  expect_s4_class(as(list(), "RLum.Data.Image"),
+                  "RLum.Data.Image")
   expect_type(as(ExampleData.RLum.Data.Image, "list"), "list")
 
   ## check edge cases

--- a/tests/testthat/test_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_RLum.Data.Spectrum.R
@@ -35,5 +35,10 @@ test_that("check class", {
   expect_s4_class(as(object = data.frame(x = 1:10), Class = "RLum.Data.Spectrum"), "RLum.Data.Spectrum")
   expect_s3_class(as(set_RLum("RLum.Data.Spectrum"), "data.frame"), "data.frame")
   expect_s4_class(as(object = matrix(1:10,ncol = 2), Class = "RLum.Data.Spectrum"), "RLum.Data.Spectrum")
-
+  expect_s4_class(as(list(1:10), "RLum.Data.Spectrum"),
+                  "RLum.Data.Spectrum")
+  expect_s4_class(as(list(), "RLum.Data.Spectrum"),
+                  "RLum.Data.Spectrum")
+  expect_type(as(set_RLum("RLum.Data.Spectrum"), "list"),
+              "list")
 })


### PR DESCRIPTION
Fixes the two crashes, adds the coercion functions between `list` and `RLum.Data.Spectrum`, and adds some newline when showing those objects. Fixes #326.