### PR TITLE
Check if the originator is not NA before using it in a comparison

### DIFF
--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -459,7 +459,8 @@ analyse_IRSAR.RF<- function(
       temp_main <- .listify(list(...)$main, rep.length)
 
     }else{
-      if(object[[1]]@originator == "read_RF2R"){
+      originator <- object[[1]]@originator
+      if (!is.na(originator) && originator == "read_RF2R") {
         temp_main <- lapply(object, function(x) x@info$ROI)
       } else {
         temp_main <- as.list(paste0("ALQ #",1:length(object)))

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -159,5 +159,11 @@ test_that("test edge cases", {
     plot = TRUE,
     txtProgressBar = FALSE
   )), "RLum.Results")
+})
 
+test_that("regression tests", {
+  testthat::skip_on_cran()
+
+  ## issue 382
+  expect_silent(analyse_IRSAR.RF(list(IRSAR.RF.Data), plot = FALSE))
 })


### PR DESCRIPTION
Fixes #382.