### PR TITLE
Clean up calc_EED_Model() and increase coverage

### DIFF
--- a/R/calc_EED_Model.R
+++ b/R/calc_EED_Model.R
@@ -49,11 +49,11 @@
 #' @param sample_name [character] (*with default*): name of the sample
 #'
 #' @param method_control [list] (*with default*): additional deep control parameters, parameters
-#' need to be provided as names list, see details
+#' need to be provided as named list, see details
 #'
-#' @param verbose [logical] (with default): enable/disable verbose mode
+#' @param verbose [logical] (*with default*): enable/disable verbose mode
 #'
-#' @param plot [logical] (with default): enable/disable plot output
+#' @param plot [logical] (*with default*): enable/disable plot output
 #'
 #' @param ... further parameters that can be passed to better control the plot output. Support arguments
 #' are `xlab`, `xlim`.
@@ -111,9 +111,9 @@ calc_EED_Model <- function(
   verbose = TRUE,
   plot = TRUE,
   ...
-
-){
-
+) {
+  .set_function_name("calc_EED_Model")
+  on.exit(.unset_function_name(), add = TRUE)
 
   ##TODO
   ## add docu examples
@@ -125,23 +125,19 @@ calc_EED_Model <- function(
   ##  - so far the parameter uncertainty estimation does not work nicely.x
   ##  happens to data where this is not observed? I cannot work?
 
-# Integrity tests  ----------------------------------------------------------------------------
-  ##check input data and make it a hard stop
-  if(missing(data) || class(data) != 'data.frame')
-    stop("[calc_EED_Model()] 'data' needs to be a two-column data.frame, see manual!", call. = FALSE)
+  ## Integrity checks -------------------------------------------------------
 
-  if(missing(expected_dose) || !is.numeric(expected_dose))
-    stop("[calc_EED_Model()] 'expected_dose' is either missing or not of type numeric!", call. = FALSE)
-
+  .validate_class(data, "data.frame")
+  .validate_class(expected_dose, "numeric")
 
   ##store and restore par settings
   par_default <- par(no.readonly = TRUE)
-  on.exit(par(mfrow = par_default$mfrow))
+  on.exit(par(mfrow = par_default$mfrow), add = TRUE)
 
 # Helper functions ----------------------------------------------------------------------------
 
   ##the helper functions base on ode by Pierre, each helper was only a little bit
-  ##optimised and then tested separatly
+  ## optimised and then tested separately
 
   # Calcul de la variance du plateau sur la base des doses arch?o
   # corrig?es de la dose r?siduelle uniquement (modif 31.5.2018)
@@ -296,7 +292,7 @@ calc_EED_Model <- function(
         return(1)
 
       if (!is.numeric(MinIndivDose))
-        stop("[calc_EED_Model()] MinIndivDose must by of type numeric or NULL!", call. = FALSE)
+        .throw_error("MinIndivDose must by of type numeric or NULL")
 
       current_index <- 1
       while ((MinIndivDose > M_Data[current_index, 9]) &
@@ -315,7 +311,7 @@ calc_EED_Model <- function(
       return(Ndata)
 
     if (!is.numeric(MaxIndivDose))
-      stop("[calc_EED_Model()] MaxIndivDose must by of type numeric or NULL!", call. = FALSE)
+      .throw_error("MaxIndivDose must by of type numeric or NULL")
 
         current_index <- 1
         while ((MaxIndivDose > M_Data[current_index, 9]) &
@@ -367,7 +363,6 @@ calc_EED_Model <- function(
                                             MaxDose_Index = set_MaxDose_Index),
         RESIDUAL = sum((M_Data[,6] - rep(set_expected_dose, nrow(M_Data)))^2)
         ))
-
       }
 
     par(mfrow = c(3,3))
@@ -403,7 +398,6 @@ calc_EED_Model <- function(
             M_Data,
             Ndata
           )
-
       }
 
       ##surface interpolation
@@ -417,8 +411,9 @@ calc_EED_Model <- function(
           duplicate = "strip" #does not seem to work
         ), silent = FALSE)
 
-      if(inherits(s, "try-error"))
-        stop("[calc_EED_Model()] Surface interpolation failed, you may want to try it again!", call. = FALSE)
+      if (inherits(s, "try-error")) {
+        .throw_error("Surface interpolation failed, you may want to try it again")
+      }
 
       ##graphical output
       if(plot & method_control$trace_plot){
@@ -446,7 +441,6 @@ calc_EED_Model <- function(
         cat("\n\n variance threshold: ", min(s$z, na.rm = TRUE))
         cat("\n >> kappa: ",   optim_kappa[1], "\u00b1", optim_kappa[2])
         cat("\n >> sigma_distr: ", optim_sigm_distr[1] , "\u00b1", optim_sigm_distr[2])
-
       }
 
         ##reset parameters
@@ -456,7 +450,6 @@ calc_EED_Model <- function(
       if(verbose && method_control$trace){
         cat("\n >> lower: ",  paste(method_control$lower[1:2], collapse = ", "))
         cat("\n >> upper: ",  paste(method_control$upper[1:2], collapse = ", "))
-
       }
 
       ##update threshold
@@ -466,7 +459,6 @@ calc_EED_Model <- function(
       ##implement differential break if the search area is already smaller than the area
       if(diff(c(method_control$lower[1], method_control$upper[1])) < 0.1)
          break()
-
     }
 
     return(list(
@@ -475,7 +467,6 @@ calc_EED_Model <- function(
        min_var = test_var,
        expected_dose = m[1,3]
        ))
-
   }
 
 # Input data ----------------------------------------------------------------------------------
@@ -580,7 +571,6 @@ if(is.null(kappa) || is.null(sigma_distr)){
     cat(">> min. variance:", min_var)
     cat("\n>> kappa: ", kappa, " | sigma: ",sigma_distr)
   }
-
 }
 
 # Calculation ---------------------------------------------------------------------------------
@@ -601,8 +591,6 @@ cat("\n------------------------------------ \n")
 cat("\n Maximal Individual Equivalent Dose integrated: ", round(M_Data[index_min_uncert[1],9],2), "Gy")
 cat("\n Averaged Corrected Equivalent Dose: ",
     round(M_Data[index_min_uncert[1],6],2), "\u00b1", round(M_Data[index_min_uncert[1],7],2), "Gy")
-
-
 }
 
 #### THE ONE SHOT : calcule les valeurs de dose moyenne
@@ -786,7 +774,6 @@ if(plot) {
      col = "green"
    )
 
-
    ##add legend
    legend(
      "topright",
@@ -799,7 +786,6 @@ if(plot) {
      bty = "n",
      pch = 20,
      col = c("black", "grey", "red", "green"))
-
 
    ##add standard deviation plot
    plot(
@@ -825,5 +811,4 @@ set_RLum(
   info = list(
     call = sys.call()
   ))
-
 }

--- a/man/calc_EED_Model.Rd
+++ b/man/calc_EED_Model.Rd
@@ -51,11 +51,11 @@ contribution from the sampling}
 \item{sample_name}{\link{character} (\emph{with default}): name of the sample}
 
 \item{method_control}{\link{list} (\emph{with default}): additional deep control parameters, parameters
-need to be provided as names list, see details}
+need to be provided as named list, see details}
 
-\item{verbose}{\link{logical} (with default): enable/disable verbose mode}
+\item{verbose}{\link{logical} (\emph{with default}): enable/disable verbose mode}
 
-\item{plot}{\link{logical} (with default): enable/disable plot output}
+\item{plot}{\link{logical} (\emph{with default}): enable/disable plot output}
 
 \item{...}{further parameters that can be passed to better control the plot output. Support arguments
 are \code{xlab}, \code{xlim}.}

--- a/tests/testthat/test_calc_EED_Model.R
+++ b/tests/testthat/test_calc_EED_Model.R
@@ -1,30 +1,31 @@
-## load needed example data
+## load data
 data(ExampleData.MortarData, envir = environment())
 
-test_that("break function", {
+test_that("input validation", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## data
-  expect_error(calc_EED_Model(), regexp = "'data' needs to be a two-column data.frame, see manual!")
-  expect_error(calc_EED_Model(1L), regexp = "'data' needs to be a two-column data.frame, see manual!")
+  expect_error(calc_EED_Model(),
+               "'data' should be of class 'data.frame'")
+  expect_error(calc_EED_Model(1L),
+               "'data' should be of class 'data.frame'")
 
   ## expected dose
-  expect_error(calc_EED_Model(data = MortarData), regexp = "'expected_dose' is either missing or not of type numeric!")
-  expect_error(calc_EED_Model(data = MortarData, expected_dose = "test"),
-               regexp = "'expected_dose' is either missing or not of type numeric!")
-
-
-
+  expect_error(calc_EED_Model(MortarData),
+               "'expected_dose' should be of class 'numeric'")
+  expect_error(calc_EED_Model(MortarData, expected_dose = "error"),
+               "'expected_dose' should be of class 'numeric'")
 })
 
-test_that("successfull run", {
+test_that("check functionality", {
   testthat::skip_on_cran()
-  local_edition(3)
 
   ## automated
   set.seed(1)
-  expect_s4_class(calc_EED_Model(data = MortarData, expected_dose = 11.7), "RLum.Results")
+  SW({
+  expect_s4_class(calc_EED_Model(MortarData, expected_dose = 11.7),
+                  "RLum.Results")
+  })
 
   ## TODO this leads to a crash and should be checked
   ## calc_EED_Model(data = MortarData, expected_dose = 11.7, n.simul = 1950)
@@ -34,6 +35,7 @@ test_that("successfull run", {
     data = MortarData,
     kappa = 14,
     sigma_distr = 0.37,
+    verbose = FALSE,
     expected_dose = 11.7), "RLum.Results")
 
   ## fast run, no plot, no terminal
@@ -44,5 +46,4 @@ test_that("successfull run", {
     verbose = FALSE,
     plot = FALSE,
     expected_dose = 11.7), "RLum.Results")
-
 })

--- a/tests/testthat/test_calc_EED_Model.R
+++ b/tests/testthat/test_calc_EED_Model.R
@@ -15,6 +15,14 @@ test_that("input validation", {
                "'expected_dose' should be of class 'numeric'")
   expect_error(calc_EED_Model(MortarData, expected_dose = "error"),
                "'expected_dose' should be of class 'numeric'")
+
+  ## IndivDose
+  expect_error(calc_EED_Model(MortarData, expected_dose = 0.17,
+                              MinIndivDose = "error"),
+               "'MinIndivDose' should be of class 'numeric")
+  expect_error(calc_EED_Model(MortarData, expected_dose = 0.17,
+                              MaxIndivDose = "error"),
+               "'MaxIndivDose' should be of class 'numeric")
 })
 
 test_that("check functionality", {
@@ -46,4 +54,14 @@ test_that("check functionality", {
     verbose = FALSE,
     plot = FALSE,
     expected_dose = 11.7), "RLum.Results")
+
+  ## more coverage
+  SW({
+  expect_s4_class(calc_EED_Model(
+    data = MortarData,
+    sigma_distr = 0.37,
+    verbose = TRUE,
+    method_control = list(trace = TRUE, trace_plot = TRUE),
+    expected_dose = 11.7), "RLum.Results")
+  })
 })


### PR DESCRIPTION
This adds some `nocov` blocks around functions that are not called, and removes a duplicate copy of `.Initial_State_of_OSL()`. Fixes #404.