### PR TITLE
Allow to control the ITL_model argument from analyse_ThermochronometryData()

### DIFF
--- a/R/analyse_ThermochronometryData.R
+++ b/R/analyse_ThermochronometryData.R
@@ -8,6 +8,9 @@
 #' @param object [character] (**required**): path to a CSV file with;
 #' alternatively a [vector] of paths
 #'
+#' @param ITL_model [character] (*with default*): type of model to fit,
+#' either `"GOK"` or `"BTS"`
+#'
 #' @param plot [logical] (*with default*): enable/disable plot output
 #'
 #' @param verbose [logical] (*with default*): enable/disable terminal output
@@ -32,6 +35,7 @@
 #' @export
 analyse_ThermochronometryData <- function(
   object,
+  ITL_model = c("GOK", "BTS"),
   plot = TRUE,
   verbose = TRUE,
   ...
@@ -51,6 +55,7 @@ analyse_ThermochronometryData <- function(
   ## Integrity checks -------------------------------------------------------
   ## for a start with only allow data coming in in the format proposed by the MatLab script
   .validate_class(object, "character")
+  .validate_args(ITL_model, c("GOK", "BTS"))
 
   object <- .import_ThermochronometryData(object, output_type = "RLum.Results")
   sample_names <- object@info$sample_names
@@ -86,6 +91,7 @@ analyse_ThermochronometryData <- function(
     df_ITL <- object@data$ITL[object@data$ITL$SAMPLE == sample_names[i],]
     results_ITL <- fit_IsoThermalHolding(
       data = df_ITL,
+      ITL_model = ITL_model,
       rhop = results_FAD,
       plot = plot)
 

--- a/R/fit_IsothermalHolding.R
+++ b/R/fit_IsothermalHolding.R
@@ -52,6 +52,7 @@ fit_IsoThermalHolding <- function(
   ## - the rhop value has uncertainties, which are not yet considered
 
   .validate_class(data, c("character", "RLum.Results", "data.frame"))
+  .validate_args(ITL_model, c("GOK", "BTS"))
 
   if (inherits(data[1], "character")) {
     records_ITL <- .import_ThermochronometryData(file = data, output_type = "RLum.Results")@data$ITL

--- a/man/analyse_ThermochronometryData.Rd
+++ b/man/analyse_ThermochronometryData.Rd
@@ -4,11 +4,20 @@
 \alias{analyse_ThermochronometryData}
 \title{Analyse Thermochronometry Data}
 \usage{
-analyse_ThermochronometryData(object, plot = TRUE, verbose = TRUE, ...)
+analyse_ThermochronometryData(
+  object,
+  ITL_model = c("GOK", "BTS"),
+  plot = TRUE,
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{object}{\link{character} (\strong{required}): path to a CSV file with;
 alternatively a \link{vector} of paths}
+
+\item{ITL_model}{\link{character} (\emph{with default}): type of model to fit,
+either \code{"GOK"} or \code{"BTS"}}
 
 \item{plot}{\link{logical} (\emph{with default}): enable/disable plot output}
 

--- a/tests/testthat/test_analyse_ThermochronometryData.R
+++ b/tests/testthat/test_analyse_ThermochronometryData.R
@@ -1,3 +1,7 @@
+## load data
+input.csv <- file.path(test_path("_data"),
+                       paste0("CLBR_IR", c(50, 100, 150, 225), ".csv"))
+
 test_that("input validation", {
   testthat::skip_on_cran()
 
@@ -7,14 +11,15 @@ test_that("input validation", {
                "File does not exist")
   expect_error(analyse_ThermochronometryData(test_path("_data/CLBR.xlsx")),
                "XLS/XLSX format is not supported, use CSV instead")
+  expect_error(analyse_ThermochronometryData(input.csv[1], ITL_model = "error"),
+               "'ITL_model' should be one of 'GOK' or 'BTS'")
 })
 
 test_that("check functionality", {
   testthat::skip_on_cran()
 
-  input.csv <- file.path(test_path("_data"),
-                         paste0("CLBR_IR", c(50, 100, 150, 225), ".csv"))
-
   expect_s4_class(analyse_ThermochronometryData(input.csv[1]),
+                  "RLum.Results")
+  expect_s4_class(analyse_ThermochronometryData(input.csv[1], ITL_model = "BTS"),
                   "RLum.Results")
 })

--- a/tests/testthat/test_fit_IsoThermalHolding.R
+++ b/tests/testthat/test_fit_IsoThermalHolding.R
@@ -1,3 +1,6 @@
+input.csv <- file.path(test_path("_data"),
+                       paste0("CLBR_IR", c(50, 100, 150, 225), ".csv"))
+
 test_that("input validation", {
   testthat::skip_on_cran()
 
@@ -9,15 +12,14 @@ test_that("input validation", {
                "'data' has unsupported originator")
   expect_error(fit_IsoThermalHolding(iris),
                "'data' has the wrong column headers")
+  expect_error(fit_IsoThermalHolding(input.csv[1], ITL_model = "error"),
+               "'ITL_model' should be one of 'GOK' or 'BTS'")
   expect_error(fit_IsoThermalHolding(test_path("_data/CLBR.xlsx")),
                "XLS/XLSX format is not supported, use CSV instead")
 })
 
 test_that("check functionality", {
   testthat::skip_on_cran()
-
-  input.csv <- file.path(test_path("_data"),
-                         paste0("CLBR_IR", c(50, 100, 150, 225), ".csv"))
 
   expect_s4_class(fit_IsoThermalHolding(input.csv[1], rhop = -7),
                   "RLum.Results")


### PR DESCRIPTION
Before one could only run the `GOK` model from `analyse_ThermochronometryData()`.