### PR TITLE
Fix crashes and messages when setting `variable.names` in analyse_baSAR()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -86,6 +86,9 @@ with and the argument `irradiation_times` was set; fixed.
 it almost never did; fixed.
 * The function is more robust against input that may have been subset
 inconsistently (#517, fixed in #518).
+* The function doesn't crash but reports more helpful messages in case the
+user overrides the default set of monitored variables using `variable.names`
+within the `method_control` argument (#521, fixed in #522).
 
 ### `analyse_FadingMeasurement()`
 * The function now checks for the version of the BIN-file that originated the

--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,10 @@
   well it almost never did; fixed.
 - The function is more robust against input that may have been subset
   inconsistently (#517, fixed in \#518).
+- The function doesn’t crash but reports more helpful messages in case
+  the user overrides the default set of monitored variables using
+  `variable.names` within the `method_control` argument (#521, fixed in
+  \#522).
 
 ### `analyse_FadingMeasurement()`
 

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -1987,21 +1987,17 @@ analyse_baSAR <- function(
         col[2]
       }else if(aliquot_quantiles[2,x] < results[[1]][,c("CENTRAL_Q_.16")] |
                aliquot_quantiles[1,x] > results[[1]][,c("CENTRAL_Q_.84")]){
-
         "orange"
       }else{
         "white"
       }
-
     }, FUN.VALUE = vector(mode = "character", length = 1))
 
     ## to assure a minimum of quality not more then 15 boxes are plotted in each plot
     i <- 1
 
     while(i < ncol(plot_matrix)){
-
-      step <- if((i + 14) > ncol(plot_matrix)){ncol(plot_matrix)}else{i + 14}
-
+      step <- min(ncol(plot_matrix), i + 14)
       plot_check <- try(boxplot(
         x = plot_matrix[,i:step],
         use.cols = TRUE,

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -832,6 +832,9 @@ analyse_baSAR <- function(
     variable.names <- method_control[["variable.names"]]
   }
 
+  ## always monitor the D variable
+  variable.names <- unique(c(variable.names, "D"))
+
 
   # Set input -----------------------------------------------------------------------------------
 

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -1951,14 +1951,15 @@ analyse_baSAR <- function(
     ##TRACE AND DENSITY PLOT
     ####//////////////////////////////////////////////////////////////////////////////////////////
     if(plot_reduced){
-      plot_check <- try(plot(results[[2]][,c("central_D","sigma_D"),drop = FALSE]), silent = TRUE)
-
-      ##show error
-      if(is(plot_check, "try-error")){
-        .throw_error("Plots for 'central_D' and 'sigma_D' could not be ",
-                     "produced. You are probably monitoring the wrong variables")
+      if (!all(c("central_D", "sigma_D") %in% variable.names)) {
+        var.missing <- setdiff(c("central_D", "sigma_D"), variable.names)
+        .throw_message("Plots for 'central_D' and 'sigma_D' could not be ",
+                       "produced as 'variable.names' does not include ",
+                       .collapse(var.missing))
+      } else {
+        try(plot(results[[2]][, c("central_D", "sigma_D"), drop = FALSE]),
+            silent = TRUE)
       }
-
     }else{
       try(plot(results[[2]]))
     }

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -829,7 +829,9 @@ analyse_baSAR <- function(
   ## variable names to monitor
   variable.names <- c('central_D', 'sigma_D', 'D', 'Q', 'a', 'b', 'c', 'g')
   if (!is.null(method_control[["variable.names"]])) {
-    variable.names <- method_control[["variable.names"]]
+    ## take variable from the user but remove nonsense values
+    variable.names <- setdiff(method_control[["variable.names"]],
+                              c("", NA))
   }
 
   ## always monitor the D variable

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -352,6 +352,16 @@ test_that("Full check of analyse_baSAR function", {
                 method_control = list(n.chains = 1),
                 aliquot_range = 1:2,
                 n.MCMC = 10)
+
+  vnames <- c('central_D', 'sigma_D', 'D')
+  expect_message(analyse_baSAR(CWOSL.sub,
+                               source_doserate = c(0.04, 0.001),
+                               signal.integral = 1:2,
+                               background.integral = 60:100,
+                               method_control = list(n.chains = 1,
+                                                     variable.names = vnames),
+                               n.MCMC = 10, verbose = FALSE),
+                 "Dose-response curves could not be plotted as 'variable.names'")
   })
 })
 

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -360,6 +360,7 @@ test_that("Full check of analyse_baSAR function", {
                                background.integral = 60:100,
                                method_control = list(n.chains = 1,
                                                      variable.names = vnames),
+                               plot_reduced = FALSE,
                                n.MCMC = 10, verbose = FALSE),
                  "Dose-response curves could not be plotted as 'variable.names'")
 

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -353,7 +353,7 @@ test_that("Full check of analyse_baSAR function", {
                 aliquot_range = 1:2,
                 n.MCMC = 10)
 
-  vnames <- c('central_D', 'sigma_D', 'D')
+  vnames <- c("central_D", "sigma_D")
   expect_message(analyse_baSAR(CWOSL.sub,
                                source_doserate = c(0.04, 0.001),
                                signal.integral = 1:2,

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -281,7 +281,7 @@ test_that("Full check of analyse_baSAR function", {
           n.MCMC = 100),
       "Error: 'aliquot_range' out of bounds, input ignored")
 
-  expect_warning(expect_error(
+  expect_warning(expect_message(
       analyse_baSAR(
           object = results,
           plot = TRUE,
@@ -362,6 +362,16 @@ test_that("Full check of analyse_baSAR function", {
                                                      variable.names = vnames),
                                n.MCMC = 10, verbose = FALSE),
                  "Dose-response curves could not be plotted as 'variable.names'")
+
+  vnames <- c("D", "Q", "a", "b", "c", "g")
+  expect_message(analyse_baSAR(CWOSL.sub,
+                               source_doserate = c(0.04, 0.001),
+                               signal.integral = 1:2,
+                               background.integral = 60:100,
+                               method_control = list(n.chains = 1,
+                                                     variable.names = vnames),
+                               n.MCMC = 10, verbose = FALSE),
+                 "Plots for 'central_D' and 'sigma_D' could not be produced")
   })
 })
 

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -353,7 +353,7 @@ test_that("Full check of analyse_baSAR function", {
                 aliquot_range = 1:2,
                 n.MCMC = 10)
 
-  vnames <- c("central_D", "sigma_D")
+  vnames <- c("central_D", "sigma_D", "")
   expect_message(analyse_baSAR(CWOSL.sub,
                                source_doserate = c(0.04, 0.001),
                                signal.integral = 1:2,


### PR DESCRIPTION
There were four different bugs, each one fixed in its own commit. Fixes #521.