### PR TITLE
Increase coverage in plot_RLum.Results.R

### DIFF
--- a/R/plot_RLum.Results.R
+++ b/R/plot_RLum.Results.R
@@ -117,7 +117,7 @@ plot_RLum.Results<- function(
   switch(object@originator,
       "analyse_SAR.CWOSL" = plot_AbanicoPlot(object),
       "analyse_pIRIRSequence" = plot_AbanicoPlot(object),
-      "analyse_IRSARRF" = plot_AbanicoPlot(object),
+      "analyse_IRSAR.RF" = plot_AbanicoPlot(object),
     NULL
     )
 
@@ -833,13 +833,8 @@ plot_RLum.Results<- function(
           # create legend labels
           dose.lab.legend<- paste("c", 1:n.components[length(n.components)], sep="")
 
-          if(max(n.components)>8) {
-            ncol.temp<- 8
-            yadj<- 1.025
-          } else {
-            ncol.temp<- max(n.components)
-            yadj<- 0.93
-          }
+          ncol.temp <- min(max(n.components), 8)
+          yadj <- if (max(n.components) > 8) 1.025 else 0.93
 
           # add legend
           if(i==n.plots) {

--- a/tests/testthat/test_plot_RLum.Results.R
+++ b/tests/testthat/test_plot_RLum.Results.R
@@ -1,3 +1,4 @@
+## load data
 data(ExampleData.DeValues, envir = environment())
 
 test_that("input validation", {
@@ -43,11 +44,15 @@ test_that("check functionality", {
   expect_silent(plot_RLum.Results(d4, pdf.colors = "colors"))
   expect_silent(plot_RLum.Results(d4, main = "Title", plot.proportions = FALSE,
                                   pdf.weight = FALSE, pdf.sigma = "sigmab"))
+  expect_silent(plot_RLum.Results(d4, main = "Title", plot.proportions = FALSE,
+                                  pdf.weight = TRUE, pdf.sigma = "se",
+                                  pdf.scale = 1))
 
   ## calc_AliquotSize
   d5 <- calc_AliquotSize(grain.size = c(100, 150), sample.diameter = 1,
                          MC.iter = 100, plot = FALSE, verbose = FALSE)
   expect_silent(plot_RLum.Results(d5))
+  expect_silent(plot_RLum.Results(d5, main = "MC simulation", xlab = "Grains"))
 
   ## calc_SourceDoseRate
   d6 <- calc_SourceDoseRate(measurement = "2012-01-27", calib = "2014-12-19",
@@ -58,6 +63,17 @@ test_that("check functionality", {
   data(ExampleData.CW_OSL_Curve, envir = environment())
   d7 <- calc_FastRatio(ExampleData.CW_OSL_Curve, plot = FALSE, verbose = FALSE)
   expect_silent(plot_RLum.Results(d7))
+  d7 <- calc_FastRatio(ExampleData.CW_OSL_Curve, dead.channels = c(1, 1),
+                       plot = FALSE, verbose = FALSE)
+  expect_silent(plot_RLum.Results(d7))
+
+  ## analyse_IRSAR.RF
+  data(ExampleData.RLum.Analysis, envir = environment())
+  d8 <- analyse_IRSAR.RF(IRSAR.RF.Data, method = "VSLIDE", n.MC = 10,
+                         plot = FALSE, txtProgressBar = FALSE)
+  SW({
+  expect_warning(plot_RLum.Results(d8))
+  })
 
   ## no valid originator
   expect_silent(plot_RLum.Results(set_RLum("RLum.Results",


### PR DESCRIPTION
This also fixes an error when plotting an object produced by `analyse_IRSAR.RF()` as it was matching a mistyped originator.