### PR TITLE
Fix regression in plot generated by analyse_FadingMeasurement()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -23,6 +23,11 @@ header-includes:
 contains irradiation steps and returns an error if none are available,
 instead of producing an unhelpful output (#588).
 
+### `analyse_FadingMeasurement()`
+
+* A regression in `plot_RLum.Analysis()` caused part of the plot of the
+luminescence curves to be messed up (#589).
+
 ### `calc_FastRatio()`
 
 * The function crashed if the input was an RLum.Analysis object (#586).
@@ -31,3 +36,9 @@ instead of producing an unhelpful output (#588).
 
 * The `xlim`, `ylim` and `zlim` parameters are now better validated to avoid
 possible crashes if misspecified (#581).
+
+### `plot_RLum.Analysis()`
+
+* The function reset incorrectly the graphical parameters for the case
+`plot_singlePanels = TRUE`. This caused a regression in the plot output
+from `analyse_FadingMeasurement()` (#589).

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
   contains irradiation steps and returns an error if none are available,
   instead of producing an unhelpful output (#588).
 
+### `analyse_FadingMeasurement()`
+
+- A regression in `plot_RLum.Analysis()` caused part of the plot of the
+  luminescence curves to be messed up (#589).
+
 ### `calc_FastRatio()`
 
 - The function crashed if the input was an RLum.Analysis object (#586).
@@ -29,3 +34,9 @@
 
 - The `xlim`, `ylim` and `zlim` parameters are now better validated to
   avoid possible crashes if misspecified (#581).
+
+### `plot_RLum.Analysis()`
+
+- The function reset incorrectly the graphical parameters for the case
+  `plot_singlePanels = TRUE`. This caused a regression in the plot
+  output from `analyse_FadingMeasurement()` (#589).

--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -427,11 +427,13 @@ plot_RLum.Analysis <- function(
     temp.recordType <- as.character(unique(temp.object.structure$recordType))
 
     ##change graphic settings
-    par.default <- par()[c("cex", "mfrow")]
     if (!plot_singlePanels) {
+      par.default <- par()[c("cex", "mfrow")]
       if(!missing(ncols) & !missing(nrows)){
         par(mfrow = c(nrows, ncols))
       }
+    } else {
+      par.default <- par()["cex"]
     }
     ## this 2nd par request is needed as setting mfrow resets the par
     ## settings ... this might not be wanted


### PR DESCRIPTION
The issue seems to be that setting `mfrow` resets the `par` settings (as the pre-existing comment stated) even in the case when `mfrow` is not actually changed. Therefore, we cannot have a shared par.default for the two cases of `plot_singlePanels`, but each must define its own.

This fixes a regression introduced in 9f5a918. Fixes #589.