### PR TITLE
Fix crashes in calc_FastRatio()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -109,6 +109,10 @@ produce unusable results (all `NA`s) or buggy behaviour (#302, fixed in #304).
 profile log-likelihood as soon as `sigma < 1e-16`, as allowing `sigma` to
 become zero leads to infinities and buggy behaviour (also fixed in #304).
 
+### `calc_FastRatio()`
+* A number of crashes related to input validation have been fixed (#471,
+fixed in #472).
+
 ### `calc_IEU()`
 * The code of this function has been consolidated to avoid duplication and
 make its debugging easier: this has uncovered a small coding error and also

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -179,12 +179,12 @@ calc_FastRatio <- function(object,
     # lambdaLED = wavelength of stimulation source in nm
     P <- stimulation.power 
     lamdaLED <- wavelength
-    
+
     ## Constants
-    # h = speed of light, h = Planck's constant
+    ## c = speed of light, h = Planck's constant
     h <- 6.62607004E-34
     c <- 299792458
-    
+
     I0 <- (P / 1000) / (h * c / (lamdaLED * 10^-9))
     Ch_width <- max(A[ ,1]) / length(A[ ,1])
     
@@ -298,7 +298,7 @@ calc_FastRatio <- function(object,
                            "5 channels."), Ch_L3st, Ch_L3end, nrow(A))
       settings$info <- modifyList(settings$info, list(L3 = msg))
       .throw_warning(msg)
-      Ch_L3st <- nrow(A) - 5
+      Ch_L3st <- max(nrow(A) - 5, 1)
       Ch_L3end <- nrow(A)
       t_L3_start <- A[Ch_L3st,1]
       t_L3_end <- A[Ch_L3end,1]

--- a/R/calc_FastRatio.R
+++ b/R/calc_FastRatio.R
@@ -30,17 +30,17 @@
 #' 
 #' @param Ch_L2 [numeric] (*optional*): 
 #' An integer specifying the channel for L2.
-#' @param x [numeric] (*with default*): 
 #'
 #' @param Ch_L3 [numeric] (*optional*):
 #' A vector of length 2 with integer values specifying the start and end
 #' channels for L3 (e.g., `c(40, 50)`), with the second component greater
 #' than or equal to the first.
 #'
+#' @param x [numeric] (*with default*):
 #' \% of signal remaining from the fast component.
 #' Used to define the location of L2 and L3 (start).
-#' 
-#' @param x2 [numeric] (*with default*): 
+#'
+#' @param x2 [numeric] (*with default*):
 #' \% of signal remaining from the medium component.
 #' Used to define the location of L3 (end). 
 #' 
@@ -141,6 +141,16 @@ calc_FastRatio <- function(object,
       .throw_error("'Ch_L3[2]' must be greater than or equal to 'Ch_L3[1]'")
     }
   }
+  .validate_positive_scalar(wavelength)
+  .validate_positive_scalar(sigmaF)
+  .validate_positive_scalar(sigmaM)
+  .validate_positive_scalar(x)
+  .validate_positive_scalar(x2)
+  .validate_class(dead.channels, c("integer", "numeric"))
+  .validate_length(dead.channels, 2)
+  if (any(dead.channels < 0)) {
+    .throw_error("All elements of 'dead.channels' should be non-negative")
+  }
 
   ## Input object handling -----------------------------------------------------
   if (inherits(object, "RLum.Analysis"))
@@ -160,11 +170,11 @@ calc_FastRatio <- function(object,
                    output.terminal = FALSE,
                    info = list(),
                    fit = NULL)
-  
+
   # override defaults with args in ...
   settings <- modifyList(settings, list(...))
-  
-  
+
+
   ## Calculations --------------------------------------------------------------
   # iterate over all user provided objects and calculate the FR
   fast.ratios <- lapply(object, function(obj) {

--- a/R/fit_CWCurve.R
+++ b/R/fit_CWCurve.R
@@ -233,6 +233,7 @@ fit_CWCurve<- function(
   }
 
   fit.method <- .validate_args(fit.method, c("port", "LM"))
+  .validate_positive_scalar(n.components.max, int = TRUE)
 
   # Deal with extra arguments -----------------------------------------------
 

--- a/R/fit_CWCurve.R
+++ b/R/fit_CWCurve.R
@@ -232,6 +232,9 @@ fit_CWCurve<- function(
     y<-values[,2]
   }
 
+  if (any(order(x) != seq_along(x))) {
+    .throw_error("Time values are not ordered")
+  }
   fit.method <- .validate_args(fit.method, c("port", "LM"))
   .validate_positive_scalar(n.components.max, int = TRUE)
 

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -42,6 +42,23 @@ test_that("input validation", {
                "Value in 'Ch_L3' (5, 1001) exceeds number of available channels",
                fixed = TRUE)
 
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, wavelength=0),
+               "'wavelength' should be a positive scalar")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, sigmaF= 0),
+               "'sigmaF' should be a positive scalar")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, sigmaM= 0),
+               "'sigmaM' should be a positive scalar")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, x = -12),
+               "'x' should be a positive scalar")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, x2 = -12),
+               "'x2' should be a positive scalar")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, dead.channels = TRUE),
+               "'dead.channels' should be of class 'integer' or 'numeric'")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, dead.channels = 1),
+               "'dead.channels' should have length 2")
+  expect_error(calc_FastRatio(ExampleData.CW_OSL_Curve, dead.channels = c(-1, 1)),
+               "All elements of 'dead.channels' should be non-negative")
+
   expect_warning(expect_null(calc_FastRatio(ExampleData.CW_OSL_Curve,
                                             Ch_L2 = 1)),
                  "Calculated time/channel for L2 is too small (0, 1)",

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -133,4 +133,21 @@ test_that("regression tests", {
   expect_s4_class(suppressWarnings(
       calc_FastRatio(ExampleData.CW_OSL_Curve[1:5, ], verbose = FALSE)),
       "RLum.Results")
+
+  SW({
+  expect_message(expect_s4_class(
+      calc_FastRatio(ExampleData.CW_OSL_Curve, fitCW.sigma=TRUE,
+                     n.components.max = 0),
+      "RLum.Results"),
+      "Error: Fitting failed, please call 'fit_CWCurve()' manually",
+      fixed = TRUE)
+
+  set.seed(1)
+  expect_message(expect_s4_class(
+      calc_FastRatio(ExampleData.CW_OSL_Curve[sample(50), ],
+                     fitCW.sigma = TRUE),
+      "RLum.Results"),
+      "Error: Fitting failed, please call 'fit_CWCurve()' manually",
+      fixed = TRUE)
+  })
 })

--- a/tests/testthat/test_calc_FastRatio.R
+++ b/tests/testthat/test_calc_FastRatio.R
@@ -1,6 +1,5 @@
+## load data
 data(ExampleData.CW_OSL_Curve, envir = environment())
-temp <- calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE, verbose = FALSE)
-
 
 test_that("input validation", {
   testthat::skip_on_cran()
@@ -59,9 +58,11 @@ test_that("input validation", {
   })
 })
 
-test_that("check class and length of output", {
+test_that("check functionality", {
   testthat::skip_on_cran()
 
+  temp <- calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE,
+                         verbose = FALSE)
   expect_s4_class(temp, "RLum.Results")
   expect_equal(length(temp), 5)
 
@@ -78,13 +79,8 @@ test_that("check class and length of output", {
                  "L3 contains more counts (566) than L2 (562)",
                  fixed = TRUE)
   })
-})
-
-test_that("check values from output", {
-  testthat::skip_on_cran()
 
   results <- get_RLum(temp)
-
   expect_equal(round(results$fast.ratio, digits = 3), 405.122)
   expect_equal(round(results$fast.ratio.se, digits = 4), 119.7442)
   expect_equal(round(results$fast.ratio.rse, digits = 5), 29.55756)
@@ -107,5 +103,17 @@ test_that("check values from output", {
   expect_equal(results$Cts_L1, 11111)
   expect_equal(results$Cts_L2, 65)
   expect_equal(round(results$Cts_L3, digits = 5), 37.66667)
+})
 
+test_that("regression tests", {
+
+  ## issue 471 --------------------------------------------------------------
+
+  expect_s4_class(suppressWarnings(
+      calc_FastRatio(ExampleData.CW_OSL_Curve[1:3, ], verbose = FALSE)),
+      "RLum.Results")
+
+  expect_s4_class(suppressWarnings(
+      calc_FastRatio(ExampleData.CW_OSL_Curve[1:5, ], verbose = FALSE)),
+      "RLum.Results")
 })

--- a/tests/testthat/test_fit_CWCurve.R
+++ b/tests/testthat/test_fit_CWCurve.R
@@ -9,6 +9,8 @@ test_that("input validation", {
                "'values' cannot be an empty data.frame")
   expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve, fit.method = "error"),
                "'fit.method' should be one of 'port' or 'LM'")
+  expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve, n.components.max = 0),
+               "'n.components.max' should be a positive integer scalar")
 })
 
 test_that("check class and length of output", {

--- a/tests/testthat/test_fit_CWCurve.R
+++ b/tests/testthat/test_fit_CWCurve.R
@@ -11,6 +11,8 @@ test_that("input validation", {
                "'fit.method' should be one of 'port' or 'LM'")
   expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve, n.components.max = 0),
                "'n.components.max' should be a positive integer scalar")
+  expect_error(fit_CWCurve(ExampleData.CW_OSL_Curve[5:1, ]),
+               "Time values are not ordered")
 })
 
 test_that("check class and length of output", {


### PR DESCRIPTION
These were mainly due to poor input validation, but also to not dealing correctly with cases when `fit_CWCurve()` failed. Some better validation in `fit_CWCurve()` was also necessary. Fixes #471.