### PR TITLE
Always recompute the record index at the end of read_BIN2R()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -98,6 +98,11 @@ fixed in #263).
 * Add support for `lphi` and `ltheta` light direction arguments for `plot.type = "persp"`. 
 * Fix the reason for the unclear warning `In col.unique == col :  longer object length is not a multiple of shorter object length`
 
+### `read_BIN2R()`
+* Argument `n.records` is now better supported for BIN files v3 and v4 and
+doesn't lead to a crash when used in conjuction with the `fastForward`
+option (#343, fixed in #344).
+
 ### `read_XSYG2R()`
 * Add a new argument `n_records` that enables to limit the number of imported records in case the file was faulty or only a limited number of records is wanted.  
 * The function sometimes struggled with the import if only a directory was provided; fixed. 

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -914,6 +914,7 @@ read_BIN2R <- function(
 
       ## set temp ID if within select
       if(!is.null(n.records) && !(temp.ID + 1) %in% n.records) {
+        temp.ID <- temp.ID + 1
         seek.connection(con, temp.LENGTH - 8, origin = "current")
         next()
       }

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -1254,18 +1254,14 @@ read_BIN2R <- function(
   if(verbose)
     message("\t >> ", length(results.DATA), " records read successfully\n")
 
-  # Further limitation --------------------------------------------------------------------------
+  ## Record removals --------------------------------------------------------
+
+  ## check if only the specified positions should be returned
   if(!is.null(position)){
     ##check whether the position is valid at all
     if (all(position %in% results.METADATA[["POSITION"]])) {
       results.METADATA <- results.METADATA[which(results.METADATA[["POSITION"]] %in% position),]
       results.DATA <- results.DATA[results.METADATA[["ID"]]]
-
-        ##re-calculate ID ... otherwise it will not match
-        results.METADATA[["ID"]] <- 1:length(results.DATA )
-
-        ##show a message
-        message("[read_BIN2R()] The record index has been recalculated")
 
     }else{
       .throw_warning("At least one position number is not valid, ",
@@ -1274,6 +1270,12 @@ read_BIN2R <- function(
                                quote = FALSE))
     }
   }
+
+  ## recalculate ID as some records may not have been read if n.records was set
+  ## or were dropped by position in the previous block
+  results.METADATA[["ID"]] <- 1:nrow(results.METADATA)
+  if (verbose)
+    message("[read_BIN2R()] The record index has been recalculated")
 
   ##check for position that have no data at all (error during the measurement)
   if(zero_data.rm){

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -158,6 +158,9 @@ test_that("test the import of various BIN-file versions", {
              show.raw.values = list(TRUE), zero_data.rm = list(FALSE),
              duplicated.rm = list(TRUE), show.record.number = list(TRUE),
              forced.VersionNumber = list(8), fastForward = TRUE)
-  })
   expect_length(res[[2]], 0)
+
+  res <- read_BIN2R(bin.v8, verbose = FALSE, n.records = 2, fastForward = TRUE)
+  expect_length(res, 1)
+  })
 })

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -162,5 +162,8 @@ test_that("test the import of various BIN-file versions", {
 
   res <- read_BIN2R(bin.v8, verbose = FALSE, n.records = 2, fastForward = TRUE)
   expect_length(res, 1)
+
+  res <- read_BIN2R(test_path("_data/BINfile_V3.bin"), n.records = 2)
+  expect_length(res, 1)
   })
 })


### PR DESCRIPTION
If records are not read because n.records is set by the user, the record ID will not be sequential starting from 1, and thus cause problems elsewhere. Fixes #343.