### PR TITLE
fit_IsothermalHolding(): define the models as functions rather than strings

### DIFF
--- a/tests/testthat/test_fit_IsothermalHolding.R
+++ b/tests/testthat/test_fit_IsothermalHolding.R
@@ -22,10 +22,10 @@ test_that("input validation", {
 test_that("check functionality", {
   testthat::skip_on_cran()
 
-  expect_s4_class(fit_IsothermalHolding(input.csv[1], rhop = -7),
+  expect_s4_class(fit_IsothermalHolding(input.csv[1], rhop = 1e-7),
                   "RLum.Results")
 
   data <- .import_ThermochronometryData(input.csv[1])
-  expect_s4_class(fit_IsothermalHolding(data, rhop = -7, mfrow = c(2, 2)),
+  expect_s4_class(fit_IsothermalHolding(data, rhop = 1e-7, mfrow = c(2, 2)),
                   "RLum.Results")
 })


### PR DESCRIPTION
This is necessary as the BTS model uses `integrate()`, and in order to retrieve its result one needs to extract `$value` from the object it returns. But this confuses `nlsLM()` into thinking that `value` is a parameter to be optimized and for which a starting point should be given.

The only workable solution seems to hide all that complexity into a wrapper function (`f_BTS)` that is used as right-hand side in the formula. Because of this, we need to reformulate also `f_GOK` as a function.

Due to R's abstruse way of accessing variables in the environment from inside a function, it turns out that we can access `rhop` but not `isoT`, so we have to add `isoT` to the model signatures and also to the `data` argument.

This commit also introduces some changes to the BTS model: in particular we now use `sapply()` inside `f_BTS()`, and also fix `DeltaE` to 1.5eV as suggested from the Li&Li paper. However, even with these changes the model doesn't fit, but reports this error:

>  singular gradient matrix at initial parameter estimates