### PR TITLE
Make the pattern in the identifiers submitted to DRAC not discoverable

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -206,6 +206,8 @@ CSV files according to the DRAC v1.2 CSV template.
 * The function gained support for three new `...` arguments: `version_ignore`
 to ignore the DRAC version check, `user` and `password` to access password
 protected websites.
+* The identifiers submitted to the DRAC server are now better randomized to
+to guarantee more confidentiality of the data transmitted (#435, fixed in #438).
 
 ### `verify_SingleGrainData()`
 * **Potentially breaking old code!**: if `cleanup = TRUE` the result was not

--- a/R/use_DRAC.R
+++ b/R/use_DRAC.R
@@ -175,6 +175,9 @@ use_DRAC <- function(
     .throw_error("The provided data object is not a valid DRAC template.")
   }
 
+  ## NOTE: if this limit is ever raised above 9999, the generation of
+  ## random identifiers below at (4) must be adjusted accordingly to
+  ## guarantee uniqueness of identifiers
   if (nrow(input.raw) > 5000)
     .throw_error("The limit of allowed datasets is 5000!")
 
@@ -218,10 +221,9 @@ use_DRAC <- function(
 
   ##(4) replace ID values
   DRAC_submission.df$`TI:1` <- paste0(
-      sample(c(LETTERS, letters), runif(1, 2, 4)),
-      sample(c("", "-", "_"), 1),
-      sprintf("%02d", seq(sample(1:50, 1), by = 1,
-                         length.out = num.rows.df)))[1:num.rows.df]
+      sample(c(LETTERS, letters), max(4, num.rows.df), replace = TRUE),
+      sample(c("", "-", "_"), num.rows.df, replace = TRUE),
+      sprintf("%04d", sample(0:9999, num.rows.df)))[1:num.rows.df]
 
   ##(5) store the real IDs in a separate object
   DRAC_results.id <-  DRAC_submission.df[1:nrow(input.raw), "TI:1"]


### PR DESCRIPTION
This increases the randomness in the names ensuring that they are unique without generating on obvious pattern. Instead of appending a sequential numerical value, we append a unique random integer so that we don't make the pattern so obvious (it's probably not not discoverable at all, but who knows for sure). Uniqueness is enforced by the fact that we sample over all numbers from 0 to 9999, which is enough as we accept a maximum of 5000 inputs.
