### PR TITLE
Fix single page layout of SAR.CWOSL plots from analyse_pIRIRSequence()

### DIFF
--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -1233,7 +1233,7 @@ error.list <- list()
           list(
             sample = temp.sample,
             output.plot = plot,
-            plot_singlePanels = plot_onePage,
+            plot_singlePanels = plot_onePage || length(plot_singlePanels) > 1,
             cex.global = if(plot_onePage) .6 else 1
             ),
           list(...)


### PR DESCRIPTION
The interaction of the various plot options between `analyse_pIRIRSequence()`, `analyse_SAR.CWOSL()`, `plot_DoseResponseCurve()` is quite intricate. For example, the `plot_singlePanels` option is just a logical in `analyse_pIRIRSequence()` and `plot_DoseResponseCurve()`, but can accept integer values in `analyse_SAR.CWOSL()`. The latter also has a `plot_onePage` option which is largely overlapping (but not totally) with `plot_singlePanels`.

In any case, from my testing this PR fixes the problem without regressing `analyse_SAR.CWOSL()`. No NEWS as the regression occurred on the development version.

Fixes #572.