### PR TITLE
Speed up the reading of BIN/BINX files

### DIFF
--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -260,11 +260,11 @@ read_BIN2R <- function(
     return(NULL)
   }
 
-  # Config ------------------------------------------------------------------
   ##set supported BIN format version
   VERSIONS.supported <- as.raw(c(03, 04, 05, 06, 07, 08))
 
-  # Short file parsing to get number of records -------------------------------------------------
+  ## Short file parsing to get number of records ----------------------------
+
   #open connection
   con <- file(file, "rb")
 
@@ -274,7 +274,7 @@ read_BIN2R <- function(
 
   ##start for BIN-file check up
   while(length(temp.VERSION <- readBin(con, what="raw", 1, size=1, endian="little"))>0) {
-     ##force version number
+    ## force version number
     if(!is.null(forced.VersionNumber)){
       temp.VERSION <- as.raw(forced.VersionNumber)
       if (verbose)
@@ -310,17 +310,18 @@ read_BIN2R <- function(
 
     ## get record LENGTH
     if(temp.VERSION == 06 | temp.VERSION == 07 | temp.VERSION == 08){
-      temp.LENGTH  <- readBin(con, what = "int", 1, size = 4, endian = "little")
-      STEPPING <- readBin(con, what = "raw", n = max(0, temp.LENGTH - 6),
-                          size = 1, endian = "little")
+      length.size <- 4
     }else{
-      temp.LENGTH  <- readBin(con, what = "int", 1, size = 2, endian = "little")
-      STEPPING <- readBin(con, what = "raw", n = max(0, temp.LENGTH - 4),
-                          size = 1, endian = "little")
+      length.size <- 2
     }
 
-    ## STEPPING has 0 length when we have read for a length n = 0
-    if (length(STEPPING) == 0) {
+    temp.LENGTH  <- readBin(con, what = "integer", 1, size = length.size,
+                            endian = "little")
+    num.toread <- max(0, temp.LENGTH - length.size - 2)
+    if (num.toread > 0) {
+      STEPPING <- readBin(con, what = "raw", n = num.toread,
+                          size = 1, endian = "little")
+    } else {
       if (verbose)
         message("\n[read_BIN2R()] Record #", temp.ID + 1,
                 " skipped due to wrong record length")
@@ -720,7 +721,6 @@ read_BIN2R <- function(
             suppressWarnings(readChar(con, USER_SIZE, useBytes = TRUE)) #set to 30 (manual)
         }else{
           USER_SIZE <- 0
-
         }
 
         #step forward in con
@@ -739,7 +739,7 @@ read_BIN2R <- function(
 
           ##correct the mess by others
           if(nchar(temp.TIME) == 5)
-            temp.TIME <- paste(c("0", temp.TIME), collapse = "")
+            temp.TIME <- paste0("0", temp.TIME)
 
         }else{
           TIME_SIZE <- 0
@@ -749,7 +749,6 @@ read_BIN2R <- function(
           STEPPING<-readBin(con, what="raw", (6-TIME_SIZE),
                             size=1, endian="little")
         }
-
 
         ##DATE
         DATE_SIZE<-readBin(con, what="int", 1, size=1, endian="little")
@@ -771,7 +770,6 @@ read_BIN2R <- function(
 
         ##NORM1, NORM2, NORM3, BG
         temp <- readBin(con, what="double", 4, size=4, endian="little")
-
         temp.NORM1 <- temp[1]
         temp.NORM2 <- temp[2]
         temp.NORM3 <- temp[3]
@@ -796,7 +794,6 @@ read_BIN2R <- function(
 
         ##LIGHTPOWER, LOW, HIGH, RATE
         temp <- readBin(con, what="double", 4, size=4, endian="little")
-
         temp.LIGHTPOWER <- temp[1]
         temp.LOW <- temp[2]
         temp.HIGH <- temp[3]
@@ -816,7 +813,6 @@ read_BIN2R <- function(
 
         ##DELAY, ON, OFF
         temp <- readBin(con, what="int", 3, size=2, endian="little")
-
         temp.TOLDELAY <- temp[1]
         temp.TOLON <- temp[2]
         temp.TOLOFF <- temp[3]
@@ -896,9 +892,8 @@ read_BIN2R <- function(
           ##ENOISEFACTOR
           temp.ENOISEFACTOR <- readBin(con, what="double", 1, size=4, endian="little")
 
-          ##CHECK FOR VERSION 08
+          ##CHECK FOR VERSION 07
           if(temp.VERSION == 07){
-             ##RESERVED for version 07
             temp.RESERVED2<-readBin(con, what="raw", 15, size=1, endian="little")
 
           }else {
@@ -917,7 +912,6 @@ read_BIN2R <- function(
               temp.EXTR_END <- temp[2]
 
             temp.RESERVED2<-readBin(con, what="raw", 42, size=1, endian="little")
-
           }
         }# end RECTYPE 128
       }
@@ -925,7 +919,6 @@ read_BIN2R <- function(
       ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ##START BIN FILE FORMAT SUPPORT  (vers. 03 and 04)
       ##LENGTH, PREVIOUS, NPOINTS, LTYPE
-
       temp <- readBin(con, what="int", 3, size=2, endian="little")
       temp.LENGTH <- temp[1]
       temp.PREVIOUS <- temp[2]
@@ -1020,7 +1013,6 @@ read_BIN2R <- function(
 
       ##AN_TEMP, AN_TIME, NORM1, NORM2, NORM3, BG
       temp <- readBin(con, what="double", 6, size=4, endian="little")
-
       temp.AN_TEMP <- temp[1]
       temp.AN_TIME <- temp[2]
       temp.NORM1 <- temp[3]
@@ -1071,7 +1063,6 @@ read_BIN2R <- function(
 
         ##ONTIME, OFFTIME
         temp <- readBin(con, what="double", 2, size=4, endian="little")
-
         temp.ONTIME <- temp[1]
         temp.OFFTIME <- temp[2]
 
@@ -1081,7 +1072,6 @@ read_BIN2R <- function(
 
         ##ONGATEDELAY, OFFGATEDELAY
         temp <- readBin(con, what="double", 2, size=4, endian="little")
-
         temp.GATE_START <- temp[1]
         temp.GATE_STOP <- temp[2]
 
@@ -1100,7 +1090,6 @@ read_BIN2R <- function(
 
         ##ONTIME, STIMPERIOD
         temp <- readBin(con, what="integer", 2, size=4, endian="little")
-
         temp.ONTIME <- temp[1]
         temp.STIMPERIOD <- temp[2]
 
@@ -1109,7 +1098,6 @@ read_BIN2R <- function(
 
         ##ONGATEDELAY, OFFGATEDELAY
         temp <- readBin(con, what="double", 2, size=4, endian="little")
-
         temp.GATE_START <- temp[1]
         temp.GATE_END <- temp[2]
         temp.GATE_STOP <- temp.GATE_END

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -787,10 +787,10 @@ read_BIN2R <- function(
         ##(5) Measurement characteristics
 
         ##LTYPE
-        temp.LTYPE <- readBin(con, what="int", 1, size=1, endian="little")
-
         ##LTYPESOURCE
-        temp.LIGHTSOURCE <- readBin(con, what="int", 1, size=1, endian="little")
+        temp <- readBin(con, what = "integer", 2, size = 1, endian = "little")
+        temp.LTYPE <- temp[1]
+        temp.LIGHTSOURCE <- temp[2]
 
         ##LIGHTPOWER, LOW, HIGH, RATE
         temp <- readBin(con, what="double", 4, size=4, endian="little")
@@ -800,16 +800,16 @@ read_BIN2R <- function(
         temp.RATE <- temp[4]
 
         ##TEMPERATURE
-        temp.TEMPERATURE <- readBin(con, what="int", 1, size=2, endian="little")
-
         ##MEASTEMP
-        temp.MEASTEMP <- readBin(con, what="integer", 1, size=2, endian="little")
+        temp <- readBin(con, what = "integer", 2, size = 2, endian = "little")
+        temp.TEMPERATURE <- temp[1]
+        temp.MEASTEMP <- temp[2]
 
         ##AN_TEMP
-        temp.AN_TEMP <- readBin(con, what="double", 1, size=4, endian="little")
-
         ##AN_TIME
-        temp.AN_TIME <- readBin(con, what="double", 1, size=4, endian="little")
+        temp <- readBin(con, what = "double", 2, size = 4, endian = "little")
+        temp.AN_TEMP <- temp[1]
+        temp.AN_TIME <- temp[2]
 
         ##DELAY, ON, OFF
         temp <- readBin(con, what="int", 3, size=2, endian="little")
@@ -837,25 +837,25 @@ read_BIN2R <- function(
         temp.TIMETICK <- readBin(con, what="double", 1, size=4, endian="little")
 
         ##ONTIME
-        temp.ONTIME <- readBin(con, what="integer", 1, size=4, endian="little")
-
         ##STIMPERIOD
-        temp.STIMPERIOD <- readBin(con, what="integer", 1, size=4, endian="little")
+        temp <- readBin(con, what = "integer", 2, size = 4, endian = "little")
+        temp.ONTIME <- temp[1]
+        temp.STIMPERIOD <- temp[2]
 
         ##GATE_ENABLED
         temp.GATE_ENABLED <- readBin(con, what="raw", 1, size=1, endian="little")
 
         ##GATE_START
-        temp.GATE_START <- readBin(con, what="integer", 1, size=4, endian="little")
-
         ##GATE_STOP
-        temp.GATE_STOP <- readBin(con, what="integer", 1, size=4, endian="little")
+        temp <- readBin(con, what = "integer", 2, size = 4, endian = "little")
+        temp.GATE_START <- temp[1]
+        temp.GATE_STOP <- temp[2]
 
         ##PTENABLED
-        temp.PTENABLED <- readBin(con, what="raw", 1, size=1, endian="little")
-
         ##DTENABLED
-        temp.DTENABLED <- readBin(con, what="raw", 1, size=1, endian="little")
+        temp <- readBin(con, what = "raw", 2, size = 1, endian = "little")
+        temp.PTENABLED <- temp[1]
+        temp.DTENABLED <- temp[2]
 
         ##DEADTIME, MAXLPOWER, XRF_ACQTIME, XRF_HV
         temp <- readBin(con, what="double", 4, size=4, endian="little")
@@ -898,18 +898,16 @@ read_BIN2R <- function(
 
           }else {
             ##MARKER_POSITION
-            temp <- readBin(con, what="double", 6, size=4, endian="little")
+            ###EXTR_START, EXTR_END
+            temp <- readBin(con, what = "double", 8, size = 4, endian = "little")
               temp.MARPOS_X1 <- temp[1]
               temp.MARPOS_Y1 <- temp[2]
               temp.MARPOS_X2 <- temp[3]
               temp.MARPOS_Y2 <- temp[4]
               temp.MARPOS_X3 <- temp[5]
               temp.MARPOS_Y3 <- temp[6]
-
-            ###EXTR_START, EXTR_END
-            temp <- readBin(con, what="double", 2, size=4, endian="little")
-              temp.EXTR_START <- temp[1]
-              temp.EXTR_END <- temp[2]
+              temp.EXTR_START <- temp[7]
+              temp.EXTR_END <- temp[8]
 
             temp.RESERVED2<-readBin(con, what="raw", 42, size=1, endian="little")
           }
@@ -939,23 +937,21 @@ read_BIN2R <- function(
       temp.HIGH <- temp[2]
       temp.RATE <- temp[3]
 
-      temp.TEMPERATURE<-readBin(con, what="integer", 1, size=2, endian="little")
-
       ##XCOORD, YCOORD, TOLDELAY, TOLON, TOLOFF
-      temp <- readBin(con, what="integer", 5, size=2, endian="little")
-      temp.XCOORD <- temp[1]
-      temp.YCOORD <- temp[2]
-      temp.TOLDELAY <- temp[3]
-      temp.TOLON <- temp[4]
-      temp.TOLOFF <- temp[5]
+      temp <- readBin(con, what = "integer", 6, size = 2, endian = "little")
+      temp.TEMPERATURE <- temp[1]
+      temp.XCOORD <- temp[2]
+      temp.YCOORD <- temp[3]
+      temp.TOLDELAY <- temp[4]
+      temp.TOLON <- temp[5]
+      temp.TOLOFF <- temp[6]
 
       ##POSITION
-      temp.POSITION <- readBin(
-        con, what="int", 1, size=1, endian="little", signed = FALSE)
-
       ##RUN
-      temp.RUN <- readBin(
-        con, what="int", 1, size=1, endian="little", signed = FALSE)
+      temp <- readBin(con, what = "integer", 2, size = 1, endian = "little",
+                      signed = FALSE)
+      temp.POSITION <- temp[1]
+      temp.RUN <- temp[2]
 
       ##TIME
       TIME_SIZE <- readBin(
@@ -1000,10 +996,10 @@ read_BIN2R <- function(
       temp.IRR_TIME <- readBin(con, what="double", 1, size=4, endian="little")
 
       ##IRR_TYPE
-      temp.IRR_TYPE<-readBin(con, what="int", 1, size=1, endian="little")
-
       ##IRR_UNIT
-      temp.IRR_UNIT<-readBin(con, what="int", 1, size=1, endian="little")
+      temp <- readBin(con, what = "integer", 2, size = 1, endian = "little")
+      temp.IRR_TYPE <- temp[1]
+      temp.IRR_UNIT <- temp[2]
 
       ##BL_TIME
       temp.BL_TIME<-readBin(con, what="double", 1, size=4, endian="little")
@@ -1103,10 +1099,10 @@ read_BIN2R <- function(
         temp.GATE_STOP <- temp.GATE_END
 
         ##PTENABLED
-        temp.PTENABLED <- readBin(con, what="raw", 1, size=1, endian="little")
-
         ##RESERVED
-        temp.RESERVED2 <- readBin(con, what="raw", 10, size=1, endian="little")
+        temp <- readBin(con, what = "raw", 11, size = 1, endian = "little")
+        temp.PTENABLED <- temp[1]
+        temp.RESERVED2 <- temp[2:11]
       }
     }
 

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -95,11 +95,12 @@
 #' The function works for BIN/BINX-format versions 03, 04, 05, 06, 07 and 08. The
 #' version number depends on the used Sequence Editor.
 #'
-#' @section Function version: 0.17.3
+#' @section Function version: 0.18
 #'
 #' @author
 #' Sebastian Kreutzer, Institute of Geography, Heidelberg University (Germany)\cr
 #' Margret C. Fuchs, HZDR Freiberg, (Germany) \cr
+#' Marco Colombo, Institute of Geography, Heidelberg University (Germany)\cr
 #' based on information provided by Torben Lapp and Karsten Bracht Nielsen (Risø DTU, Denmark)
 #'
 #'
@@ -437,104 +438,104 @@ read_BIN2R <- function(
   ## set index for entry row in table
   id_row <- 1
 
-  ##initialise data.frame
-  results.METADATA <- data.table::data.table(
+  ## initialise default empty list
+  results.METADATA.defaults <- list(
     ##1 to 7
-    ID = integer(length = n.length),
-    SEL = logical(length = n.length),
-    VERSION = numeric(length = n.length),
-    LENGTH = integer(length = n.length),
-    PREVIOUS = integer(length = n.length),
-    NPOINTS = integer(length = n.length),
-    RECTYPE = integer(length = n.length),
+    ID = 0,
+    SEL = FALSE,
+    VERSION = 0,
+    LENGTH = 0L,
+    PREVIOUS = 0L,
+    NPOINTS = 0L,
+    RECTYPE = 0L,
 
     #8 to 17
-    RUN = integer(length = n.length),
-    SET = integer(length = n.length),
-    POSITION = integer(length = n.length),
-    GRAIN = integer(length = n.length),
-    GRAINNUMBER = integer(length = n.length),
-    CURVENO = integer(length = n.length),
-    XCOORD = integer(length = n.length),
-    YCOORD = integer(length = n.length),
-    SAMPLE = character(length = n.length),
-    COMMENT = character(length = n.length),
+    RUN = 0L,
+    SET = 0L,
+    POSITION = 0L,
+    GRAIN = 0L,
+    GRAINNUMBER = 0L,
+    CURVENO = 0L,
+    XCOORD = 0L,
+    YCOORD = 0L,
+    SAMPLE = "",
+    COMMENT = "",
 
     #18 to 22
-    SYSTEMID = integer(length = n.length),
-    FNAME = character(length = n.length),
-    USER = character(length = n.length),
-    TIME = character(length = n.length),
-    DATE = character(length = n.length),
+    SYSTEMID = 0L,
+    FNAME = "",
+    USER = "",
+    TIME = "",
+    DATE = "",
 
     ##23 to 31
-    DTYPE = character(length = n.length),
-    BL_TIME = numeric(length = n.length),
-    BL_UNIT = integer(length = n.length),
-    NORM1 = numeric(length = n.length),
-    NORM2 = numeric(length = n.length),
-    NORM3 = numeric(length = n.length),
-    BG = numeric(length = n.length),
-    SHIFT = integer(length = n.length),
-    TAG = integer(length = n.length),
+    DTYPE = NA_character_,
+    BL_TIME = 0,
+    BL_UNIT = 0L,
+    NORM1 = 0,
+    NORM2 = 0,
+    NORM3 = 0,
+    BG = 0,
+    SHIFT = 0L,
+    TAG = 0L,
 
     ##32 to 67
-    LTYPE = character(length = n.length),
-    LIGHTSOURCE = character(length = n.length),
-    LPOWER = numeric(length = n.length),
-    LIGHTPOWER = numeric(length = n.length),
-    LOW = numeric(length = n.length),
-    HIGH = numeric(length = n.length),
-    RATE = numeric(length = n.length),
-    TEMPERATURE = numeric(length = n.length),
-    MEASTEMP = numeric(length = n.length),
-    AN_TEMP = numeric(length = n.length),
-    AN_TIME = numeric(length = n.length),
-    TOLDELAY = integer(length = n.length),
-    TOLON = integer(length = n.length),
-    TOLOFF = integer(length = n.length),
-    IRR_TIME = numeric(length = n.length),
-    IRR_TYPE = integer(length = n.length),
-    IRR_UNIT = integer(length = n.length),
-    IRR_DOSERATE = numeric(length = n.length),
-    IRR_DOSERATEERR = numeric(length = n.length),
-    TIMESINCEIRR = numeric(length = n.length),
-    TIMETICK = numeric(length = n.length),
-    ONTIME = numeric(length = n.length),
-    OFFTIME = numeric(length = n.length),
-    STIMPERIOD = integer(length = n.length),
-    GATE_ENABLED = numeric(length = n.length),
-    ENABLE_FLAGS = numeric(length = n.length),
-    GATE_START  = numeric(length = n.length),
-    GATE_STOP = numeric(length = n.length),
-    PTENABLED = numeric(length = n.length),
-    DTENABLED = numeric(length = n.length),
-    DEADTIME = numeric(length = n.length),
-    MAXLPOWER = numeric(length = n.length),
-    XRF_ACQTIME = numeric(length = n.length),
-    XRF_HV = numeric(length = n.length),
-    XRF_CURR = numeric(length = n.length),
-    XRF_DEADTIMEF = numeric(length = n.length),
+    LTYPE = NA_character_,
+    LIGHTSOURCE = "",
+    LPOWER = 0,
+    LIGHTPOWER = 0,
+    LOW = 0,
+    HIGH = 0,
+    RATE = 0,
+    TEMPERATURE = 0,
+    MEASTEMP = 0,
+    AN_TEMP = 0,
+    AN_TIME = 0,
+    TOLDELAY = 0L,
+    TOLON = 0L,
+    TOLOFF = 0L,
+    IRR_TIME = 0,
+    IRR_TYPE = 0L,
+    IRR_UNIT = 0L,
+    IRR_DOSERATE = 0,
+    IRR_DOSERATEERR = 0,
+    TIMESINCEIRR = 0,
+    TIMETICK = 0,
+    ONTIME = 0,
+    OFFTIME = 0,
+    STIMPERIOD = 0L,
+    GATE_ENABLED = 0,
+    ENABLE_FLAGS = 0,
+    GATE_START  = 0,
+    GATE_STOP = 0,
+    PTENABLED = 0,
+    DTENABLED = 0,
+    DEADTIME = 0,
+    MAXLPOWER = 0,
+    XRF_ACQTIME = 0,
+    XRF_HV = 0,
+    XRF_CURR = 0,
+    XRF_DEADTIMEF = 0,
 
     #68 to 79
-    DETECTOR_ID = integer(length = n.length),
-    LOWERFILTER_ID = integer(length = n.length),
-    UPPERFILTER_ID = integer(length = n.length),
-    ENOISEFACTOR = numeric(length = n.length),
-    MARKPOS_X1 = numeric(length = n.length),
-    MARKPOS_Y1 = numeric(length = n.length),
-    MARKPOS_X2 = numeric(length = n.length),
-    MARKPOS_Y2 = numeric(length = n.length),
-    MARKPOS_X3 = numeric(length = n.length),
-    MARKPOS_Y3 = numeric(length = n.length),
-    EXTR_START = numeric(length = n.length),
-    EXTR_END = numeric(length = n.length),
+    DETECTOR_ID = 0L,
+    LOWERFILTER_ID = 0L,
+    UPPERFILTER_ID = 0L,
+    ENOISEFACTOR = 0,
+    MARKPOS_X1 = 0,
+    MARKPOS_Y1 = 0,
+    MARKPOS_X2 = 0,
+    MARKPOS_Y2 = 0,
+    MARKPOS_X3 = 0,
+    MARKPOS_Y3 = 0,
+    EXTR_START = 0,
+    EXTR_END = 0,
 
     ##80
-    SEQUENCE = character(length = n.length)
+    SEQUENCE = ""
+  )
 
-  ) #end set data table
-
+  results.METADATA.list <- list(results.METADATA.defaults)
 
   #set variable for DPOINTS handling
   results.DATA <- list()
@@ -582,7 +583,7 @@ read_BIN2R <- function(
           cat("\n")
         }
       }
-   }
+    }
 
     #empty byte position
     EMPTY <- readBin(con, what="raw", 1, size=1, endian="little")
@@ -638,7 +639,9 @@ read_BIN2R <- function(
               ## we set the VERSION to NA and remove it later, otherwise we
               ## break expected functionality
               temp.ID <- temp.ID + 1
-              results.METADATA[temp.ID,`:=` (VERSION = NA)]
+              results.METADATA.list[[length(results.METADATA.list) + 1]] <-
+                modifyList(x = results.METADATA.defaults,
+                           val = list(ID = temp.ID, VERSION = NA))
               next()
             }
         }
@@ -1156,7 +1159,7 @@ read_BIN2R <- function(
     temp.SEL <- if(temp.TAG == 1) TRUE else FALSE
 
     ##replace values in the data.table with values
-    results.METADATA[id_row, `:=` (
+    results.METADATA.list[[length(results.METADATA.list) + 1]] <- list(
       ID = temp.ID,
       SEL = temp.SEL,
       VERSION = as.numeric(temp.VERSION),
@@ -1234,8 +1237,16 @@ read_BIN2R <- function(
       MARKPOS_Y2 = temp.MARKPOS_Y2,
       MARKPOS_X3 = temp.MARKPOS_X3,
       MARKPOS_Y3 = temp.MARKPOS_Y3,
+
+      ## FIXME(mcol): these two fields were not present when we were building
+      ## up a data.table directly, so to reproduce exactly the objects as
+      ## the previous code, we set them to 0, but arguably this is not
+      ## correct
+      EXTR_START = 0, # temp.EXTR_START,
+      EXTR_END = 0, # temp.EXTR_END,
+
       SEQUENCE = temp.SEQUENCE
-    )]
+    )
 
     results.DATA[[id_row]] <- temp.DPOINTS
 
@@ -1257,7 +1268,13 @@ read_BIN2R <- function(
   }
 
   ## remove NA values created by skipping records
+  results.METADATA <- rbindlist(results.METADATA.list)
   results.METADATA <- na.omit(results.METADATA, cols = "VERSION")
+
+  ## remove the first row (default) unless it's the only one left
+  if (nrow(results.METADATA) > 1) {
+    results.METADATA <- results.METADATA[-1]
+  }
 
   ##output
   if(verbose)

--- a/man/read_BIN2R.Rd
+++ b/man/read_BIN2R.Rd
@@ -118,7 +118,7 @@ The function works for BIN/BINX-format versions 03, 04, 05, 06, 07 and 08. The
 version number depends on the used Sequence Editor.
 }
 \section{Function version}{
- 0.17.3
+ 0.18
 }
 
 \examples{
@@ -145,6 +145,7 @@ DTU Nutech, 2016. The Sequence Editor, Users Manual, February, 2016.
 \author{
 Sebastian Kreutzer, Institute of Geography, Heidelberg University (Germany)\cr
 Margret C. Fuchs, HZDR Freiberg, (Germany) \cr
+Marco Colombo, Institute of Geography, Heidelberg University (Germany)\cr
 based on information provided by Torben Lapp and Karsten Bracht Nielsen (Risø DTU, Denmark)
 , RLum Developer Team}
 \keyword{IO}


### PR DESCRIPTION
This changes the way we build the final metadata table: rather than first allocating space for an empty `data.table` and then modify it at each iteration, we create a list of lists corresponding to each row and call `rbindlist()` on it at the end.

This provides a massive speed up: the time to read a 46MB file, goes from ~33s to ~15s.

I've left a FIXME note, as in the previous code the `EXTR_START` and `EXTR_END` fields (although they were read), were not assigned, so they picked up their default value (0). To reproduce exactly the previous results, I'm doing the same here, but I'm not sure if this is correct, so we may want to revisit it.

This is clearer to review by looking at the single commits, the speed up being contained in the first. Part of #298.