### PR TITLE
Improve validation against a list with an empty RLum.Data.Curve

### DIFF
--- a/R/merge_RLum.Data.Curve.R
+++ b/R/merge_RLum.Data.Curve.R
@@ -151,7 +151,7 @@ merge_RLum.Data.Curve<- function(
   ##(1) build new data matrix
   ## first find the shortest object
   check.rows <- vapply(object, function(x) nrow(x@data), numeric(1))
-  if (length(check.rows) == 0) {
+  if (length(check.rows) < 2) {
     .throw_error("'object' contains no data")
   }
   num.rows <- min(check.rows)

--- a/tests/testthat/test_merge_RLum.Data.Curve.R
+++ b/tests/testthat/test_merge_RLum.Data.Curve.R
@@ -22,6 +22,8 @@ test_that("input validation", {
                "All elements of 'object' should be of class 'RLum.Data.Curve'")
   expect_error(merge_RLum.Data.Curve(list(), merge.method = "/"),
                "'object' contains no data")
+  expect_error(merge_RLum.Data.Curve(list(set_RLum("RLum.Data.Curve"))),
+               "'object' contains no data")
   expect_error(merge_RLum.Data.Curve(list(TL.curve.1, TL.curve.3),
                                      merge.method = "error"),
                "'merge.method' should be one of 'mean', 'median', 'sum', 'sd'")


### PR DESCRIPTION
An empty RLum.Data.Curve has 1 row of zeros, so we need to consider also objects with only 1 row to be empty.

Fixes #507.