### PR TITLE
Add explicit support for disabling the fitting in analyse_IRSAR.RF()

### DIFF
--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -199,7 +199,7 @@
 #'
 #' @param method [character] (*with default*): select method applied for the
 #' data analysis. Possible options are `"FIT"`, `"SLIDE"`, `"VSLIDE"`;
-#' `"None"` can be used to disable the analysis and plot the natural points
+#' `"NONE"` can be used to disable the analysis and plot the natural points
 #' at their original position.
 #'
 #' @param method_control [list] (*optional*):
@@ -529,7 +529,7 @@ analyse_IRSAR.RF<- function(
     .validate_class(RF_nat.lim, c("numeric", "integer"))
   if (!is.null(RF_reg.lim))
     .validate_class(RF_reg.lim, c("numeric", "integer"))
-  method <- .validate_args(method, c("FIT", "SLIDE", "VSLIDE", "None"))
+  method <- .validate_args(toupper(method), c("FIT", "SLIDE", "VSLIDE", "NONE"))
   .validate_positive_scalar(n.MC, int = TRUE, null.ok = TRUE)
 
   ##SELECT ONLY MEASURED CURVES

--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -197,8 +197,10 @@
 #' If only one value is provided this will be treated as minimum value and the
 #' maximum limit will be added automatically.
 #'
-#' @param method [character] (*with default*): select method applied for the data analysis.
-#' Possible options are `"FIT"`, `"SLIDE"`, `"VSLIDE"`.
+#' @param method [character] (*with default*): select method applied for the
+#' data analysis. Possible options are `"FIT"`, `"SLIDE"`, `"VSLIDE"`;
+#' `"None"` can be used to disable the analysis and plot the natural points
+#' at their original position.
 #'
 #' @param method_control [list] (*optional*):
 #' parameters to control the method, that can be passed to the chosen method.
@@ -527,7 +529,7 @@ analyse_IRSAR.RF<- function(
     .validate_class(RF_nat.lim, c("numeric", "integer"))
   if (!is.null(RF_reg.lim))
     .validate_class(RF_reg.lim, c("numeric", "integer"))
-  method <- .validate_args(method, c("FIT", "SLIDE", "VSLIDE"))
+  method <- .validate_args(method, c("FIT", "SLIDE", "VSLIDE", "None"))
   .validate_positive_scalar(n.MC, int = TRUE, null.ok = TRUE)
 
   ##SELECT ONLY MEASURED CURVES

--- a/man/analyse_IRSAR.RF.Rd
+++ b/man/analyse_IRSAR.RF.Rd
@@ -42,8 +42,10 @@ set minimum and maximum channel range for regenerated signal fitting and sliding
 If only one value is provided this will be treated as minimum value and the
 maximum limit will be added automatically.}
 
-\item{method}{\link{character} (\emph{with default}): select method applied for the data analysis.
-Possible options are \code{"FIT"}, \code{"SLIDE"}, \code{"VSLIDE"}.}
+\item{method}{\link{character} (\emph{with default}): select method applied for the
+data analysis. Possible options are \code{"FIT"}, \code{"SLIDE"}, \code{"VSLIDE"};
+\code{"None"} can be used to disable the analysis and plot the natural points
+at their original position.}
 
 \item{method_control}{\link{list} (\emph{optional}):
 parameters to control the method, that can be passed to the chosen method.

--- a/man/analyse_IRSAR.RF.Rd
+++ b/man/analyse_IRSAR.RF.Rd
@@ -44,7 +44,7 @@ maximum limit will be added automatically.}
 
 \item{method}{\link{character} (\emph{with default}): select method applied for the
 data analysis. Possible options are \code{"FIT"}, \code{"SLIDE"}, \code{"VSLIDE"};
-\code{"None"} can be used to disable the analysis and plot the natural points
+\code{"NONE"} can be used to disable the analysis and plot the natural points
 at their original position.}
 
 \item{method_control}{\link{list} (\emph{optional}):

--- a/tests/testthat/_snaps/analyse_IRSAR.RF.md
+++ b/tests/testthat/_snaps/analyse_IRSAR.RF.md
@@ -1048,3 +1048,198 @@
       }
     }
 
+---
+
+    {
+      "type": "S4",
+      "attributes": {
+        "data": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": ["data", "De.MC", "test_parameters", "slide"]
+            }
+          },
+          "value": [
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["DE", "DE.ERROR", "DE.LOWER", "DE.UPPER", "DE.STATUS", "RF_NAT.LIM", "RF_REG.LIM", "POSITION", "DATE", "SEQUENCE_NAME"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["OK"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["1:5"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["1:524"]
+                },
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null]
+                }
+              ]
+            },
+            {
+              "type": "logical",
+              "attributes": {},
+              "value": [null]
+            },
+            {
+              "type": "list",
+              "attributes": {
+                "names": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["POSITION", "PARAMETER", "THRESHOLD", "VALUE", "STATUS", "SEQUENCE_NAME"]
+                },
+                "row.names": {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": [1, 2, 3, 4, 5, 6, 7, 8]
+                },
+                "class": {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["data.frame"]
+                }
+              },
+              "value": [
+                {
+                  "type": "integer",
+                  "attributes": {},
+                  "value": ["NA", "NA", "NA", "NA", "NA", "NA", "NA", "NA"]
+                },
+                {
+                  "type": "character",
+                  "attributes": {},
+                  "value": ["curves_ratio", "intersection_ratio", "residuals_slope", "curves_bounds", "dynamic_ratio", "lambda", "beta", "delta.phi"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [1.001, "NA", "NA", 716, "NA", "NA", "NA", "NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": [0.68456846, 0.00554174, "NA", "NA", 1.52426091, 0.00021822, 0.54187185, 2103.4]
+                },
+                {
+                  "type": "integer",
+                  "attributes": {
+                    "levels": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["OK"]
+                    },
+                    "class": {
+                      "type": "character",
+                      "attributes": {},
+                      "value": ["factor"]
+                    }
+                  },
+                  "value": [1, 1, 1, 1, 1, 1, 1, 1]
+                },
+                {
+                  "type": "logical",
+                  "attributes": {},
+                  "value": [null, null, null, null, null, null, null, null]
+                }
+              ]
+            },
+            {
+              "type": "list",
+              "attributes": {},
+              "value": []
+            }
+          ]
+        },
+        "originator": {
+          "type": "character",
+          "attributes": {},
+          "value": ["analyse_IRSAR.RF"]
+        },
+        "info": {
+          "type": "list",
+          "attributes": {
+            "names": {
+              "type": "character",
+              "attributes": {},
+              "value": []
+            }
+          },
+          "value": []
+        },
+        ".uid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        },
+        ".pid": {
+          "type": "character",
+          "attributes": {},
+          "value": [null]
+        }
+      },
+      "value": {
+        "class": "RLum.Results",
+        "package": "Luminescence"
+      }
+    }
+

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -13,7 +13,7 @@ test_that("input validation", {
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, n.MC = 0),
                "'n.MC' should be a positive integer scalar")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method = "error"),
-               "'method' should be one of 'FIT', 'SLIDE', 'VSLIDE' or 'None'")
+               "'method' should be one of 'FIT', 'SLIDE', 'VSLIDE' or 'NONE'")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method_control = 3),
                "'method_control' should be of class 'list'")
   expect_warning(expect_null(analyse_IRSAR.RF(list())),

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -12,7 +12,7 @@ test_that("input validation", {
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, n.MC = 0),
                "'n.MC' should be a positive integer scalar")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method = "error"),
-               "'method' should be one of 'FIT', 'SLIDE' or 'VSLIDE'")
+               "'method' should be one of 'FIT', 'SLIDE', 'VSLIDE' or 'None'")
   expect_error(analyse_IRSAR.RF(IRSAR.RF.Data, method_control = 3),
                "'method_control' should be of class 'list'")
   expect_warning(expect_null(analyse_IRSAR.RF(list())),
@@ -145,6 +145,15 @@ test_that("check class and length of output", {
     )
   )
   })
+
+  expect_snapshot_RLum(
+    analyse_IRSAR.RF(
+      object = IRSAR.RF.Data,
+      method = "None",
+      n.MC = 10,
+      txtProgressBar = FALSE
+    )
+  )
 
   expect_s3_class(results_fit$fit, class = "nls")
   expect_s3_class(results_slide$fit, class = "nls")

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -238,12 +238,9 @@ test_that("test edge cases", {
     txtProgressBar = FALSE
   )), "RLum.Results")
 
-  ## the next test fails on macos-13 CI as it doesn't throw the warning
-  skip_on_os("mac")
-
   ## test parameters values only set for coverage
   SW({
-  expect_warning(expect_s4_class(analyse_IRSAR.RF(
+  expect_s4_class(analyse_IRSAR.RF(
     object,
     method = "SLIDE",
     method_control = list(vslide_range = 'auto', correct_onset = FALSE),
@@ -258,8 +255,7 @@ test_that("test edge cases", {
                            beta = 1e-4,
                            delta.phi = 1e-4),
     txtProgressBar = FALSE
-  ), "RLum.Results"),
-  "lmdif: info = -1. Number of iterations has reached `maxiter' == 50")
+  ), "RLum.Results")
   })
 })
 

--- a/tests/testthat/test_analyse_IRSAR.RF.R
+++ b/tests/testthat/test_analyse_IRSAR.RF.R
@@ -1,3 +1,4 @@
+## load data
 data(ExampleData.RLum.Analysis, envir = environment())
 
 test_that("input validation", {
@@ -211,6 +212,7 @@ test_that("test edge cases", {
     plot = TRUE,
     main = "Title",
     mtext = "Subtitle",
+    log = "x",
     txtProgressBar = FALSE),
     "RLum.Results"),
     "Threshold exceeded for: 'curves_ratio'")
@@ -224,6 +226,14 @@ test_that("test edge cases", {
     method_control = list(vslide_range = 'auto', correct_onset = FALSE),
     RF_nat.lim = c(10,100),
     #RF_reg.lim = c(),
+    plot = TRUE,
+    txtProgressBar = FALSE
+  )), "RLum.Results")
+
+  expect_s4_class(suppressWarnings(analyse_IRSAR.RF(
+    object,
+    method = "FIT",
+    mtext = "FIT method",
     plot = TRUE,
     txtProgressBar = FALSE
   )), "RLum.Results")


### PR DESCRIPTION
This was effectively available before the changes in 51c324bd5 made the validation of the `method` argument stricter and made this feature unavailable (also causing a loss in coverage).