### PR TITLE
Make fit_DoseResponseCurve() accept a list as input

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -137,6 +137,9 @@ Please keep in mind that it does not mean that the fit results make any sense,
 it just helps to avoid uncontained events in the R session (addresses #381).
 * Option `output.plotExtended.single` has been renamed to `plot_singlePanels`
 (#351, fixed in #408).
+* The function now supports a list of data frames as input, in which case it
+calls itself on each element of the list and produces a list of `RLum.Results`
+as output (#405, fixed in #434).
 
 ### `plot_RLum.Analysis()`
 * Option `plot.single` has been renamed to `plot_singlePanels` (#351, fixed

--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -87,11 +87,12 @@
 #' especially for the composed functions (`EXP+LIN` and `EXP+EXP`).\cr
 #' Each error estimation is done with the function of the chosen fitting method.
 #'
-#' @param sample [data.frame] (**required**):
+#' @param sample [data.frame] or a [list] of such objects (**required**):
 #' data frame with columns for `Dose`, `LxTx`, `LxTx.Error` and `TnTx`.
 #' The column for the test dose response is optional, but requires `'TnTx'` as
 #' column name if used. For exponential fits at least three dose points
-#' (including the natural) should be provided.
+#' (including the natural) should be provided. If provided as a list,
+#' the function is called on each element of the list.
 #'
 #' @param mode [character] (*with default*):
 #' selects calculation mode of the function.
@@ -167,7 +168,10 @@
 #' `..$call` : \tab `call` \tab The original function call\cr
 #' }
 #'
-#' @section Function version: 1.2
+#' If `sample` is a list, then the function returns a list of `RLum.Results`
+#' objects as defined above.
+#'
+#' @section Function version: 1.2.1
 #'
 #' @author
 #' Sebastian Kreutzer, Institute of Geography, Heidelberg University (Germany)\cr
@@ -267,6 +271,34 @@ fit_DoseResponseCurve <- function(
   .set_function_name("fit_DoseResponseCurve")
   on.exit(.unset_function_name(), add = TRUE)
 
+  ## Self-call --------------------------------------------------------------
+  if (inherits(sample, "list")) {
+    lapply(sample,
+           function(x) .validate_class(x, c("data.frame", "matrix"),
+                                       name = "All elements of 'sample'"))
+
+    results <- lapply(sample, function(x) {
+      fit_DoseResponseCurve(
+          sample = x,
+          mode = mode,
+          fit.method = fit.method,
+          fit.force_through_origin = fit.force_through_origin,
+          fit.weights = fit.weights,
+          fit.includingRepeatedRegPoints = fit.includingRepeatedRegPoints,
+          fit.NumberRegPoints = fit.NumberRegPoints,
+          fit.NumberRegPointsReal = fit.NumberRegPointsReal,
+          fit.bounds = fit.bounds,
+          NumberIterations.MC = NumberIterations.MC,
+          txtProgressBar = txtProgressBar,
+          verbose = verbose,
+          ...
+      )
+    })
+
+    return(results)
+  }
+  ## Self-call end ----------------------------------------------------------
+
   .validate_class(sample, c("data.frame", "matrix", "list"))
   mode <- .validate_args(mode, c("interpolation", "extrapolation", "alternate"))
   fit.method_supported <- c("LIN", "QDR", "EXP", "EXP OR LIN",
@@ -285,7 +317,6 @@ fit_DoseResponseCurve <- function(
     class(sample)[1],
     data.frame = sample,
     matrix = sample <- as.data.frame(sample),
-    list = sample <- as.data.frame(sample),
   )
 
   ##2.1 check column numbers; we assume that in this particular case no error value

--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -91,8 +91,8 @@
 #' data frame with columns for `Dose`, `LxTx`, `LxTx.Error` and `TnTx`.
 #' The column for the test dose response is optional, but requires `'TnTx'` as
 #' column name if used. For exponential fits at least three dose points
-#' (including the natural) should be provided. If provided as a list,
-#' the function is called on each element of the list.
+#' (including the natural) should be provided. If `sample` is a list,
+#' the function is called on each its elements.
 #'
 #' @param mode [character] (*with default*):
 #' selects calculation mode of the function.

--- a/man/fit_DoseResponseCurve.Rd
+++ b/man/fit_DoseResponseCurve.Rd
@@ -21,11 +21,12 @@ fit_DoseResponseCurve(
 )
 }
 \arguments{
-\item{sample}{\link{data.frame} (\strong{required}):
+\item{sample}{\link{data.frame} or a \link{list} of such objects (\strong{required}):
 data frame with columns for \code{Dose}, \code{LxTx}, \code{LxTx.Error} and \code{TnTx}.
 The column for the test dose response is optional, but requires \code{'TnTx'} as
 column name if used. For exponential fits at least three dose points
-(including the natural) should be provided.}
+(including the natural) should be provided. If provided as a list,
+the function is called on each element of the list.}
 
 \item{mode}{\link{character} (\emph{with default}):
 selects calculation mode of the function.
@@ -104,6 +105,9 @@ In case of a resulting  linear fit when using \code{LIN}, \code{QDR} or \verb{EX
 \code{..$Formula} : \tab \link{expression} \tab Fitting formula as R expression \cr
 \code{..$call} : \tab \code{call} \tab The original function call\cr
 }
+
+If \code{sample} is a list, then the function returns a list of \code{RLum.Results}
+objects as defined above.
 }
 \description{
 A dose-response curve is produced for luminescence measurements using a
@@ -190,7 +194,7 @@ especially for the composed functions (\code{EXP+LIN} and \code{EXP+EXP}).\cr
 Each error estimation is done with the function of the chosen fitting method.
 }
 \section{Function version}{
- 1.2
+ 1.2.1
 }
 
 \examples{

--- a/man/fit_DoseResponseCurve.Rd
+++ b/man/fit_DoseResponseCurve.Rd
@@ -25,8 +25,8 @@ fit_DoseResponseCurve(
 data frame with columns for \code{Dose}, \code{LxTx}, \code{LxTx.Error} and \code{TnTx}.
 The column for the test dose response is optional, but requires \code{'TnTx'} as
 column name if used. For exponential fits at least three dose points
-(including the natural) should be provided. If provided as a list,
-the function is called on each element of the list.}
+(including the natural) should be provided. If \code{sample} is a list,
+the function is called on each its elements.}
 
 \item{mode}{\link{character} (\emph{with default}):
 selects calculation mode of the function.

--- a/tests/testthat/test_fit_DoseResponseCurve.R
+++ b/tests/testthat/test_fit_DoseResponseCurve.R
@@ -9,6 +9,8 @@ test_that("input validation", {
       fit_DoseResponseCurve("error"),
       "[fit_DoseResponseCurve()] 'sample' should be of class 'data.frame'",
       fixed = TRUE)
+  expect_error(fit_DoseResponseCurve(as.list(LxTxData)),
+               "All elements of 'sample' should be of class 'data.frame'")
 
   ## mode
   expect_error(
@@ -53,10 +55,11 @@ test_that("input validation", {
                      mode = "extrapolation"),
     "Mode 'extrapolation' for fitting method 'EXP+EXP' not supported",
     fixed = TRUE)
+})
 
-# Weird LxTx values --------------------------------------------------------
+test_that("weird LxTx values", {
+  testthat::skip_on_cran()
 
-  ##set LxTx
   LxTx <- structure(list(
     Dose = c(0, 250, 500, 750, 1000, 1500, 0, 500, 500),
     LxTx = c(1, Inf, 0, -Inf, Inf, 0, Inf, -0.25, 2),
@@ -86,11 +89,6 @@ test_that("input validation", {
     fit_DoseResponseCurve(as.matrix(LxTxData)),
     class = "RLum.Results")
   })
-
-  ## check input objects ... list
-  expect_s4_class(
-    fit_DoseResponseCurve(as.list(LxTxData), verbose = FALSE),
-    class = "RLum.Results")
 
   ## test case for only two columns
   expect_s4_class(
@@ -242,8 +240,14 @@ test_that("snapshot tests", {
 test_that("additional tests", {
   testthat::skip_on_cran()
 
-# Check more output -------------------------------------------------------
-  data(ExampleData.LxTxData, envir = environment())
+  ## self-call
+  res <- fit_DoseResponseCurve(
+      list(LxTxData, LxTxData),
+      fit.method = "LIN",
+      verbose = FALSE,
+      NumberIterations.MC = 10)
+  expect_type(res, "list")
+  expect_length(res, 2)
 
   set.seed(1)
   SW({
@@ -288,6 +292,7 @@ test_that("additional tests", {
       fit.method = "GOK",
       verbose = FALSE,
       NumberIterations.MC = 10)
+
   ## force through the origin
   temp_LxTx <-LxTxData
   temp_LxTx$LxTx[[7]] <- 1


### PR DESCRIPTION
This makes the function accept a list of data frames as input, in which case it calls itself on each element of the list and produces a list of `RLum.Results` as output. Fixes #405.