### PR TITLE
Fix crashes in trim_RLum.Data() caused by misspecifications in trim_range

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -215,6 +215,10 @@ the change should have no user-visible effect.
 (`Cresswelletal2018`).
 Please ensure that the server supports that option.
 
+### `trim_RLum.Data()`
+* The function has been made more robust against misspecifications of its
+`trim_range` argument that could lead to crashes (#460, fixed in #461).
+
 ### `use_DRAC()`
 * Support for DRAC v1.1 XLS/XLSX files has been dropped, users should use
 CSV files according to the DRAC v1.2 CSV template.

--- a/R/trim_RLum.Data.R
+++ b/R/trim_RLum.Data.R
@@ -116,7 +116,7 @@ trim_RLum.Data <- function(
   .trim_RLum.Data.Image <- function(object, type, range){
     ## only if type is matched
     if (any(object@recordType[1] %in% type)) {
-      range[2] <- min(ncol(object@data), range[2])
+      range <- pmin(range, dim(object@data)[3])
       object@data <- object@data[, , range[1]:range[2], drop = FALSE]
     }
     object

--- a/R/trim_RLum.Data.R
+++ b/R/trim_RLum.Data.R
@@ -126,12 +126,11 @@ trim_RLum.Data <- function(
       ln <- switch(
         class(x)[1],
         "RLum.Data.Curve" = dim(x@data)[1],
-        "RLum.Data.Spectrum" = dim(x@dsta)[2],
+        "RLum.Data.Spectrum" = dim(x@data)[2],
         "RLum.Data.Image" = dim(x@data)[3]
       )
       names(ln) <- x@recordType
       ln
-
     }))
 
     ## run over single objects

--- a/R/trim_RLum.Data.R
+++ b/R/trim_RLum.Data.R
@@ -95,27 +95,30 @@ trim_RLum.Data <- function(
   ## RLum.Data.Curve
   .trim_RLum.Data.Curve <- function(object, type, range){
     ## only if type is matched
-    if(any(object@recordType[1] %in% type))
-      object@data <- object@data[max(c(1,range[1])):min(c(nrow(object@data),range[2])),, drop = FALSE]
-
+    if  (any(object@recordType[1] %in% type)) {
+      range[2] <- min(nrow(object@data), range[2])
+      object@data <- object@data[range[1]:range[2], , drop = FALSE]
+    }
     object
   }
 
   ## RLum.Data.Spectrum
   .trim_RLum.Data.Spectrum <- function(object, type, range){
     ## only if type is matched
-    if(any(object@recordType[1] %in% type))
-      object@data <- object@data[,max(c(1,range[1])):min(c(ncol(object@data),range[2])), drop = FALSE]
-
+    if (any(object@recordType[1] %in% type)) {
+      range[2] <- min(ncol(object@data), range[2])
+      object@data <- object@data[, range[1]:range[2], drop = FALSE]
+    }
     object
   }
 
   ## RLum.Data.Image
   .trim_RLum.Data.Image <- function(object, type, range){
     ## only if type is matched
-    if(any(object@recordType[1] %in% type))
-      object@data <- object@data[,,max(c(1,range[1])):min(c(ncol(object@data),range[2])), drop = FALSE]
-
+    if (any(object@recordType[1] %in% type)) {
+      range[2] <- min(ncol(object@data), range[2])
+      object@data <- object@data[, , range[1]:range[2], drop = FALSE]
+    }
     object
   }
 
@@ -171,11 +174,11 @@ trim_RLum.Data <- function(
     trim_range <- c(1,Inf)
   .validate_class(trim_range, c("integer", "numeric"))
 
-  ## silently sanitize trim_range input to ensure that it has length 2 and
-  ## contains no negative elements
+  ## silently sanitize `trim_range` to ensure that it has length 2,
+  ## it contains no elements smaller than 1, and is sorted
   if (length(trim_range) == 1)
     trim_range <- c(1, trim_range)
-  trim_range <- abs(trim_range[1:2])
+  trim_range <- sort(pmax(abs(trim_range[1:2]), 1))
 
 # Dispatch and return -----------------------------------------------------
  switch(

--- a/R/trim_RLum.Data.R
+++ b/R/trim_RLum.Data.R
@@ -166,13 +166,16 @@ trim_RLum.Data <- function(
 
   }
 
-  ## silently sanitize trim_range input
-  if(all(is.null(trim_range)))
+  ## set trim_range if not provided
+  if (is.null(trim_range))
     trim_range <- c(1,Inf)
-  else if(length(trim_range) == 1)
-    trim_range <- c(1, abs(trim_range))
-  else if(length(trim_range) > 2)
-    trim_range <- abs(trim_range[1:2])
+  .validate_class(trim_range, c("integer", "numeric"))
+
+  ## silently sanitize trim_range input to ensure that it has length 2 and
+  ## contains no negative elements
+  if (length(trim_range) == 1)
+    trim_range <- c(1, trim_range)
+  trim_range <- abs(trim_range[1:2])
 
 # Dispatch and return -----------------------------------------------------
  switch(

--- a/man/trim_RLum.Data.Rd
+++ b/man/trim_RLum.Data.Rd
@@ -15,9 +15,11 @@ only isolated on each element of the \link{list}.}
 should be applied. If not set, the types are determined automatically and applied
 for each record type classes. Can be provided as \link{list}.}
 
-\item{trim_range}{\link{numeric} (\emph{optional}): sets the trim range (everything
-within the range + 1 is kept). If nothing is set all curves are trimmed to a similar
-maximum length. Can be provided as \link{list}.}
+\item{trim_range}{\link{numeric} (\emph{optional}): sets the range of indices to
+keep. If only one value is given, this is taken to be the minimum; if two
+values are given, then the range is defined between the two values
+(inclusive). Any value beyond the second is silently ignored. If nothing
+is set (default), then all curves are trimmed to the same maximum length.}
 }
 \value{
 A trimmed object or \link{list} of such objects similar to the input objects
@@ -30,19 +32,20 @@ measurement time) but should be analysed jointly by other functions.
 \details{
 The function has two modes of operation:
 \enumerate{
-\item Single \linkS4class{RLum.Data} objects or a \link{list} of such objects
-The function is applied separately over each object.
-\item Multiple curves via \linkS4class{RLum.Analysis} or a \link{list} of such objects
-In this mode, the function first determines the minimum number of channels for
-each category of records and then jointly processes them.
-For instance, the object contains one TL curve with 100 channels and two
-OSL curves with 100 and 99 channels, respectively. Than the minimum for TL would be set
-to 100 channels and 99 for the OSL curves. If no further parameters are applied, the
-function will shorten all OSL curves to 99 channels, but leave the TL curve untouched.
+\item Single \linkS4class{RLum.Data} objects or a \link{list} of such objects:
+the function is applied separately over each object.
+\item Multiple curves via \linkS4class{RLum.Analysis} or a \link{list} of such objects:
+in this mode, the function first determines the minimum number of channels
+for each category of records and then jointly processes them. For instance,
+if the object contains one TL curve with 100 channels and two OSL curves
+with 100 and 99 channels, respectively, then the minimum would be set to
+100 channels for the TL curve and to 99 for the OSL curves. If no further
+parameters are applied, the function will shorten all OSL curves to 99
+channels, but leave the TL curve untouched.
 }
 }
 \section{Function version}{
- 0.1.0
+ 0.2
 }
 
 \examples{

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -73,9 +73,13 @@ test_that("RLum.Data.Spectrum", {
   t <- testthat::expect_s4_class(
     object = trim_RLum.Data(TL.Spectrum, trim_range = c(2, 4)),
     class = "RLum.Data.Spectrum")
-
   testthat::expect_length(object = t@data[1,], n = 3)
 
+  ## RLum.Analysis object with RLum.Data.Spectrum data
+  obj <- set_RLum("RLum.Analysis", records = list(TL.Spectrum))
+  t <- expect_s4_class(trim_RLum.Data(obj, trim_range = 10),
+                       "RLum.Analysis")
+  expect_equal(ncol(t@records[[1]]@data), 10)
 })
 
 test_that("RLum.Data.Image", {

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -66,9 +66,15 @@ test_that("RLum.Data.Curve", {
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(-1)),
     class = "RLum.Data.Curve")
+  ## c(0, 1)
+  t <- trim_RLum.Data(temp@records[[1]], trim_range = c(0, 1))
+  expect_equal(nrow(t@data), 1)
   ## c(-10, -20)
   t <- trim_RLum.Data(temp@records[[1]], trim_range = c(-10, -20))
   expect_equal(nrow(t@data), 11)
+  ## c(1025, 2)
+  t <- trim_RLum.Data(temp@records[[1]], trim_range = c(1025, 2))
+  expect_equal(nrow(t@data), 249)
   ## c(1,2,3)
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(1:3)),

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -8,6 +8,8 @@ test_that("input validation", {
   expect_error(trim_RLum.Data("error"),
                "[trim_RLum.Data()] 'object' should be of class 'RLum.Data' or",
                fixed = TRUE)
+  expect_error(trim_RLum.Data(temp, trim_range = "error"),
+               "'trim_range' should be of class 'integer' or 'numeric'")
 })
 
 test_that("RLum.Data.Curve", {
@@ -64,12 +66,13 @@ test_that("RLum.Data.Curve", {
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(-1)),
     class = "RLum.Data.Curve")
+  ## c(-10, -20)
+  t <- trim_RLum.Data(temp@records[[1]], trim_range = c(-10, -20))
+  expect_equal(nrow(t@data), 11)
   ## c(1,2,3)
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(1:3)),
     class = "RLum.Data.Curve")
-
-
 })
 
 test_that("RLum.Data.Spectrum", {

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -8,6 +8,8 @@ test_that("input validation", {
   expect_error(trim_RLum.Data("error"),
                "[trim_RLum.Data()] 'object' should be of class 'RLum.Data' or",
                fixed = TRUE)
+  expect_error(trim_RLum.Data(temp, recordType = c(1, 20)),
+               "'recordType' should be of class 'character'")
   expect_error(trim_RLum.Data(temp, trim_range = "error"),
                "'trim_range' should be of class 'integer' or 'numeric'")
 })

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -108,7 +108,7 @@ test_that("RLum.Data.Image", {
   data(ExampleData.RLum.Data.Image, envir = environment())
 
   testthat::expect_s4_class(
-    object = trim_RLum.Data(ExampleData.RLum.Data.Image, recordType = c(10,100)),
+    trim_RLum.Data(ExampleData.RLum.Data.Image, trim_range = c(10, 100)),
     class = "RLum.Data.Image")
 })
 

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -1,8 +1,17 @@
-test_that("RLum.Data.Curve", {
+## load data
+data(ExampleData.BINfileData, envir = environment())
+temp <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
+
+test_that("input validation", {
   testthat::skip_on_cran()
 
-  data(ExampleData.BINfileData, envir = environment())
-  temp <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
+  expect_error(trim_RLum.Data("error"),
+               "[trim_RLum.Data()] 'object' should be of class 'RLum.Data' or",
+               fixed = TRUE)
+})
+
+test_that("RLum.Data.Curve", {
+  testthat::skip_on_cran()
 
   ## trim with range
   t <- testthat::expect_type(
@@ -92,15 +101,10 @@ test_that("RLum.Data.Image", {
   testthat::expect_s4_class(
     object = trim_RLum.Data(ExampleData.RLum.Data.Image, recordType = c(10,100)),
     class = "RLum.Data.Image")
-
 })
 
 test_that("RLum.Analysis", {
   testthat::skip_on_cran()
-
-  ##load example data
-  data(ExampleData.BINfileData, envir = environment())
-  temp <- Risoe.BINfileData2RLum.Analysis(CWOSL.SAR.Data, pos = 1)
 
   ## generate case where one OSL curve has one channel less
   temp@records[[2]]@data <- temp@records[[2]]@data[-nrow(temp[[2]]@data),]
@@ -136,12 +140,4 @@ test_that("RLum.Analysis", {
    object = t@records[[4]]@data[,1], n = 11)
  testthat::expect_length(
    object = t@records[[1]]@data[,1], n = 250)
-})
-
-test_that("input validation", {
-  testthat::skip_on_cran()
-
-  expect_error(trim_RLum.Data("error"),
-               "[trim_RLum.Data()] 'object' should be of class 'RLum.Data' or",
-               fixed = TRUE)
 })


### PR DESCRIPTION
This fixes the 3 crashes mentioned in #460 plus a 4th one:
- crash if the `Lum.Analysis` object contained `RLum.Data.Spectrum` data
- crash if two negative indices were provided in `trim_range` (bonus fix!)
- crash if the indices where given in non-increasing order and the first exceeded the bounds of the object
- crash when using `trim_range` on an `RLum.Data.Image` object

Fixes #460.