### PR TITLE
Update the .RESERVED slot when records are dropped in read_BIN2R()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -105,6 +105,8 @@ doesn't lead to a crash when used in conjuction with the `fastForward`
 option (#343, fixed in #344).
 * Argument `zero_data.rm` was not correctly propagated if the input object
 was provided as a list (#342, fixed in #345).
+* The `.RESERVED` slot is now kept in sync with the rest of the object
+when records are dropped from the input BIN/BINX file (#337, fixed in #348).
 
 ### `read_XSYG2R()`
 * Add a new argument `n_records` that enables to limit the number of imported records in case the file was faulty or only a limited number of records is wanted.  

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -1265,6 +1265,7 @@ read_BIN2R <- function(
       keep.positions <- results.METADATA[["POSITION"]] %in% position
       results.METADATA <- results.METADATA[keep.positions, ]
       results.DATA <- results.DATA[keep.positions]
+      results.RESERVED <- results.RESERVED[keep.positions]
 
       if (verbose) {
         message("[read_BIN2R()] Kept records matching 'position': ",
@@ -1292,6 +1293,8 @@ read_BIN2R <- function(
     if(length(zero_data.check) != 0){
       results.METADATA <- results.METADATA[-zero_data.check, ]
       results.DATA[zero_data.check] <- NULL
+      results.RESERVED[zero_data.check] <- NULL
+
       ## if nothing is left, return an empty object
       if(nrow(results.METADATA) == 0)
         return(set_Risoe.BINfileData())
@@ -1323,6 +1326,7 @@ read_BIN2R <- function(
         ##remove records
         results.METADATA <- results.METADATA[-duplication.check, ]
         results.DATA[duplication.check] <- NULL
+        results.RESERVED[duplication.check] <- NULL
 
         ##recalculate record index
         results.METADATA[["ID"]] <- 1:nrow(results.METADATA)

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -91,8 +91,10 @@ test_that("test the import of various BIN-file versions", {
   bin.v8 <- system.file("extdata/BINfile_V8.binx", package = "Luminescence")
   expect_s4_class(read_BIN2R(bin.v8, txtProgressBar = FALSE),
                   class = "Risoe.BINfileData")
-
-  ## V8 - as part of the package ... with arguments
+  expect_message(res <- read_BIN2R(bin.v8, txtProgressBar = FALSE,
+                                   position = 2),
+                 "Kept records matching 'position': 2")
+  expect_equal(length(res@.RESERVED), nrow(res@METADATA))
   expect_message(res <- read_BIN2R(bin.v8, txtProgressBar = FALSE,
                                    position = 1, fastForward = TRUE),
                  "Kept records matching 'position': 1")
@@ -184,12 +186,14 @@ test_that("test hand-crafted files", {
                                    duplicated.rm = TRUE, verbose = TRUE),
                  "Duplicated records detected and removed: 2")
   expect_equal(nrow(res@METADATA), 2)
+  expect_equal(length(res@.RESERVED), nrow(res@METADATA))
 
   zero.data.bin <- test_path("_data/bin-tests/zero-data-record.binx")
 
   expect_warning(res <- read_BIN2R(zero.data.bin, verbose = TRUE),
                  "Zero-data records detected and removed: 2")
   expect_equal(nrow(res@METADATA), 1)
+  expect_equal(length(res@.RESERVED), nrow(res@METADATA))
 
   expect_silent(res <- read_BIN2R(list(zero.data.bin), verbose = FALSE,
                                   zero_data.rm = FALSE))


### PR DESCRIPTION
Fixes #337.