### PR TITLE
Add an internal helper function to validate the expected length of an input

### DIFF
--- a/R/analyse_Al2O3C_Measurement.R
+++ b/R/analyse_Al2O3C_Measurement.R
@@ -315,8 +315,7 @@ analyse_Al2O3C_Measurement <- function(
                      "was created by an unsupported function")
       }
     } else if (is.numeric(irradiation_time_correction)) {
-      if (length(irradiation_time_correction) != 2)
-        .throw_error("'irradiation_time_correction' must have length 2")
+      .validate_length(irradiation_time_correction, 2)
     }
   }
 

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -132,9 +132,8 @@ calc_FastRatio <- function(object,
   .validate_positive_scalar(Ch_L1, int = TRUE)
   .validate_positive_scalar(Ch_L2, int = TRUE, null.ok = TRUE)
   if (!is.null(Ch_L3)) {
-    if (!is.numeric(Ch_L3) || length(Ch_L3) != 2) {
-      .throw_error("Input for 'Ch_L3' must be a vector of length 2")
-    }
+    .validate_class(Ch_L3, c("integer", "numeric"))
+    .validate_length(Ch_L3, 2)
     .validate_positive_scalar(Ch_L3[1], int = TRUE, name = "'Ch_L3[1]'")
     .validate_positive_scalar(Ch_L3[2], int = TRUE, name = "'Ch_L3[2]'")
     if (Ch_L3[1] > Ch_L3[2]) {

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -309,8 +309,9 @@ calc_Huntley2006 <- function(
   fit.method <- .validate_args(fit.method, c("EXP", "GOK"))
 
   ## Check length of lower.bounds
-  if (fit.method[1] == "GOK" && length(lower.bounds) != 4)
-    .throw_error("Argument 'lower.bounds' must be of length 4.")
+  if (fit.method[1] == "GOK") {
+    .validate_length(lower.bounds, 4)
+  }
 
   ## Check 'data'
   # must be a data frame
@@ -384,10 +385,7 @@ calc_Huntley2006 <- function(
 
   # check if numeric
   if (is.numeric(rhop)) {
-
-    ### TODO: can be of length 2 if error
-    if (length(rhop) != 2)
-      .throw_error("'rhop' must be a vector of length 2.")
+    .validate_length(rhop, 2)
 
     # alternatively, and RLum.Results object produced by analyse_FadingMeasurement()
     # can be provided
@@ -408,12 +406,10 @@ calc_Huntley2006 <- function(
   }
 
   ## Check ddot & readerDdot
-  # check if numeric
-  if (any(sapply(list(ddot, readerDdot), is.numeric) == FALSE))
-    .throw_error("'ddot' and 'readerDdot' must be numeric vectors.")
-  # check if length == 2
-  if (any(sapply(list(ddot, readerDdot), function(x) length(x) == 2) == FALSE))
-    .throw_error("'ddot' and 'readerDdot' must be of length 2.")
+  .validate_class(ddot, "numeric")
+  .validate_length(ddot, 2)
+  .validate_class(readerDdot, "numeric")
+  .validate_length(readerDdot, 2)
 
   ## Settings ------------------------------------------------------------------
   settings <- modifyList(

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1227,6 +1227,47 @@ SW <- function(expr) {
   return(TRUE)
 }
 
+#' @title Validate the length of a variable
+#'
+#' @param arg [character] (**required**): variable to validate.
+#' @param exp.length [integer] (**required**): the expected length.
+#' @param throw.error [logical] (*with default*): whether an error should be
+#'        thrown in case of failed validation (`TRUE` by default). If `FALSE`,
+#'        the function raises a warning and proceeds.
+#' @param name [character] (*with default*): variable name to report in case
+#'        of error: if specified, it's reported as is; if not specified it's
+#'        inferred from the name of the variable tested and reported with
+#'        quotes.
+#'
+#' @return
+#' If `throw.error = TRUE`, the function throws an error and doesn't return
+#' anything. Otherwise, it will return a boolean to indicate whether validation
+#' was successful or not.
+#'
+#' @md
+#' @noRd
+.validate_length <- function(arg, exp.length, throw.error = TRUE,
+                            name = NULL) {
+
+  if (missing(exp.length)) {
+    .throw_error("'exp.length' must be provided")
+  }
+
+  ## name of the argument to report if not specified
+  if (is.null(name))
+    name <- sprintf("'%s'", all.vars(match.call())[1])
+
+  if (length(arg) != exp.length) {
+
+    msg <- paste0(name, " should have length ", exp.length)
+    if (throw.error)
+      .throw_error(msg)
+    .throw_warning(msg)
+    return(FALSE)
+  }
+  return(TRUE)
+}
+
 #' @title Validate Scalar Variables Expected to be Positive
 #'
 #' @param val [numeric] (**required**): value to validate

--- a/R/methods_DRAC.R
+++ b/R/methods_DRAC.R
@@ -116,11 +116,8 @@ print.DRAC.list <- function(x, blueprint = FALSE, ...) {
   }
 
   ## CHECK INPUT LENGTH ----
-  length.old <- length(x[[i]])
-  length.new <- length(value)
-
-  if (length.old != length.new) {
-    .throw_warning(names(x)[i], ": Input must be of length ", length.old)
+  if (!.validate_length(value, length(x[[i]]), throw.error = FALSE,
+                        name = names(x)[i])) {
     return(x)
   }
 

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -238,9 +238,7 @@ plot_Histogram <- function(
 
   if("ylim" %in% names(extraArgs)) {
     ylim.plot <- extraArgs$ylim
-    if (length(ylim.plot) < 4) {
-      .throw_error("'ylim' must be a vector of length 4")
-    }
+    .validate_length(ylim.plot, 4, name = "'ylim'")
   } else {
     H.lim <- hist(data[,1],
                   breaks = breaks.plot,

--- a/R/plot_KDE.R
+++ b/R/plot_KDE.R
@@ -600,9 +600,7 @@ plot_KDE <- function(
 
   if("ylim" %in% names(list(...))) {
     ylim.plot <- list(...)$ylim
-    if (length(ylim.plot) < 4) {
-      .throw_error("'ylim' must be a vector of length 4")
-    }
+    .validate_length(ylim.plot, 4, name = "'ylim'")
   } else {
     if(!is.na(De.density.range[1])){
       ylim.plot <- c(De.density.range[3],

--- a/R/plot_RadialPlot.R
+++ b/R/plot_RadialPlot.R
@@ -627,9 +627,8 @@ if(centrality[1] == "mean") {
   sub <- if("sub" %in% names(extraArgs)) {extraArgs$sub} else {""}
 
   if("xlab" %in% names(extraArgs)) {
-    if(length(extraArgs$xlab) != 2) {
-      .throw_error("'xlab' must have length 2")
-    } else {xlab <- extraArgs$xlab}
+    xlab <- extraArgs$xlab
+    .validate_length(xlab,  2)
   } else {
     xlab <- c(if(log.z == TRUE) {
       "Relative standard error (%)"

--- a/tests/testthat/test_analyse_Al2O3C_Measurement.R
+++ b/tests/testthat/test_analyse_Al2O3C_Measurement.R
@@ -18,7 +18,7 @@ test_that("input validation", {
   )
   expect_error(analyse_Al2O3C_Measurement(data_CrossTalk,
                                           irradiation_time_correction = 7),
-               "must have length 2")
+               "'irradiation_time_correction' should have length 2")
   expect_error(analyse_Al2O3C_Measurement(data_CrossTalk,
                                           irradiation = set_RLum("RLum.Results")),
                "was created by an unsupported function")

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -22,12 +22,12 @@ test_that("input validation", {
 
   expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve,
                               Ch_L3 = 50),
-               "Input for 'Ch_L3' must be a vector of length 2")
+               "'Ch_L3' should have length 2")
   expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve,
                               Ch_L3 = c(40, 50, 60)),
-               "Input for 'Ch_L3' must be a vector of length 2")
+               "'Ch_L3' should have length 2")
   expect_error(calc_FastRatio(obj, Ch_L3 = list(4, 5)),
-               "Input for 'Ch_L3' must be a vector of length 2")
+               "'Ch_L3' should be of class 'integer' or 'numeric'")
   expect_error(calc_FastRatio(obj, Ch_L3 = c(0, 2)),
                "'Ch_L3[1]' should be a positive integer scalar",
                fixed = TRUE)

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -34,7 +34,7 @@ test_that("input validation", {
   expect_error(calc_Huntley2006(data, fit.method = "test"),
                "'fit.method' should be one of 'EXP' or 'GOK'")
   expect_error(calc_Huntley2006(data, fit.method = "GOK", lower.bounds = 0),
-               "Argument 'lower.bounds' must be of length 4")
+               "'lower.bounds' should have length 4")
 
   expect_error(calc_Huntley2006(data, LnTn = list()),
                "'LnTn' must be a data frame with 2 columns")
@@ -46,7 +46,7 @@ test_that("input validation", {
                "The number of columns in 'data' must be a multiple of 3")
 
   expect_error(calc_Huntley2006(data, rhop = 1),
-               "'rhop' must be a vector of length 2")
+               "'rhop' should have length 2")
   expect_error(calc_Huntley2006(data, rhop = "test"),
                "'rhop' should be of class 'numeric' or 'RLum.Results'")
   expect_error(calc_Huntley2006(data, rhop = rhop.test),
@@ -55,15 +55,21 @@ test_that("input validation", {
                "'rhop' must be a positive number")
 
   expect_error(calc_Huntley2006(data, rhop = rhop),
-               "\"ddot\" is missing, with no default")
+               "'ddot' should be of class 'numeric'")
   expect_error(calc_Huntley2006(data, rhop = rhop, ddot = ddot),
-               "\"readerDdot\" is missing, with no default")
+               "'readerDdot' should be of class 'numeric'")
   expect_error(calc_Huntley2006(data, rhop = rhop,
                                 ddot = "test", readerDdot = readerDdot),
-               "'ddot' and 'readerDdot' must be numeric vectors")
+               "'ddot' should be of class 'numeric'")
+  expect_error(calc_Huntley2006(data, rhop = rhop,
+                                ddot = 0.4, readerDdot = readerDdot),
+               "'ddot' should have length 2")
   expect_error(calc_Huntley2006(data, rhop = rhop,
                                 ddot = ddot, readerDdot = "test"),
-               "'ddot' and 'readerDdot' must be numeric vectors")
+               "'readerDdot' should be of class 'numeric'")
+  expect_error(calc_Huntley2006(data, rhop = rhop,
+                                ddot = ddot, readerDdot = 0.13),
+               "'readerDdot' should have length 2")
 
   SW({
   expect_warning(calc_Huntley2006(data[, 1:2], rhop = rhop, n.MC = 2,

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -320,6 +320,16 @@ test_that("Test internals", {
   expect_warning(fun2(),
                  "'arg' should be of class 'data.frame'")
 
+  ## .validate_length() -----------------------------------------------------
+  expect_true(.validate_length(letters, 26))
+  expect_error(.validate_length(letters),
+               "'exp.length' must be provided")
+  expect_error(.validate_length(letters, 25),
+               "'letters' should have length 25")
+  expect_error(.validate_length(letters, 25, name = "'other_name'"),
+               "'other_name' should have length 25")
+  expect_warning(expect_false(.validate_length(letters, 25, throw.error = FALSE)),
+                 "'letters' should have length 25")
 
   ## .validate_positive_scalar() --------------------------------------------
   expect_silent(.validate_positive_scalar(int = TRUE))

--- a/tests/testthat/test_methods_DRAC.R
+++ b/tests/testthat/test_methods_DRAC.R
@@ -24,7 +24,7 @@ test_that("methods_DRAC", {
   expect_warning({
     input <- template_DRAC()
     input[[1]] <- c(1, 2)
-  }, regexp = "Input must be of length")
+  }, regexp = "Project ID should have length 1")
   expect_warning({
     input <- template_DRAC()
     input[[4]] <- "error"

--- a/tests/testthat/test_plot_Histogram.R
+++ b/tests/testthat/test_plot_Histogram.R
@@ -7,7 +7,7 @@ test_that("input validation", {
   expect_error(plot_Histogram("error"),
                "'data' should be of class 'data.frame' or 'RLum.Results'")
   expect_error(plot_Histogram(df, ylim = c(0, 1)),
-               "'ylim' must be a vector of length 4")
+               "'ylim' should have length 4")
 })
 
 test_that("check functionality", {

--- a/tests/testthat/test_plot_KDE.R
+++ b/tests/testthat/test_plot_KDE.R
@@ -14,7 +14,7 @@ test_that("input validation", {
                               "Inf values removed in rows: 1 in data.frame 1"),
                "Your input is empty due to Inf removal")
   expect_error(plot_KDE(df, ylim = c(0, 1)),
-               "'ylim' must be a vector of length 4")
+               "'ylim' should have length 4")
 
   expect_warning(plot_KDE(df[1, ]),
                  "Single data point found, no density calculated")

--- a/tests/testthat/test_plot_RadialPlot.R
+++ b/tests/testthat/test_plot_RadialPlot.R
@@ -17,7 +17,7 @@ test_that("input validation", {
   expect_error(plot_RadialPlot(df[0, ]),
                "Input data 1 has 0 rows")
   expect_error(plot_RadialPlot(df, xlab = "x"),
-               "'xlab' must have length 2")
+               "'xlab' should have length 2")
   expect_error(plot_RadialPlot(df, centrality = "error"),
                "Measure of centrality not supported")
 


### PR DESCRIPTION
This adds the `.validate_length()` helper: at the moment it can only be used to validate an exact length (`==`), but I may extend it at some point to allow checking for `>=` or `<=`