### PR TITLE
Improve input validation against an empty data frame

### DIFF
--- a/R/CW2pHMi.R
+++ b/R/CW2pHMi.R
@@ -201,8 +201,11 @@ CW2pHMi<- function(
   .set_function_name("CW2pHMi")
   on.exit(.unset_function_name(), add = TRUE)
 
+  ## Integrity checks -------------------------------------------------------
+
   ##(1) data.frame or RLum.Data.Curve object?
   .validate_class(values, c("data.frame", "RLum.Data.Curve"))
+  .validate_not_empty(values)
 
   ##(2) if the input object is an 'RLum.Data.Curve' object check for allowed curves
   if (inherits(values, "RLum.Data.Curve")) {
@@ -218,7 +221,6 @@ CW2pHMi<- function(
 
     temp.values <- values
   }
-
 
   # (1) Transform values ------------------------------------------------------
 

--- a/R/CW2pLM.R
+++ b/R/CW2pLM.R
@@ -78,10 +78,11 @@ CW2pLM <- function(
   .set_function_name("CW2pLM")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # Integrity Checks --------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   ##(1) data.frame or RLum.Data.Curve object?
   .validate_class(values, c("data.frame", "RLum.Data.Curve"))
+  .validate_not_empty(values)
 
   ##(2) if the input object is an 'RLum.Data.Curve' object check for allowed curves
   if (inherits(values, "RLum.Data.Curve")) {
@@ -89,11 +90,9 @@ CW2pLM <- function(
       .throw_error("recordType ", values@recordType,
                    " is not allowed for the transformation")
     }
-
     temp.values <- as(values, "data.frame")
 
   }else{
-
     temp.values <- values
   }
 

--- a/R/CW2pLMi.R
+++ b/R/CW2pLMi.R
@@ -155,10 +155,11 @@ CW2pLMi<- function(
   .set_function_name("CW2pLMi")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # (0) Integrity checks -------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   ##(1) data.frame or RLum.Data.Curve object?
   .validate_class(values, c("data.frame", "RLum.Data.Curve"))
+  .validate_not_empty(values)
 
   ##(2) if the input object is an 'RLum.Data.Curve' object check for allowed curves
   if (inherits(values, "RLum.Data.Curve")) {

--- a/R/CW2pPMi.R
+++ b/R/CW2pPMi.R
@@ -163,10 +163,11 @@ CW2pPMi<- function(
   .set_function_name("CW2pPMi")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # (0) Integrity checks ------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   ##(1) data.frame or RLum.Data.Curve object?
   .validate_class(values, c("data.frame", "RLum.Data.Curve"))
+  .validate_not_empty(values)
 
   ##(2) if the input object is an 'RLum.Data.Curve' object check for allowed curves
   if (inherits(values, "RLum.Data.Curve")) {

--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -222,6 +222,7 @@ analyse_FadingMeasurement <- function(
     object <- list(object)
 
   } else if(inherits(object,"data.frame")){
+    .validate_not_empty(object)
     if (ncol(object) %% 3 != 0) {
       .throw_error("'object': if you provide a data.frame as input, ",
                    "the number of columns must be a multiple of 3.")

--- a/R/calc_CobbleDoseRate.R
+++ b/R/calc_CobbleDoseRate.R
@@ -84,8 +84,9 @@ calc_CobbleDoseRate <- function(input,conversion = "Guerinetal2011"){
   .set_function_name("calc_CobbleDoseRate")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # Integrity tests ---------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
   .validate_class(input, "data.frame")
+  .validate_not_empty(input)
   if ((max(input[,1])>input$CobbleDiameter[1]*10) ||
       ((max(input[,1]) + input[length(input[,1]),3]) > input$CobbleDiameter[1]*10))
     .throw_error("Slices outside of cobble: please ensure your distances ",

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -129,6 +129,7 @@ calc_FastRatio <- function(object,
   ## Input verification -----------------------------------------------------
   .validate_class(object, c("RLum.Analysis", "RLum.Results", "RLum.Data.Curve",
                             "data.frame", "matrix"))
+  .validate_not_empty(object)
   .validate_positive_scalar(Ch_L1, int = TRUE)
   .validate_positive_scalar(Ch_L2, int = TRUE, null.ok = TRUE)
   if (!is.null(Ch_L3)) {

--- a/R/calc_FuchsLang2001.R
+++ b/R/calc_FuchsLang2001.R
@@ -3,7 +3,7 @@
 #' @description This function applies the method according to Fuchs & Lang (2001) for
 #' heterogeneously bleached samples with a given coefficient of variation
 #' threshold.
-#' 
+#'
 #' @details
 #'
 #' **Used values**
@@ -89,8 +89,10 @@ calc_FuchsLang2001 <- function(
   .set_function_name("calc_FuchsLang2001")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # Integrity Tests ---------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
+
   .validate_class(data, c("data.frame", "RLum.Results"))
+  .validate_not_empty(data)
   if (inherits(data, "RLum.Results")) {
     data <- get_RLum(data, "data")
   }

--- a/R/calc_HomogeneityTest.R
+++ b/R/calc_HomogeneityTest.R
@@ -63,11 +63,10 @@ calc_HomogeneityTest <- function(
   .set_function_name("calc_HomogeneityTest")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ##============================================================================##
-  ## CONSISTENCY CHECK OF INPUT DATA
-  ##============================================================================##
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(data, c("data.frame", "RLum.Results"))
+  .validate_not_empty(data)
   if (inherits(data, "RLum.Results")) {
     data <- get_RLum(data, "data")
   }

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -301,9 +301,10 @@ calc_Huntley2006 <- function(
   .set_function_name("calc_Huntley2006")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## Validate Input ---------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(data, "data.frame")
+  .validate_not_empty(data)
 
   ## Check fit method
   fit.method <- .validate_args(fit.method, c("EXP", "GOK"))
@@ -347,7 +348,6 @@ calc_Huntley2006 <- function(
         LnTn <- setNames(data.frame(0, LnTn_mean, LnTn_error), names(data))
         data <- rbind(LnTn, data)
       }
-
     }
 
     # check number of columns

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -342,11 +342,10 @@ calc_MinDose <- function(
   .set_function_name("calc_MinDose")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## ============================================================================##
-  ## CONSISTENCY CHECK OF INPUT DATA
-  ## ============================================================================##
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(data, c("data.frame", "RLum.Results"))
+  .validate_not_empty(data)
   if (is(data, "RLum.Results")) {
     data <- get_RLum(data, "data")
   }

--- a/R/calc_Statistics.R
+++ b/R/calc_Statistics.R
@@ -71,8 +71,10 @@ calc_Statistics <- function(
   .set_function_name("calc_Statistics")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## Check input data
+  ## Integrity checks -------------------------------------------------------
+
   .validate_class(data, c("RLum.Results", "data.frame"))
+  .validate_not_empty(data)
   if (inherits(data, "RLum.Results")) {
     data <- get_RLum(data, "data")[, 1:2]
   }

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -63,12 +63,13 @@ calc_WodaFuchs2008 <- function(
   # - add statistics to the plot
   # - check whether this makes sense at all ...
 
-  ## check data and parameter consistency -------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   if (!.validate_class(data, c("data.frame", "RLum.Results", "numeric"),
                        throw.error = FALSE)) {
     return(NULL)
   }
+  .validate_not_empty(data)
 
   if (inherits(data, "RLum.Results")) {
         data <- tryCatch(get_RLum(data, "data"),

--- a/R/convert_Wavelength2Energy.R
+++ b/R/convert_Wavelength2Energy.R
@@ -153,10 +153,11 @@ convert_Wavelength2Energy <- function(
       return(m)
   }
 
-  ## Integrity tests --------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(object, c("RLum.Data.Spectrum", "data.frame", "matrix"),
                   extra = "a 'list' of such objects")
+  .validate_not_empty(object)
 
   if(inherits(object, "RLum.Data.Spectrum")){
      ##check whether the object might have this scale already

--- a/R/fit_CWCurve.R
+++ b/R/fit_CWCurve.R
@@ -212,9 +212,10 @@ fit_CWCurve<- function(
   .set_function_name("fit_CWCurve")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## Integrity tests --------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(values, c("RLum.Data.Curve", "data.frame"))
+  .validate_not_empty(values)
 
   if(is(values, "RLum.Data.Curve") == TRUE){
 

--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -300,6 +300,7 @@ fit_DoseResponseCurve <- function(
   ## Self-call end ----------------------------------------------------------
 
   .validate_class(sample, c("data.frame", "matrix", "list"))
+  .validate_not_empty(sample)
   mode <- .validate_args(mode, c("interpolation", "extrapolation", "alternate"))
   fit.method_supported <- c("LIN", "QDR", "EXP", "EXP OR LIN",
                             "EXP+LIN", "EXP+EXP", "GOK", "LambertW")

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -268,6 +268,7 @@ fit_LMCurve<- function(
 
   ##(1) data.frame or RLum.Data.Curve object?
   .validate_class(values, c("data.frame", "RLum.Data.Curve"))
+  .validate_not_empty(values)
 
   if (inherits(values, "RLum.Data.Curve")) {
     if (values@recordType != "RBR" && values@recordType != "LM-OSL") {

--- a/R/fit_OSLLifeTimes.R
+++ b/R/fit_OSLLifeTimes.R
@@ -254,7 +254,7 @@ if(inherits(object, "list") || inherits(object, "RLum.Analysis")){
   return(results)
 }
 
-  ## Integrity tests --------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   is.valid <- .validate_class(object,
                               c("RLum.Data.Curve", "data.frame", "matrix"),
@@ -263,6 +263,7 @@ if(inherits(object, "list") || inherits(object, "RLum.Analysis")){
   if (!is.valid)
     return(NULL)
 
+  .validate_not_empty(object)
   if(inherits(object, "RLum.Data.Curve")){
    if(!grepl(pattern = "POSL", x = object@recordType, fixed = TRUE))
      .throw_error("recordType '", object@recordType,

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -236,7 +236,9 @@ fit_SurfaceExposure <- function(
   )
   settings <- modifyList(settings, list(...))
 
-  ## Input object handling -----------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
+
+  .validate_not_empty(data)
 
   ## Data type validation
   if (inherits(data, "RLum.Results"))
@@ -250,8 +252,6 @@ fit_SurfaceExposure <- function(
 
   ## For global fitting of multiple data sets 'data' must be a list
   if (inherits(data, "list")) {
-
-    .validate_not_empty(data, "list")
 
     # Global fitting requires and equal amount of ages to be provided
     if (length(data) != length(age))

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1242,7 +1242,8 @@ SW <- function(expr) {
 #'
 #' @param arg [character] (**required**): variable to validate.
 #' @param what [character] (**required**): the type of the variable, used
-#'        only in the message reported.
+#'        only in the message reported; if not specified it's inferred from
+#'        they type of the variable tested.
 #' @param throw.error [logical] (*with default*): whether an error should be
 #'        thrown in case of failed validation (`TRUE` by default). If `FALSE`,
 #'        the function raises a warning and proceeds.
@@ -1258,18 +1259,18 @@ SW <- function(expr) {
 #'
 #' @md
 #' @noRd
-.validate_not_empty <- function(arg, what, throw.error = TRUE,
+.validate_not_empty <- function(arg, what = NULL, throw.error = TRUE,
                                 name = NULL) {
 
-  if (missing(what)) {
-    .throw_error("'what' must be provided")
-  }
+  ## type of the argument to report if not specified
+  if (is.null(what))
+    what <- class(arg)[1]
 
   ## name of the argument to report if not specified
   if (is.null(name))
     name <- sprintf("'%s'", all.vars(match.call())[1])
 
-  if (length(arg) == 0) {
+  if (NROW(arg) == 0 || NCOL(arg) == 0) {
     msg <- paste0(name, " cannot be an empty ", what)
     if (throw.error)
       .throw_error(msg)

--- a/R/plot_DRTResults.R
+++ b/R/plot_DRTResults.R
@@ -196,7 +196,9 @@ plot_DRTResults <- function(
   .set_function_name("plot_DRTResults")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## Validity checks ----------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
+
+  .validate_not_empty(values)
 
   ##avoid crash for wrongly set boxlot argument
   if(missing(preheat) & boxplot == TRUE){
@@ -251,7 +253,6 @@ plot_DRTResults <- function(
 
         ##remove preheat entries
         preheat <- preheat[-temp.NA.values]
-
       }
 
       values[[i]] <- na.exclude(values[[i]])
@@ -307,7 +308,6 @@ plot_DRTResults <- function(
 
       if(length(values) < length(given.dose)){
         .throw_error("'given.dose' > number of input data sets")
-
       }
 
       for(i in 1:length(values)) {
@@ -319,7 +319,6 @@ plot_DRTResults <- function(
       for(i in 1:length(values)) {
         values[[i]] <- values[[i]]/given.dose
       }
-
     }
   }
 
@@ -333,7 +332,6 @@ plot_DRTResults <- function(
         min(values[[x]][,1], na.rm = TRUE) - max(values[[x]][,2], na.rm = TRUE)})),
       max(sapply(1:length(values), function(x){
         max(values[[x]][,1], na.rm = TRUE) + max(values[[x]][,2], na.rm = TRUE)})))
-
   }
 
 

--- a/R/plot_ViolinPlot.R
+++ b/R/plot_ViolinPlot.R
@@ -93,9 +93,10 @@ plot_ViolinPlot <- function(
   .set_function_name("plot_ViolinPlot")
   on.exit(.unset_function_name(), add = TRUE)
 
-  ## Integrity tests --------------------------------------------------------
+  ## Integrity checks -------------------------------------------------------
 
   .validate_class(data, c("RLum.Results", "data.frame", "matrix"))
+  .validate_not_empty(data)
   .validate_class(summary.pos, "character")
 
   if (inherits(data, "RLum.Results")) {

--- a/tests/testthat/test_CW2pX.R
+++ b/tests/testthat/test_CW2pX.R
@@ -1,6 +1,10 @@
-##load data
+## load data
 data(ExampleData.CW_OSL_Curve, envir = environment())
 values <- CW_Curve.BosWallinga2012
+object <- set_RLum(class = "RLum.Data.Curve",
+                   data = as.matrix(ExampleData.CW_OSL_Curve),
+                   curveType = "measured",
+                   recordType = "OSL")
 
 test_that("check functionality", {
   testthat::skip_on_cran()
@@ -35,34 +39,35 @@ test_that("check functionality", {
 test_that("Test RLum.Types", {
   testthat::skip_on_cran()
 
-  ##load CW-OSL curve data
-  data(ExampleData.CW_OSL_Curve, envir = environment())
-  object <-
-    set_RLum(
-      class = "RLum.Data.Curve",
-      data = as.matrix(ExampleData.CW_OSL_Curve),
-      curveType = "measured",
-      recordType = "OSL"
-    )
-
-  ##transform values
   expect_s4_class(CW2pLM(object), class = "RLum.Data.Curve")
   expect_s4_class(CW2pLMi(object), class = "RLum.Data.Curve")
   expect_s4_class(CW2pHMi(object), class = "RLum.Data.Curve")
   expect_s4_class(suppressWarnings(CW2pPMi(object)), class = "RLum.Data.Curve")
+})
 
-  ##test error handling
+test_that("input validation", {
+  testthat::skip_on_cran()
+
   expect_error(CW2pLMi(values, P = 0),
                "[CW2pLMi()] P has to be > 0", fixed = TRUE)
-  expect_warning(CW2pLMi(values, P = 10))
+  expect_warning(CW2pLMi(values, P = 10),
+                 "t' is beyond the time resolution and more than two data points")
   expect_error(CW2pHMi(values = matrix(0, 2)),
                "'values' should be of class 'data.frame' or 'RLum.Data.Curve'")
+  expect_error(CW2pHMi(values = data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(CW2pLMi(values = matrix(0, 2)),
                "'values' should be of class 'data.frame' or 'RLum.Data.Curve'")
+  expect_error(CW2pLMi(values = data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(CW2pLM(values = matrix(0, 2)),
                "'values' should be of class 'data.frame' or 'RLum.Data.Curve'")
+  expect_error(CW2pLM(values = data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(CW2pPMi(values = matrix(0, 2)),
                "'values' should be of class 'data.frame' or 'RLum.Data.Curve'")
+  expect_error(CW2pPMi(values = data.frame()),
+               "'values' cannot be an empty data.frame")
 
   object@recordType <- "RF"
   expect_error(CW2pLM(values = object),

--- a/tests/testthat/test_analyse_FadingMeasurement.R
+++ b/tests/testthat/test_analyse_FadingMeasurement.R
@@ -7,6 +7,10 @@ test_that("input validation", {
 
   expect_error(analyse_FadingMeasurement(object = "test"),
                "'object' should be of class 'RLum.Analysis', 'data.frame' or")
+  expect_error(analyse_FadingMeasurement(object = iris[0, ]),
+               "'object' cannot be an empty data.frame")
+  expect_error(analyse_FadingMeasurement(object = iris[, 0]),
+               "'object' cannot be an empty data.frame")
   expect_warning(expect_error(
       analyse_FadingMeasurement(list(fading_data, "test")),
       "No valid records in 'object' left"),

--- a/tests/testthat/test_calc_CobbleDoseRate.R
+++ b/tests/testthat/test_calc_CobbleDoseRate.R
@@ -8,6 +8,8 @@ test_that("input validation", {
   df$Distance[[14]] <- 50000
   expect_error(calc_CobbleDoseRate("error"),
                "'input' should be of class 'data.frame'")
+  expect_error(calc_CobbleDoseRate(data.frame()),
+               "'input' cannot be an empty data.frame")
   expect_error(calc_CobbleDoseRate(df),
                "Slices outside of cobble: please ensure your distances are in mm")
 

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -8,6 +8,11 @@ test_that("input validation", {
   obj <- ExampleData.CW_OSL_Curve
   expect_error(calc_FastRatio("error"),
                "'object' should be of class 'RLum.Analysis', 'RLum.Results'")
+  expect_error(calc_FastRatio(iris[0, ]),
+               "'object' cannot be an empty data.frame")
+  expect_error(calc_FastRatio(matrix(nrow = 1, ncol = 0)),
+               "'object' cannot be an empty matrix")
+
   expect_error(calc_FastRatio(obj, Ch_L1 = NULL),
                "'Ch_L1' should be a positive integer scalar")
   expect_error(calc_FastRatio(obj, Ch_L1 = 0),

--- a/tests/testthat/test_calc_FuchsLang2001.R
+++ b/tests/testthat/test_calc_FuchsLang2001.R
@@ -1,17 +1,18 @@
+test_that("input validation", {
+  testthat::skip_on_cran()
+
+  expect_error(calc_FuchsLang2001("error"),
+               "[calc_FuchsLang2001()] 'data' should be of class 'data.frame'",
+               fixed = TRUE)
+  expect_error(calc_FuchsLang2001(data.frame()),
+               "'data' cannot be an empty data.frame")
+})
+
 test_that("check class and length of output", {
   testthat::skip_on_cran()
 
   ##load example data
   data(ExampleData.DeValues, envir = environment())
-
-  ##break function
-  expect_error(calc_FuchsLang2001(
-    data = "ExampleData.DeValues$BT998",
-    cvThreshold = 5,
-    plot = FALSE,
-    verbose = FALSE),
-    "[calc_FuchsLang2001()] 'data' should be of class 'data.frame' or 'RLum.Results'",
-    fixed = TRUE)
 
   ##the simple and silent run
   temp <- expect_s4_class(

--- a/tests/testthat/test_calc_HomogeneityTest.R
+++ b/tests/testthat/test_calc_HomogeneityTest.R
@@ -6,12 +6,17 @@ df <-
 
 temp <- calc_HomogeneityTest(df, verbose = FALSE)
 
-
-test_that("check class and length of output", {
+test_that("input validation", {
   testthat::skip_on_cran()
 
   expect_error(calc_HomogeneityTest(TRUE),
                "'data' should be of class 'data.frame' or 'RLum.Results'")
+  expect_error(calc_HomogeneityTest(data.frame()),
+               "'data' cannot be an empty data.frame")
+})
+
+test_that("check values from output example", {
+  testthat::skip_on_cran()
 
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 3)
@@ -21,10 +26,6 @@ test_that("check class and length of output", {
   expect_s4_class(calc_HomogeneityTest(temp),
                   "RLum.Results")
   })
-})
-
-test_that("check values from output example", {
-  testthat::skip_on_cran()
 
   results <- get_RLum(temp)
 

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -30,6 +30,8 @@ test_that("input validation", {
                "'data' should be of class 'data.frame'")
   expect_error(calc_Huntley2006("test"),
                "'data' should be of class 'data.frame'")
+  expect_error(calc_Huntley2006(data.frame()),
+               "'data' cannot be an empty data.frame")
 
   expect_error(calc_Huntley2006(data, fit.method = "test"),
                "'fit.method' should be one of 'EXP' or 'GOK'")

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -12,6 +12,8 @@ test_that("input validation", {
                "'data' should be of class 'data.frame' or 'RLum.Results'")
   expect_error(calc_MinDose("test"),
                "'data' should be of class 'data.frame' or 'RLum.Results'")
+  expect_error(calc_MinDose(data.frame()),
+               "'data' cannot be an empty data.frame")
   expect_error(calc_MinDose(ExampleData.DeValues$CA1),
                "is missing, with no default")
   expect_error(calc_MinDose(ExampleData.DeValues$CA1, init.values = 1:4),

--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -30,6 +30,8 @@ test_that("input validation", {
   expect_error(calc_Statistics(data = matrix(0,2)),
                "[calc_Statistics()] 'data' should be of class 'RLum.Results' or 'data.frame'",
                fixed = TRUE)
+  expect_error(calc_Statistics(data.frame()),
+               "'data' cannot be an empty data.frame")
   expect_error(calc_Statistics(data = df, weight.calc = "error"),
                "'weight.calc' should be one of 'square' or 'reciprocal'")
   expect_error(calc_Statistics(df, digits = 2.4),

--- a/tests/testthat/test_calc_WodaFuchs2008.R
+++ b/tests/testthat/test_calc_WodaFuchs2008.R
@@ -5,6 +5,8 @@ test_that("input validation", {
 
   expect_warning(expect_null(calc_WodaFuchs2008("error")),
                  "'data' should be of class 'data.frame', 'RLum.Results' or")
+  expect_error(calc_WodaFuchs2008(data.frame()),
+               "'data' cannot be an empty data.frame")
   res <- calc_WodaFuchs2008(ExampleData.DeValues$CA1)
   expect_error(calc_WodaFuchs2008(res, breaks = 4),
                "Insufficient number of data points")

--- a/tests/testthat/test_convert_Wavelength2Energy.R
+++ b/tests/testthat/test_convert_Wavelength2Energy.R
@@ -1,7 +1,17 @@
-test_that("test convert functions", {
+test_that("input validation", {
   testthat::skip_on_cran()
 
-  # Set up test scenario ------------------------------------------------------------------------
+  expect_error(convert_Wavelength2Energy("test"),
+               "'object' should be of class 'RLum.Data.Spectrum', 'data.frame'")
+  expect_error(convert_Wavelength2Energy(data.frame()),
+               "'object' cannot be an empty data.frame")
+})
+
+test_that("check functionality", {
+  testthat::skip_on_cran()
+
+  ## Set up test scenario ---------------------------------------------------
+
   #create artifical dataset according to Mooney et al. (2013)
   lambda <- seq(400,800,50)
   data <- matrix(data = rep(1, 2 * length(lambda)), ncol = 2)
@@ -17,10 +27,7 @@ test_that("test convert functions", {
     }
   }
 
-  # Test ----------------------------------------------------------------------------------------
-  ##crash function
-  expect_error(convert_Wavelength2Energy("test"),
-               "'object' should be of class 'RLum.Data.Spectrum', 'data.frame'")
+  ## Test --------------------------------------------------------------------
 
   ##test all three allowed input objects
   expect_type(convert_Wavelength2Energy(data), "double")
@@ -62,6 +69,4 @@ test_that("test convert functions", {
   # par(mfrow = c(1,2))
   # plot_RLum.Data.Spectrum(object, plot.type = "single", par.local = FALSE)
   # plot_RLum.Data.Spectrum(convert_Wavelength2Energy(object), plot.type = "single", par.local = FALSE)
-
-
 })

--- a/tests/testthat/test_fit_CWCurve.R
+++ b/tests/testthat/test_fit_CWCurve.R
@@ -5,6 +5,8 @@ test_that("input validation", {
 
   expect_error(fit_CWCurve("error"),
                "'values' should be of class 'RLum.Data.Curve' or 'data.frame'")
+  expect_error(fit_CWCurve(data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve, fit.method = "error"),
                "'fit.method' should be one of 'port' or 'LM'")
 })

--- a/tests/testthat/test_fit_DoseResponseCurve.R
+++ b/tests/testthat/test_fit_DoseResponseCurve.R
@@ -9,6 +9,8 @@ test_that("input validation", {
       fit_DoseResponseCurve("error"),
       "[fit_DoseResponseCurve()] 'sample' should be of class 'data.frame'",
       fixed = TRUE)
+  expect_error(fit_DoseResponseCurve(data.frame()),
+               "'sample' cannot be an empty data.frame")
   expect_error(fit_DoseResponseCurve(as.list(LxTxData)),
                "All elements of 'sample' should be of class 'data.frame'")
 

--- a/tests/testthat/test_fit_LMCurve.R
+++ b/tests/testthat/test_fit_LMCurve.R
@@ -6,6 +6,8 @@ test_that("input validation", {
 
   expect_error(fit_LMCurve("error"),
                "'values' should be of class 'data.frame' or 'RLum.Data.Curve'")
+  expect_error(fit_LMCurve(data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(fit_LMCurve(set_RLum("RLum.Data.Curve", recordType = "OSL")),
                "recordType should be 'RBR' or 'LM-OSL'")
   expect_error(fit_LMCurve(values.curve, values.bg = "error"),

--- a/tests/testthat/test_fit_OSLLifeTimes.R
+++ b/tests/testthat/test_fit_OSLLifeTimes.R
@@ -5,9 +5,12 @@ temp_mat <- get_RLum(ExampleData.TR_OSL)[1:200, ]
 test_that("input validation", {
   testthat::skip_on_cran()
 
-
   expect_warning(expect_null(fit_OSLLifeTimes("error")),
                  "'object' should be of class 'RLum.Data.Curve', 'data.frame'")
+  expect_error(fit_OSLLifeTimes(data.frame()),
+               "'object' cannot be an empty data.frame")
+  expect_error(fit_OSLLifeTimes(matrix(NA, 0, 3)),
+               "'object' cannot be an empty matrix")
   expect_error(fit_OSLLifeTimes(ExampleData.TR_OSL, n.components = -1),
                "'n.components' should be a positive integer scalar")
   expect_error(fit_OSLLifeTimes(ExampleData.TR_OSL, signal_range = FALSE),

--- a/tests/testthat/test_fit_SurfaceExposure.R
+++ b/tests/testthat/test_fit_SurfaceExposure.R
@@ -11,6 +11,8 @@ test_that("input validation", {
                "'data' should be of class 'data.frame'")
   expect_error(fit_SurfaceExposure(list()),
                "'data' cannot be an empty list")
+  expect_error(fit_SurfaceExposure(data.frame()),
+               "'data' cannot be an empty data.frame")
   expect_error(fit_SurfaceExposure(list(d1)),
                "'age' must be of the same length")
   expect_error(fit_SurfaceExposure(d4, age = 1e4),

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -323,12 +323,24 @@ test_that("Test internals", {
   ## .validate_not_empty() --------------------------------------------------
   expect_true(.validate_not_empty(letters, "vector"))
 
-  expect_error(.validate_not_empty(letters),
-               "'what' must be provided")
   expect_error(.validate_not_empty(test <- c(), "vector"),
                "'test' cannot be an empty vector")
-  expect_error(.validate_not_empty(test <- list(), "list"),
+  expect_error(.validate_not_empty(test <- list()),
                "'test' cannot be an empty list")
+  expect_error(.validate_not_empty(test <- numeric(0)),
+               "'test' cannot be an empty numeric")
+  expect_error(.validate_not_empty(test <- data.frame()),
+               "'test' cannot be an empty data.frame")
+  expect_error(.validate_not_empty(iris[0, ]),
+               "'iris' cannot be an empty data.frame")
+  expect_error(.validate_not_empty(iris[, 0]),
+               "'iris' cannot be an empty data.frame")
+  expect_error(.validate_not_empty(test <- matrix(NA, 0, 5)),
+               "'test' cannot be an empty matrix")
+  expect_error(.validate_not_empty(test <- matrix(NA, 5, 0)),
+               "'test' cannot be an empty matrix")
+  expect_error(.validate_not_empty(test <- set_RLum("RLum.Analysis")),
+               "'test' cannot be an empty RLum.Analysis")
   expect_error(.validate_not_empty(list(), "list", name = "'other_name'"),
                "'other_name' cannot be an empty list")
   expect_warning(expect_false(.validate_not_empty(test <- list(), "list",

--- a/tests/testthat/test_plot_DRTResults.R
+++ b/tests/testthat/test_plot_DRTResults.R
@@ -1,3 +1,4 @@
+## load data
 set.seed(1)
 data(ExampleData.DeValues, envir = environment())
 df <- ExampleData.DeValues$BT998[7:11,]
@@ -19,9 +20,11 @@ test_that("input validation", {
 
   empty <- set_RLum("RLum.Results")
   expect_error(plot_DRTResults(empty),
-                     "No valid records in 'values'")
+               "'values' cannot be an empty RLum.Results")
   expect_error(plot_DRTResults(list()),
-               "No valid records in 'values'")
+               "'values' cannot be an empty list")
+  expect_error(plot_DRTResults(data.frame()),
+               "'values' cannot be an empty data.frame")
   expect_error(plot_DRTResults(list(empty, empty)),
                      "No valid records in 'values'")
 })
@@ -68,11 +71,8 @@ test_that("check functionality", {
   expect_silent(plot_DRTResults(df, summary.pos = "bottomright",
                                 legend.pos = "bottomleft"))
 
-
   ## plot_DRTResults(df.list, preheat = c(200, 200, 200, 240, 240),
   ##                 given.dose = 2800, boxplot = TRUE)
-
-
 
   ## RLum.Results object
   expect_silent(plot_DRTResults(calc_CommonDose(df, plot = FALSE,

--- a/tests/testthat/test_plot_ViolinPlot.R
+++ b/tests/testthat/test_plot_ViolinPlot.R
@@ -11,8 +11,10 @@ test_that("input validation", {
   expect_error(plot_ViolinPlot(df, summary.pos = 5),
                "'summary.pos' should be of class 'character'")
 
-  expect_warning(plot_ViolinPlot(df[0, ]),
-                 "it is rather hard to plot 0 values, returning")
+  expect_error(plot_ViolinPlot(data.frame()),
+               "'data' cannot be an empty data.frame")
+  expect_error(plot_ViolinPlot(df[0, ]),
+               "'data' cannot be an empty data.frame")
   expect_warning(plot_ViolinPlot(df[1, ]),
                  "Single data point found, no density calculated")
   expect_warning(plot_ViolinPlot(df, summary = "error"),


### PR DESCRIPTION
This generalizes `.validate_not_empty()` so that it can be apply more broadly and fixes #466.