### PR TITLE
Don't let verify_SingleGrainData() crash on an empty list input

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -130,6 +130,10 @@ ROI record while using `fastForward = TRUE` (#356, fixed in #360).
 * Support for DRAC v1.1 XLS/XLSX files has been dropped, users should use
 CSV files according to the DRAC v1.2 CSV template.
 
+### `verify_SingleGrainData()`
+* The function doesn't crash anymore when applied to an empty list (#365,
+fixed in #366).
+
 ### `write_R2BIN()`
 * Recently, non-ASCII characters in comments or file names became more common and that led to crashes during the 
 file export. To avoid this now all non-ASCII characters are replaced by `_` before writing them to the BIN/BINX files. 

--- a/R/verify_SingleGrainData.R
+++ b/R/verify_SingleGrainData.R
@@ -157,6 +157,9 @@ verify_SingleGrainData <- function(
 
   # Self Call -----------------------------------------------------------------------------------
   if(is(object, "list")){
+    if (length(object) == 0)
+      return(set_RLum(class = if (cleanup) "RLum.Analysis"
+                              else "RLum.Results"))
     results <- .warningCatcher(lapply(1:length(object), function(x) {
       verify_SingleGrainData(
         object = object[[x]],

--- a/tests/testthat/test_verify_SingleGrainData.R
+++ b/tests/testthat/test_verify_SingleGrainData.R
@@ -52,6 +52,17 @@ test_that("check functionality", {
   res <- expect_silent(verify_SingleGrainData(obj.risoe))
   expect_s4_class(res, "RLum.Results")
 
+  ## empty list
+  expect_s4_class(res <- verify_SingleGrainData(list()),
+                  "RLum.Results")
+  expect_length(res@data, 0)
+  expect_equal(res@originator, "verify_SingleGrainData")
+
+  expect_s4_class(res <- verify_SingleGrainData(list(), cleanup = TRUE),
+                  "RLum.Analysis")
+  expect_length(res@records, 0)
+  expect_equal(res@originator, "verify_SingleGrainData")
+
   ##check options
   expect_silent(suppressWarnings(verify_SingleGrainData(object, plot = TRUE)))
   expect_silent(suppressWarnings(verify_SingleGrainData(object, threshold = 100)))


### PR DESCRIPTION
Fixes #365.