### PR TITLE
Introduce the .throw_message() helper

### DIFF
--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -397,8 +397,8 @@ setMethod("get_RLum",
                 tmp <- mapply(function(name, op) {
                   message("  ", name, ": ", .collapse(unique(op), quote = FALSE))
                 }, names(envir), envir)
-                message("\n [get_RLum()] 'subset' expression produced an ",
-                        "empty selection, NULL returned")
+                .throw_message("'subset' expression produced an ",
+                               "empty selection, NULL returned")
                 return(NULL)
               }
 
@@ -449,8 +449,8 @@ setMethod("get_RLum",
 
               ##check if record.id exists
               if (FALSE %in% (abs(record.id) %in% (1:length(object@records)))) {
-                message("[get_RLum()] Error: At least one 'record.id' ",
-                        "is invalid, NULL returned")
+                .throw_message("At least one 'record.id' is invalid, ",
+                               "NULL returned")
                 return(NULL)
               }
 
@@ -794,10 +794,10 @@ setMethod(
 #' Melts [RLum.Analysis-class] objects into a flat data.frame to be used
 #' in combination with other packages such as `ggplot2`.
 #'
-#' @return 
-#' 
+#' @return
+#'
 #' **`melt_RLum`**
-#' 
+#'
 #' Flat [data.frame] with `X`, `Y`, `TYPE`, `UID`
 #'
 #' @md

--- a/R/analyse_Al2O3C_Measurement.R
+++ b/R/analyse_Al2O3C_Measurement.R
@@ -220,11 +220,11 @@ analyse_Al2O3C_Measurement <- function(
 
       ##check whether everything is subtracted from everything ... you never know, users do weird stuff
       if(length(travel_dosimeter) == nrow(results$data))
-        message("[analyse_Al2O3C_Measurement()] Error: 'travel_dosimeter' specifies every position, nothing corrected")
+        .throw_message("'travel_dosimeter' specifies every position, nothing corrected")
 
       ##check if the position is valid
       if(any(!travel_dosimeter%in%results$data$POSITION))
-        message("[analyse_Al2O3C_Measurement()] Error: Invalid position in 'travel_dosimeter', nothing corrected")
+        .throw_message("Invalid position in 'travel_dosimeter', nothing corrected")
 
       ##correct for the travel dosimeter calculating the weighted mean and the sd (as new error)
       ##if only one value is given just take it
@@ -327,7 +327,8 @@ analyse_Al2O3C_Measurement <- function(
     POSITION <- get_RLum(object = object[[1]], info.object = "position")
 
   }else{
-    message("[analyse_Al2O3_Measurement()] Aliquot position number was not found. No cross talk correction was applied!")
+    message("[analyse_Al2O3_Measurement()] Aliquot position number was not ",
+            "found, no cross talk correction applied")
     cross_talk_correction <- c(0,0,0)
     POSITION <- NA
   }

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -327,7 +327,7 @@ analyse_FadingMeasurement <- function(
 
       ##not support
     }else{
-      message("[analyse_FadingMeasurement()] Error: Unknown or unsupported originator")
+      .throw_message("Unknown or unsupported originator, NULL returned")
       return(NULL)
     }
 
@@ -380,7 +380,7 @@ analyse_FadingMeasurement <- function(
       Tx_data <- NULL
 
     }else{
-      message("[analyse_FadingMeasurement()] Error: I have no idea what your structure means")
+      .throw_message("I have no idea what your structure means, NULL returned")
       return(NULL)
     }
 

--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -1230,7 +1230,8 @@ analyse_IRSAR.RF<- function(
           cores <- min(requested.cores, available.cores)
 
         }else{
-          message("[analyse_IRSAR.RF()] Invalid value for control argument 'cores'. Value set to 1")
+          .throw_message("Invalid value for control argument 'cores', ",
+                         "value set to 1")
           cores <- 1
         }
 

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -400,8 +400,8 @@ error.list <- list()
     m = regexpr("(OSL[a-zA-Z]*|IRSL[a-zA-Z]*|POSL[a-zA-Z]*)", names(object), perl = TRUE))
 
   if(length(CWcurve.type) == 0) {
-    message("[analyse_SAR.CWOSL()] No record of type 'OSL', 'IRSL', 'POSL' ",
-            "detected! NULL returned.")
+    .throw_message("No record of type 'OSL', 'IRSL', 'POSL' detected, ",
+                   "NULL returned")
     return(NULL)
   }
 
@@ -615,8 +615,8 @@ error.list <- list()
     ##this is basically for the OSL.component case to avoid that everything
     ##fails if something goes wrong therein
     if(inherits(LnLxTnTx, "try-error")){
-      message("[analyse_SAR.CWOSL()] Something went wrong while generating ",
-              "the LxTx table, NULL returned")
+      .throw_message("Something went wrong while generating the LxTx table, ",
+                     "NULL returned")
       return(NULL)
     }
 

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -862,7 +862,7 @@ analyse_baSAR <- function(
 
      ## return NULL if not at least three aliquots are used for the calculation
      if (Nb_aliquots < 3) {
-       message("[analyse_baSAR()] Error: Number of aliquots < 3, NULL returned")
+       .throw_message("Number of aliquots < 3, NULL returned")
        return(NULL)
      }
 
@@ -941,8 +941,7 @@ analyse_baSAR <- function(
          Nb_aliquots <- nrow(input_object)
 
        } else{
-         message("[analyse_basAR()] Error: 'aliquot_range' out of bounds, ",
-                 "input ignored")
+         .throw_message("'aliquot_range' out of bounds, input ignored")
 
          ##reset aliquot range
          aliquot_range <- NULL
@@ -1027,8 +1026,7 @@ analyse_baSAR <- function(
 
       ##create fallback
        if(inherits(object, "try-error")){
-         message("[analyse_baSAR()] Error: Object conversion failed, ",
-                 "NULL returned")
+         .throw_message("Object conversion failed, NULL returned")
          return(NULL)
        }
 
@@ -1227,8 +1225,8 @@ analyse_baSAR <- function(
           aliquot_selection$unique_pairs[!aliquot_selection$unique_pairs[["GRAIN"]] == 0,]
 
         if(nrow(datalu) == 0){
-          message("[analyse_baSAR()] Error: nothing was left after ",
-                  "the automatic grain selection, NULL returned")
+          .throw_message("Nothing left after the automatic grain selection, ",
+                         "NULL returned")
           return(NULL)
         }
 
@@ -1418,8 +1416,7 @@ analyse_baSAR <- function(
 
     ##if all irradiation times are 0 we should stop here
     if (length(unique(irrad_time.vector)) == 1) {
-      message("[analyse_baSAR()] Error: all irradiation times are identical, ",
-              "NULL returned")
+      .throw_message("All irradiation times are identical, NULL returned")
       return(NULL)
     }
 
@@ -1438,7 +1435,7 @@ analyse_baSAR <- function(
          ##disc (position)
          disc_logic <- (disc_selected == measured_discs.vector)
          if (!any(disc_logic)) {
-            message("[analyse_baSAR()] In BIN-file '",
+            .throw_message("In BIN-file '",
                     unique(fileBIN.list[[k]]@METADATA[["FNAME"]]),
                     "' position number ", disc_selected,
                     " does not exist, NULL returned")
@@ -1449,7 +1446,7 @@ analyse_baSAR <- function(
           grain_logic <- (grain_selected == measured_grains.vector)
 
           if (!any(grain_logic)) {
-            message("[analyse_baSAR()] In BIN-file '",
+            .throw_message("In BIN-file '",
                     unique(fileBIN.list[[k]]@METADATA[["FNAME"]]),
                     "' grain number ", grain_selected,
                     " does not exist, NULL returned")
@@ -2228,8 +2225,8 @@ analyse_baSAR <- function(
               )
             }
           }else{
-            message("[analyse_baSAR()] Error: Wrong 'variable.names' ",
-                    "monitored, dose responses curves could not be plotted")
+            .throw_message("Wrong 'variable.names' monitored, ",
+                           "dose responses curves could not be plotted")
           }
 
           ##add dose points

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -337,8 +337,8 @@ analyse_pIRIRSequence <- function(
       sequence.structure, nrow(temp.sequence.structure)/2/length(sequence.structure))
 
   }else{
-    message("[analyse_pIRIRSequence()] Error: The number of records is not a ",
-            "multiple of the defined sequence structure, NULL returned")
+    .throw_message("The number of records is not a multiple of the defined ",
+                   "sequence structure, NULL returned")
     return(NULL)
   }
 
@@ -537,7 +537,7 @@ analyse_pIRIRSequence <- function(
 
       ##check whether NULL was return
       if (is.null(temp.results)) {
-        message("[plot_pIRIRSequence()] An error occurred, analysis skipped. Check your sequence!")
+        .throw_message("Analysis skipped: check your sequence, NULL returned")
         return(NULL)
       }
 

--- a/R/calc_AverageDose.R
+++ b/R/calc_AverageDose.R
@@ -245,8 +245,7 @@ calc_AverageDose <- function(
 
   ##check for number of columns
   if(ncol(data)<2){
-    message("[calc_AverageDose()] Error: 'data' contains < 2 columns, ",
-            "NULL returned")
+    .throw_message("'data' contains < 2 columns, NULL returned")
     return(NULL)
   }
 
@@ -265,8 +264,7 @@ calc_AverageDose <- function(
 
   ##check data set
   if(nrow(data) == 0){
-    message("[calc_AverageDose()] Error: data set contains 0 rows! ",
-            "NULL returned!")
+    .throw_message("Data set contains 0 rows, NULL returned")
     return(NULL)
   }
 

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -100,7 +100,7 @@ calc_WodaFuchs2008 <- function(
 
   ## estimate bin width based on Woda and Fuchs (2008)
   if (all(is.na(data[, 2]))) {
-    message("[calc_WodFuchs2008()] No errors provided. Bin width set ",
+    message("[calc_WodaFuchs2008()] No errors provided, bin width set ",
             "by 10 percent of input data")
     bin_width <- median(data[,1] / 10,
                         na.rm = TRUE)

--- a/R/calc_gSGC_feldspar.R
+++ b/R/calc_gSGC_feldspar.R
@@ -182,8 +182,7 @@ calc_gSGC_feldspar <- function (
 
       ## in case the initial uniroot solve does not work
       if(inherits(temp, "try-error")) {
-        message("[calc_gSGC_feldspar()] Error: No solution found for ",
-                "dataset #", i, ", NA returned")
+        .throw_message("No solution found for dataset #", i, ", NA returned")
         return(NA)
       }
 

--- a/R/extract_IrradiationTimes.R
+++ b/R/extract_IrradiationTimes.R
@@ -386,8 +386,8 @@ extract_IrradiationTimes <- function(
         message("[extract_IrradiationTimes()] 'Time Since Irradiation' was redefined in the exported BINX-file to: 'Time Since Irradiation' plus the 'Irradiation Time' to be compatible with the Analyst.")
       }
     } else {
-      message("[extract_IrradiationTimes()] XSYG-file and BINX-file ",
-              "do not contain similar entries, BINX-file update skipped")
+      .throw_message("XSYG-file and BINX-file do not contain similar entries, ",
+                     "BINX-file update skipped")
     }
   }
 

--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -303,8 +303,7 @@ fit_DoseResponseCurve <- function(
 
   ##2.3 check whether the dose value is equal all the time
   if(sum(abs(diff(sample[[1]])), na.rm = TRUE) == 0){
-    message("[fit_DoseResponseCurve()] Error: All points have the same dose, ",
-            "NULL returned")
+    .throw_message("All points have the same dose, NULL returned")
     return(NULL)
   }
 
@@ -318,8 +317,8 @@ fit_DoseResponseCurve <- function(
 
   ## Check if anything is left after removal
   if (nrow(sample) == 0) {
-    message("[fit_DoseResponseCurve()] Error: After NA removal, nothing is left ",
-            "from the data set, NULL returned")
+    .throw_message("After NA removal, nothing is left from the data set, ",
+                   "NULL returned")
     return(NULL)
   }
 
@@ -614,8 +613,8 @@ fit_DoseResponseCurve <- function(
     if(fit.method != "LIN"){
 
       if (anyNA(c(a, b, c))) {
-        message("[fit_DoseResponseCurve()] Error: Fit ", fit.method, " (", mode,
-                ") could not be applied to this data set, NULL returned")
+        .throw_message("Fit ", fit.method, " (", mode,
+                       ") could not be applied to this data set, NULL returned")
         return(NULL)
       }
 

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -875,8 +875,7 @@ fit_LMCurve<- function(
   }else{
     output.table <- NA
     component.contribution.matrix <- NA
-    message("[fit_LMCurve] Fitting Error: Plot without fit produced!")
-
+    .throw_message("Fitting failed, plot without fit produced")
   }
 
   # Calculate component curves ----------------------------------------------

--- a/R/fit_OSLLifeTimes.R
+++ b/R/fit_OSLLifeTimes.R
@@ -321,7 +321,6 @@ if(inherits(object, "list") || inherits(object, "RLum.Analysis")){
 
     ##set range
     df <- df[signal_range[1]:signal_range[2],]
-
   }
 
   ## number of components requested
@@ -337,9 +336,8 @@ if(inherits(object, "list") || inherits(object, "RLum.Analysis")){
   ## positive (see `qf()` in the `while` loop further down at (B))
   min.num.signals <- 2 * m + 2 + 1
   if (nrow(df) < min.num.signals) {
-    message("[fit_OSLLifeTimes()] Error: For ", m, " components ",
-            "the dataset must have at least ", min.num.signals,
-            " signal points, NULL returned")
+    .throw_message("For ", m, " components the dataset must have at least ",
+                   min.num.signals, " signal points, NULL returned")
     return(NULL)
   }
 
@@ -356,7 +354,6 @@ if(inherits(object, "list") || inherits(object, "RLum.Analysis")){
     nlsLM.trace = FALSE,
     nlsLM.upper = TRUE,
     nlsLM.lower = TRUE
-
   )
 
   ##udpate list if the user did something
@@ -614,8 +611,7 @@ if(verbose){
     cat("-------------------------------------------------------------------------\n")
 
   }else{
-    message("[fit_OSLLifeTimes()] Error: The fitting was not successful, ",
-            "consider trying again")
+    .throw_message("The fitting was not successful, consider trying again")
   }
 
   cat("\n(3) Further information\n")

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -380,7 +380,7 @@ fit_SurfaceExposure <- function(
     coef <- as.data.frame(coef(summary(fit)))
   } else {
     if (settings$verbose)
-      message("[fit_SurfaceExposure()] Unable to fit the data. ",
+      .throw_message("Unable to fit the data. ",
               "Original error from minpack.lm::nlsLM(): ", fit$message)
 
     # Fill with NA values

--- a/R/fit_ThermalQuenching.R
+++ b/R/fit_ThermalQuenching.R
@@ -262,7 +262,7 @@ fit_ThermalQuenching <- function(
     })
 
   }else{
-    message("[fit_ThermalQuenching()] Error: Fitting failed, NULL returned!")
+    .throw_message("Fitting failed, NULL returned")
     return(NULL)
   }
 

--- a/R/import_Data.R
+++ b/R/import_Data.R
@@ -41,6 +41,9 @@ import_Data <- function (
   fastForward = TRUE,
   verbose = FALSE
 ) {
+  .set_function_name("import_Data")
+  on.exit(.unset_function_name(), add = TRUE)
+
   ## supported functions
   fun <- c(
     "read_BIN2R",
@@ -63,6 +66,5 @@ import_Data <- function (
       return(t)
 
   }
-  message("[import_Data()] Unknown file format, nothing imported!")
-
+  .throw_message("Unknown file format, nothing imported")
 }

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1065,6 +1065,17 @@ fancy_scientific <- function(l) {
   warning("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] ", ..., call. = FALSE)
 }
 
+#'@title Throws a Custom Tailored Message
+#'
+#'@param ... the message to throw, preceded by "Error:"
+#'
+#'@md
+#'@noRd
+.throw_message <- function(...) {
+  top.idx <- length(.LuminescenceEnv$fn_stack)
+  message("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] Error: ", ...)
+}
+
 #' @title Silence Output and Warnings during Tests
 #'
 #' @description

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -511,7 +511,7 @@ plot_AbanicoPlot <- function(
   ##(1)
   ##check if there is still data left in the entire set
   if(all(sapply(data, nrow) == 0)){
-    message("[plot_AbanicoPlot()] Error: Nothing plotted, your data set is empty")
+    .throw_message("Nothing plotted, your data set is empty")
     return(NULL)
   }
   ##(2)
@@ -529,8 +529,7 @@ plot_AbanicoPlot <- function(
 
     ##unfortunately, the data set might become now empty at all
     if(length(data) == 0){
-      message("[plot_AbanicoPlot()] Error: After removing invalid entries, ",
-              "nothing is plotted")
+      .throw_message("After removing invalid entries, nothing is plotted")
       return(NULL)
     }
   }

--- a/R/plot_DoseResponseCurve.R
+++ b/R/plot_DoseResponseCurve.R
@@ -454,14 +454,12 @@ plot_DoseResponseCurve <- function(
           text(5, 5, "not available\n no TnTx column")
         }
       }
-
     }
   }
 
   ##reset graphic device if the plotting failed!
   if (inherits(plot_check, "try-error")) {
-    message("[plot_DoseResponseCurve()] Error: Figure margins too large, ",
-            "nothing plotted")
+    .throw_message("Figure margins too large, nothing plotted")
     dev.off()
   }
 

--- a/R/plot_RLum.Data.Spectrum.R
+++ b/R/plot_RLum.Data.Spectrum.R
@@ -502,7 +502,8 @@ plot_RLum.Data.Spectrum <- function(
 
     ##check worst case
     if(sum(temp.xyz) == 0){
-      message("[plot_RLum.Data.Spectrum()] After background subtraction all counts < 0. Nothing plotted, NULL returned!")
+      .throw_message("After background subtraction all counts < 0: ",
+                     "nothing plotted, NULL returned")
       return(NULL)
     }
   }
@@ -540,11 +541,11 @@ plot_RLum.Data.Spectrum <- function(
   }
 
   ##limit z-values if requested, this idea was taken from the Diss. by Thomas Schilles, 2002
-  if(!is.null(limit_counts[1])) { 
+  if(!is.null(limit_counts[1])) {
     if(min(temp.xyz) > limit_counts[1]) {
       limit_counts <- floor(limit_counts[1] + min(temp.xyz))
       .throw_warning(
-        "Lowest count value is larger than the set count threshold. Set limit_counts = ", limit_counts, ".")  
+        "Lowest count value is larger than the set count threshold. Set limit_counts = ", limit_counts, ".")
     }
 
     temp.xyz[temp.xyz[] > max(min(temp.xyz), limit_counts[1])] <- limit_counts[1]
@@ -659,8 +660,7 @@ if(plot){
   }
 
   if (nrow(temp.xyz) == 1 && plot.type != "single") {
-    message("[plot_RLum.Data.Spectrum()] Insufficient data for plotting, ",
-            "NULL returned")
+    .throw_message("Insufficient data for plotting, NULL returned")
     return(NULL)
   }
 

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -257,15 +257,14 @@ read_BIN2R <- function(
 
   ## skip if zero-byte
   if (info$size == 0) {
-    message("[read_BIN2R()] File '", file, "' is a zero-byte file, ",
-            "NULL returned")
+    .throw_message("File '", file, "' is a zero-byte file, NULL returned")
     return(NULL)
   }
 
   ## check if file is a BIN or BINX file
   if(!any(tolower(tools::file_ext(file)) %in%  c("bin", "binx"))) {
-    message("[read_BIN2R()] File '", file, "' is not a file of type ",
-            "'BIN' or 'BINX', NULL returned")
+    .throw_message("File '", file, "' is not a file of type ",
+                   "'BIN' or 'BINX', NULL returned")
     con <- NULL
     return(NULL)
   }

--- a/R/read_RF2R.R
+++ b/R/read_RF2R.R
@@ -52,8 +52,7 @@ read_RF2R <- function(
 
       ##check whether it worked
       if(inherits(temp, "try-error")){
-        message("[read_RF2R()] Error: Import for file '", f,
-                "' failed, NULL returned")
+        .throw_message("Import for file '", f, "' failed, NULL returned")
         return(NULL)
       }else{
         return(temp)
@@ -120,8 +119,7 @@ read_RF2R <- function(
 
     ##test the header
     if(inherits(header, 'try-error')){
-      message("[read_RF2R()] Error: Header extraction failed, ",
-              "trying to continue without ... ")
+      .throw_message("Header extraction failed, trying to continue without ...")
       header <- NA
     }
 

--- a/R/read_SPE2R.R
+++ b/R/read_SPE2R.R
@@ -145,7 +145,7 @@ read_SPE2R <- function(
     }
 
     if (failed) {
-      message("[read_SPE2R()] Error: File does not exist, NULL returned")
+      .throw_message("File does not exist, NULL returned")
       return(NULL)
     }
   }

--- a/R/read_XSYG2R.R
+++ b/R/read_XSYG2R.R
@@ -214,8 +214,8 @@ read_XSYG2R <- function(
       file <- as.list(dir(file, recursive = TRUE, pattern = pattern, full.names = TRUE))
       if (length(file) == 0) {
         if (verbose)
-          message("[read_XSYG2R()] No files matching the given pattern ",
-                  "found in directory, NULL returned")
+          .throw_message("No files matching the given pattern ",
+                         "found in directory, NULL returned")
         return(NULL)
       }
     }
@@ -261,7 +261,7 @@ read_XSYG2R <- function(
   ## check whether file exist
   if(!file.exists(file)) {
     if(verbose)
-      message("[read_XSYG2R()] File does not exist, nothing imported!")
+      .throw_message("File does not exist, nothing imported, NULL returned")
     return(NULL)
 
   }
@@ -333,7 +333,7 @@ read_XSYG2R <- function(
   ##show error
   if(inherits(temp, "try-error")){
     if(verbose)
-      message("[read_XSYG2R()] XML file not readable, nothing imported!")
+      .throw_message("XML file not readable, nothing imported, NULL returned")
     return(NULL)
   }
 

--- a/tests/testthat/test_calc_AverageDose.R
+++ b/tests/testthat/test_calc_AverageDose.R
@@ -19,7 +19,7 @@ test_that("input validation", {
       "Error: 'data' contains < 2 columns")
   expect_message(expect_null(
       calc_AverageDose(data[0, ], sigma_m = 0.1)),
-      "Error: data set contains 0 rows")
+      "Error: Data set contains 0 rows")
 
   SW({
   expect_warning(calc_AverageDose(cbind(data, data), sigma_m = 0.1),

--- a/tests/testthat/test_convert_XSYG2CSV.R
+++ b/tests/testthat/test_convert_XSYG2CSV.R
@@ -10,9 +10,11 @@ test_that("input validation", {
                "File '.*error' does not exist") # windows CI needs the regexp
   expect_error(convert_PSL2CSV(file = "error"),
                "No .psl files found")
+  SW({
   expect_error(expect_message(convert_XSYG2CSV(file = "", export = FALSE),
                               "XML file not readable, nothing imported"),
                "'object' should be of class 'RLum.Analysis', 'RLum.Data.Curve'")
+  })
 })
 
 test_that("test convert functions", {

--- a/tests/testthat/test_fit_LMCurve.R
+++ b/tests/testthat/test_fit_LMCurve.R
@@ -76,7 +76,7 @@ test_that("check class and length of output", {
   expect_message(fit <- fit_LMCurve(values.curve, values.bg = values.curveBG,
                                     start_values = data.frame(Im = c(70,25,400),
                                                               xm = c(56,200,10))),
-                 "Fitting Error: Plot without fit produced")
+                 "Error: Fitting failed, plot without fit produced")
   expect_equal(fit@data$component_matrix, NA)
 
   fit_LMCurve(values.curve, values.bg = values.curveBG, plot.BG = TRUE,

--- a/tests/testthat/test_read_XSYG2R.R
+++ b/tests/testthat/test_read_XSYG2R.R
@@ -10,11 +10,11 @@ test_that("input validation", {
   expect_error(read_XSYG2R(data.frame()),
                "'file' should be of class 'character' or 'list'")
   expect_message(expect_null(read_XSYG2R("_error_file_")),
-                "File does not exist, nothing imported!")
+                "Error: File does not exist, nothing imported")
   expect_message(expect_null(read_XSYG2R("/Test", fastForward = TRUE)),
-                 "File does not exist, nothing imported!")
+                 "Error: File does not exist, nothing imported")
   expect_message(expect_null(read_XSYG2R(test_path("_data/xsyg-tests/XSYG_broken.xsyg"), fastForward = TRUE)),
-                 "XML file not readable, nothing imported!")
+                 "Error: XML file not readable, nothing imported")
 
   SW({
   expect_message(expect_null(read_XSYG2R(test_path("_data/bin-tests/"))),


### PR DESCRIPTION
This is not meant to replace all uses of `message()`, but only those that refer to an error condition, as it prepends the `Error:` string to the message reported. Fixes #422.