### PR TITLE
Return empty objects from read_BIN2R() when no records are kept

### DIFF
--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -1040,15 +1040,13 @@ read_BIN2R <- function(
 
     ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     ## Unrecognised version
-    else {
-      ## We should already have raised a warning that the file is corrupt
-      ## during the first scan of the BIN/BINX file: at that point we have
-      ## set `n.records` so that we would stop reading before encountering
-      ## again the record with unrecognised version number, so here we just
-      ## assert that that is the case and exit the loop
-      stopifnot(temp.ID + 1 > n.records)
-      break()
-    }
+    ##
+    ## We should already have raised a warning that the file is corrupt
+    ## during the first scan of the BIN/BINX file: at that point we have
+    ## set `n.records` so that we would stop reading before encountering
+    ## again the record with unrecognised version number, so here we just
+    ## assert that that is the case
+    stopifnot(temp.VERSION %in% VERSIONS.supported)
 
      #DPOINTS
      if(temp.RECTYPE != 128) {

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -581,22 +581,17 @@ read_BIN2R <- function(
         if(temp.RECTYPE != 0 & temp.RECTYPE != 1 & temp.RECTYPE != 128) {
           ##jump to the next record by stepping the record length minus the already read bytes
           seek.connection(con, temp.LENGTH - 15, origin = "current")
-            if(!ignore.RECTYPE){
-              .throw_error("Byte RECTYPE = ", temp.RECTYPE,
-                           " is not supported in record #", temp.ID + 1, ", ",
-                           "check your BIN/BINX file")
-            } else {
-              if(verbose)
-                message("\n[read_BIN2R()] Byte RECTYPE = ", temp.RECTYPE,
-                        " is not supported in record #", temp.ID + 1,
-                        ", record skipped")
+          msg <- paste0("Byte RECTYPE = ", temp.RECTYPE,
+                        " is not supported in record #", temp.ID + 1)
+          if (!ignore.RECTYPE) {
+            .throw_error(msg, ", set `ignore.RECTYPE = TRUE` to skip this record")
+          }
 
-              ## update and jump to next record, to avoid further trouble
-              ## we set the VERSION to NA and remove it later, otherwise we
-              ## break expected functionality
-              temp.ID <- temp.ID + 1
-              next()
-            }
+          ## skip to next record
+          if (verbose)
+            message("\n[read_BIN2R()] ", msg, ", record skipped")
+          temp.ID <- temp.ID + 1
+          next()
         }
       }
 

--- a/tests/testthat/test_Risoe.BINfileData2RLum.Analysis.R
+++ b/tests/testthat/test_Risoe.BINfileData2RLum.Analysis.R
@@ -50,8 +50,18 @@ test_that("check functionality", {
   expect_s4_class(res, "RLum.Analysis")
 
   ## reading an empty object
-  zero <- read_BIN2R(test_path("_data/BINfile_V3.bin"), n.records = 999,
-                     verbose = FALSE)
+  empty <- read_BIN2R(test_path("_data/BINfile_V3.bin"), n.records = 999,
+                      verbose = FALSE)
+  expect_null(Risoe.BINfileData2RLum.Analysis(empty))
+  expect_null(Risoe.BINfileData2RLum.Analysis(empty, keep.empty = FALSE))
+  expect_warning(expect_null(Risoe.BINfileData2RLum.Analysis(empty, pos = 0)),
+                 "Invalid position number skipped: 0")
+
+  ## reading an object with fields set to zero
+  zero <- set_Risoe.BINfileData(METADATA = data.frame(ID = 1, VERSION = 0,
+                                                      POSITION = 0, GRAIN = 0),
+                                DATA = list(),
+                                .RESERVED = list())
   expect_message(res <- Risoe.BINfileData2RLum.Analysis(zero),
                  "Empty Risoe.BINfileData object detected")
   expect_s4_class(res, "RLum.Analysis")

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -48,9 +48,10 @@ test_that("input validation", {
   expect_error(read_BIN2R(fake, verbose = FALSE),
                "Byte RECTYPE = 99 is not supported in record #1")
   SW({
-  expect_message(read_BIN2R(fake, verbose = TRUE, ignore.RECTYPE = TRUE),
+  expect_message(res <- read_BIN2R(fake, verbose = TRUE, ignore.RECTYPE = TRUE),
                  "Byte RECTYPE = 99 is not supported in record #1")
   })
+  expect_length(res, 0)
 })
 
 test_that("test the import of various BIN-file versions", {
@@ -106,22 +107,21 @@ test_that("test the import of various BIN-file versions", {
         file = bin.v8,
         txtProgressBar = FALSE,
         n.records = 1), class = "Risoe.BINfileData")
+    expect_length(t_n.records_1, n = 1)
+
     t_n.records_0 <- expect_s4_class(
       read_BIN2R(
         file = bin.v8,
         txtProgressBar = FALSE,
         n.records = 0), class = "Risoe.BINfileData")
+    expect_length(t_n.records_0, n = 0)
 
     t_n.records_1_2 <- expect_s4_class(
       read_BIN2R(
         file = bin.v8,
         txtProgressBar = FALSE,
         n.records = 1:2), class = "Risoe.BINfileData")
-
-      ## test length
-      expect_length(t_n.records_1, n = 1)
-      expect_length(t_n.records_0, n = 1)
-      expect_length(t_n.records_1_2, n = 2)
+    expect_length(t_n.records_1_2, n = 2)
 
   ## directory
   res <- read_BIN2R(test_path("_data"), show_record_number = TRUE)


### PR DESCRIPTION
This ensures that we return an object that is recognised to be empty (`set_Risoe.BINfileData()`), rather than objects with all fields set to 0. Fixes #346.

This also removes a block of code that had become unreachable after the changes in 58c2c23, and  consolidates the text of two messages.