### PR TITLE
Improve performance of src_analyse_IRSARRF_SRS() with optimization at -O2

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -50,11 +50,13 @@ older than 5 was used (#281, fixed in #282).
 
 ### `analyse_IRSAR.RF()`
 * The performance of this function has been improved for the "SLIDE" and
-"VSLIDE" methods: the default number of sliding windows tested in the
-algorithm has been reduced from 10 to 3, and the new `num_slide_windows`
-option provides a way of tuning this parameter, thus allowing to find a
-balance between computation time and quality of fit (#372, fixed in #388
-and #398).
+"VSLIDE" methods, thanks both to tweaks in the C++ implementation of the
+sliding algorithm and in how that is managed on the R side. In particular,
+the default number of sliding windows tested in the algorithm has been
+reduced from 10 to 3: this value is no longer hardcoded, but can be tuned
+through the new `num_slide_windows` setting (part of the `method.control`
+option), thus allowing to find a balance between computation time and
+quality of fit (#372, fixed in #388, #398 and #399).
 * The function is more robust against `sequence_structure` misspecifications
 (#393, fixed in #394).
 * Some data preparation steps where not correctly applied for `method = "VSLIDE"`

--- a/src/src_analyse_IRSARRF_SRS.cpp
+++ b/src/src_analyse_IRSARRF_SRS.cpp
@@ -46,10 +46,9 @@ RcppExport SEXP analyse_IRSARRF_SRS(arma::vec values_regenerated_limited,
   int v_length = vslide_range.size();
   int v_index = 0;
   arma::vec results(res_size);
-  arma::vec residuals(nat_size);
-  arma::vec v_leftright(two_size); // the virtual vector
-  arma::vec t_leftright(two_size); // the test points
-  arma::vec c_leftright(two_size); // the calculation
+  arma::vec::fixed<two_size> v_leftright; // the virtual vector
+  arma::vec::fixed<two_size> t_leftright; // the test points
+  arma::vec::fixed<two_size> c_leftright; // the calculation
 
   // initialise values: at the beginning, the virtual vector includes all
   // points in vslide_range
@@ -84,19 +83,18 @@ RcppExport SEXP analyse_IRSARRF_SRS(arma::vec values_regenerated_limited,
 
       //HORIZONTAL SLIDING CORE -------------------------------------------------------------(start)
 
+      results.zeros();
       auto curr_vslide_range = vslide_range[t_leftright[t]];
 
       //slide the curves against each other
-      for (int i=0; i<static_cast<int>(results.size()); ++i){
+      for (unsigned int i = 0u; i < res_size; ++i) {
+        // calculate the sum of squared residuals along one curve
 
-        //calculate squared residuals along one curve
-        for (int j=0; j<static_cast<int>(values_natural_limited.size()); ++j){
-          residuals[j] = pow(values_regenerated_limited[j + i] -
-                             (values_natural_limited[j] + curr_vslide_range), 2);
+        for (unsigned int j = 0u; j < nat_size; ++j) {
+          double residual = values_regenerated_limited[j + i] -
+            (values_natural_limited[j] + curr_vslide_range);
+          results[i] += residual * residual;
         }
-
-        //sum results and fill the results vector
-        results[i] = sum(residuals);
       }
 
       //HORIZONTAL SLIDING CORE ---------------------------------------------------------------(end)

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -80,6 +80,14 @@ test_that("input validation", {
                                   method.control = list(vslide_range = 1:4)),
                  "'vslide_range' in 'method.control' has more than 2 elements")
 
+  ## num_slide_windows
+  expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
+                                method.control = list(num_slide_windows = NA)),
+                 "should be a positive integer scalar")
+  expect_warning(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
+                                  method.control = list(num_slide_windows = 20)),
+                 "should be between 1 and 10, reset to 10")
+
   expect_message(analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE",
                                   method.control = list(cores = "4")),
                  "Invalid value for control argument 'cores'")


### PR DESCRIPTION
These changes improve the running time of our example when using -O2, which is the default compilation flag on CRAN. This is a mild regression for the -O3 flag, but given that hardly anybody will use that, the compromise seems worth it. Part of #372.

Single core performance using 3 slide windows:
 - with -O2 time goes from 13.5s to 10.7s
 - with -03 time goes from 10.1s to 10.7s

Single core performance using 10 slide windows:
 - with -O2 time goes from 40.9s to 32.6s
 - with -03 time goes from 29.1s to 32.5s