### PR TITLE
Don't listify the method.control argument when the input object is a list

### DIFF
--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -443,7 +443,6 @@ analyse_IRSAR.RF<- function(
     RF_nat.lim <- .listify(RF_nat.lim, rep.length)
     RF_reg.lim <- .listify(RF_reg.lim, rep.length)
     method <- .listify(method, rep.length)
-    method.control <- .listify(method.control, rep.length)
     n.MC <- .listify(n.MC, rep.length)
 
     ##test_parameters
@@ -476,7 +475,7 @@ analyse_IRSAR.RF<- function(
         RF_nat.lim = RF_nat.lim[[x]],
         RF_reg.lim = RF_reg.lim[[x]],
         method = method[[x]],
-        method.control = method.control[[x]],
+        method.control = method.control,
         test_parameters = test_parameters[[x]],
         n.MC = n.MC[[x]],
         txtProgressBar = txtProgressBar,

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -164,6 +164,10 @@ test_that("test edge cases", {
 test_that("regression tests", {
   testthat::skip_on_cran()
 
+  ## issue 372
+  expect_silent(analyse_IRSAR.RF(list(IRSAR.RF.Data), plot = FALSE,
+                                 method.control = list(maxiter = 10)))
+
   ## issue 382
   expect_silent(analyse_IRSAR.RF(list(IRSAR.RF.Data), plot = FALSE))
 })


### PR DESCRIPTION
As `method.control` is already given as a list and it's unlikely we want to support applying different algorithmic parameters to different aliquots, in the self-call we pass it directly, without further listifying it. I've checked all other uses we have of `method.control` and indeed this was the only case.

This is a regression that was introduced in f0d075275, and was first noticed in #372.