### PR TITLE
Return also the computed De without abs() from fit_DoseResponseCurve()

### DIFF
--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -1583,6 +1583,7 @@ fit_DoseResponseCurve <- function(
     Dc = Dc,
     n_N = n_N,
     De.MC = De.MonteCarlo,
+    De.plot = De, # no absolute value, used for plotting
     Fit = fit.method,
     HPDI68_L = HPDI[1,1],
     HPDI68_U = HPDI[1,2],

--- a/R/plot_DoseResponseCurve.R
+++ b/R/plot_DoseResponseCurve.R
@@ -114,7 +114,7 @@ plot_DoseResponseCurve <- function(
   colnames(xy) <- c("x", "y")
   y.Error <- sample[first.idx:last.idx, 3]
 
-  De <- object@data$De$De
+  De <- object@data$De$De.plot
   x.natural <- object@data$De.MC
   De.MonteCarlo <- mean(na.exclude(x.natural))
   De.Error <- sd(na.exclude(x.natural))

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL.md
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL.md
@@ -19,7 +19,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U", "RC.Status", "signal.range", "background.range", "signal.range.Tx", "background.range.Tx", "ALQ", "POS"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U", "RC.Status", "signal.range", "background.range", "signal.range.Tx", "background.range.Tx", "ALQ", "POS"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -79,6 +79,11 @@
                   "value": [1674.83051133]
                 },
                 {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1668.25051746]
+                },
+                {
                   "type": "character",
                   "attributes": {},
                   "value": ["EXP"]
@@ -96,7 +101,7 @@
                 {
                   "type": "double",
                   "attributes": {},
-                  "value": [1581.40910176]
+                  "value": [1580.77337983]
                 },
                 {
                   "type": "double",
@@ -325,7 +330,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U", "RC.Status", "signal.range", "background.range", "signal.range.Tx", "background.range.Tx", "ALQ", "POS"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U", "HPDI95_L", "HPDI95_U", "RC.Status", "signal.range", "background.range", "signal.range.Tx", "background.range.Tx", "ALQ", "POS"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -385,6 +390,11 @@
                   "value": [1770.23018623, 1669.32980118]
                 },
                 {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1768.62308496, 1660.6965308]
+                },
+                {
                   "type": "character",
                   "attributes": {},
                   "value": ["LIN", "LIN"]
@@ -402,12 +412,12 @@
                 {
                   "type": "double",
                   "attributes": {},
-                  "value": [1694.49193165, 1565.71247498]
+                  "value": [1694.00062711, 1565.71247498]
                 },
                 {
                   "type": "double",
                   "attributes": {},
-                  "value": [1844.33981662, 1751.68431891]
+                  "value": [1844.33981662, 1752.32339741]
                 },
                 {
                   "type": "character",
@@ -615,7 +625,7 @@
                       "value": ["srcref"]
                     }
                   },
-                  "value": [297, 5, 313, 10, 5, 10, 297, 313]
+                  "value": [291, 5, 307, 10, 5, 10, 291, 307]
                 }
               },
               "value": ["analyse_SAR.CWOSL(object = object[[x]], signal.integral.min = parm$signal.integral.min[[x]], ", "    signal.integral.max = parm$signal.integral.max[[x]], background.integral.min = parm$background.integral.min[[x]], ", "    background.integral.max = parm$background.integral.max[[x]], ", "    OSL.component = parm$OSL.component[[x]], dose.points = parm$dose.points[[x]], ", "    trim_channels = parm$trim_channels[[x]], mtext.outer = parm$mtext.outer[[x]], ", "    plot = parm$plot[[x]], rejection.criteria = parm$rejection.criteria[[x]], ", "    plot.single = parm$plot.single[[x]], plot_onePage = parm$plot_onePage[[x]], ", "    onlyLxTxTable = parm$onlyLxTxTable[[x]], main = main[[x]], ", "    ...)"]

--- a/tests/testthat/_snaps/fit_DoseResponseCurve.md
+++ b/tests/testthat/_snaps/fit_DoseResponseCurve.md
@@ -19,7 +19,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -77,6 +77,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1756.23503279]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1737.88094437]
                 },
                 {
                   "type": "character",
@@ -255,7 +260,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -313,6 +318,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1839.83430692]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1811.33104805]
                 },
                 {
                   "type": "character",
@@ -491,7 +501,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -539,6 +549,11 @@
                   "type": "logical",
                   "attributes": {},
                   "value": [null]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0]
                 },
                 {
                   "type": "double",
@@ -727,7 +742,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -785,6 +800,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1803.21631787]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1792.84642796]
                 },
                 {
                   "type": "character",
@@ -963,7 +983,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -1021,6 +1041,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1811.36154986]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1787.14784685]
                 },
                 {
                   "type": "character",
@@ -1199,7 +1224,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -1257,6 +1282,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1654.19502336]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1666.20445767]
                 },
                 {
                   "type": "character",
@@ -1435,7 +1465,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -1493,6 +1523,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1776.80632145]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1786.19063906]
                 },
                 {
                   "type": "character",
@@ -1671,7 +1706,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -1729,6 +1764,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1753.44276397]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1784.77518933]
                 },
                 {
                   "type": "character",
@@ -1907,7 +1947,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -1965,6 +2005,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [-38.31783644]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [-38.6899891]
                 },
                 {
                   "type": "character",
@@ -2143,7 +2188,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "Fit", "HPDI68_L", "HPDI68_U"]
+                  "value": ["De", "De.Error", "D01", "D01.ERROR", "D02", "D02.ERROR", "Dc", "n_N", "De.MC", "De.plot", "Fit", "HPDI68_L", "HPDI68_U"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -2201,6 +2246,11 @@
                   "type": "double",
                   "attributes": {},
                   "value": [-5.49687638e-06]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [-4.70773252e-06]
                 },
                 {
                   "type": "character",

--- a/tests/testthat/test_fit_DoseResponseCurve.R
+++ b/tests/testthat/test_fit_DoseResponseCurve.R
@@ -363,9 +363,7 @@ temp_LambertW <-
   LxTxData[1,2:3] <- c(0.5, 0.001)
   SW({
   LIN <- expect_s4_class(
-    fit_DoseResponseCurve(LxTxData,mode = "extrapolation", fit.method = "LIN",
-                     main = "Title", xlab = "x-axis", ylab = "y-axis",
-                     xlim = c(0, 10), ylim = c(0, 10)),
+    fit_DoseResponseCurve(LxTxData,mode = "extrapolation", fit.method = "LIN"),
     "RLum.Results")
   EXP <- expect_s4_class(
     fit_DoseResponseCurve(LxTxData,mode = "extrapolation", fit.method = "EXP"),


### PR DESCRIPTION
This allows to produce correct plots in the extrapolation case, where `De` can be negative. Fixes #340.