### PR TITLE
Tighten checks on inputs and consolidate code in calc_CosmicDoseRate()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -39,6 +39,11 @@ triggered by the floating point values computed by `grDevices::dev.size()`,
 which sometimes could be spuriously just below threshold. We also changed
 the minimum device size from 18 to 16 inches (#593).
 
+### `calc_CosmicDoseRate()`
+
+* The function crashed if the number of depths provided exceeded that of the
+densities and the latter contained more than one value (#595).
+
 ### `calc_FastRatio()`
 
 * The function crashed if the input was an RLum.Analysis object (#586).

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,11 @@
   below threshold. We also changed the minimum device size from 18 to 16
   inches (#593).
 
+### `calc_CosmicDoseRate()`
+
+- The function crashed if the number of depths provided exceeded that of
+  the densities and the latter contained more than one value (#595).
+
 ### `calc_FastRatio()`
 
 - The function crashed if the input was an RLum.Analysis object (#586).

--- a/R/calc_CosmicDoseRate.R
+++ b/R/calc_CosmicDoseRate.R
@@ -276,9 +276,9 @@ calc_CosmicDoseRate<- function(
     }
   }
 
-  if(length(density) > length(depth)) {
-    .throw_error("If you provide more than one value for density, please ",
-                 "provide an equal number of values for depth")
+  if (length(depth) < length(density)) {
+    .throw_error("The number of values for 'density' should either be 1 ",
+                 "or correspond to the number of values for 'depth'")
   }
 
   settings <- list(verbose = TRUE)

--- a/R/calc_CosmicDoseRate.R
+++ b/R/calc_CosmicDoseRate.R
@@ -309,19 +309,10 @@ calc_CosmicDoseRate<- function(
 
   profile.mode<- FALSE
 
-  #calculate absorber (hgcm) of one depth and one absorber [single sample]
-  if(length(depth)==1) {
-    hgcm<- depth*density
-    if(half.depth == TRUE) {
-      hgcm<- hgcm/2
-    }
-  }
-
-  #calculate total absorber of n depths and n densities [single sample]
+  ## calculate total absorber of n depths and n densities [single sample]
+  ## the calculation is still valid if there is only one depth and one density
   if(length(depth)==length(density)){
-
     hgcm<- 0
-
     for(i in 1:length(depth)) {
       hgcm<- hgcm + depth[i]*density[i]
     }

--- a/R/calc_CosmicDoseRate.R
+++ b/R/calc_CosmicDoseRate.R
@@ -159,7 +159,7 @@
 #' function at the time of writing.
 #'
 #'
-#' @section Function version: 0.5.2
+#' @section Function version: 0.5.3
 #'
 #' @author
 #' Christoph Burow, University of Cologne (Germany)
@@ -276,7 +276,8 @@ calc_CosmicDoseRate<- function(
     }
   }
 
-  if (length(depth) < length(density)) {
+  if (length(depth) < length(density) ||
+      (length(depth) > length(density) && length(density) > 1)) {
     .throw_error("The number of values for 'density' should either be 1 ",
                  "or correspond to the number of values for 'depth'")
   }

--- a/R/calc_CosmicDoseRate.R
+++ b/R/calc_CosmicDoseRate.R
@@ -255,10 +255,15 @@ calc_CosmicDoseRate<- function(
   ## Integrity checks -------------------------------------------------------
 
   .validate_class(depth, "numeric")
+  .validate_not_empty(depth)
   .validate_class(density, "numeric")
+  .validate_not_empty(density)
   .validate_class(latitude, "numeric")
+  .validate_not_empty(latitude)
   .validate_class(longitude, "numeric")
+  .validate_not_empty(longitude)
   .validate_class(altitude, "numeric")
+  .validate_not_empty(altitude)
 
   if(any(depth < 0) || any(density < 0)) {
     .throw_error("No negative values allowed for 'depth' and 'density'")

--- a/tests/testthat/test_calc_CosmicDoseRate.R
+++ b/tests/testthat/test_calc_CosmicDoseRate.R
@@ -23,6 +23,11 @@ test_that("input validation", {
                                    latitude = 38.06451, longitude = 1.49646,
                                    altitude = 364),
                "The number of values for 'density' should either be 1 or")
+  expect_error(calc_CosmicDoseRate(depth = rep(2.78, 3), density = c(1.7, 2.9),
+                                   latitude = 38.06451, longitude = 1.49646,
+                                   altitude = 364),
+               "The number of values for 'density' should either be 1 or")
+
   expect_output(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
                                     corr.fieldChanges = TRUE, est.age = 100,
                                     latitude = 38.0645, longitude = 1.4964,

--- a/tests/testthat/test_calc_CosmicDoseRate.R
+++ b/tests/testthat/test_calc_CosmicDoseRate.R
@@ -22,7 +22,7 @@ test_that("input validation", {
                                    corr.fieldChanges = TRUE, est.age = 20,
                                    latitude = 38.06451, longitude = 1.49646,
                                    altitude = 364),
-               "If you provide more than one value for density")
+               "The number of values for 'density' should either be 1 or")
   expect_output(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
                                     corr.fieldChanges = TRUE, est.age = 100,
                                     latitude = 38.0645, longitude = 1.4964,

--- a/tests/testthat/test_calc_CosmicDoseRate.R
+++ b/tests/testthat/test_calc_CosmicDoseRate.R
@@ -3,21 +3,34 @@ test_that("input validation", {
 
   expect_error(calc_CosmicDoseRate(depth = "error"),
                "'depth' should be of class 'numeric'")
+  expect_error(calc_CosmicDoseRate(depth = numeric(0), density = 1.7,
+                                   latitude = 38.1, longitude = 1.4),
+               "'depth' cannot be an empty numeric")
   expect_error(calc_CosmicDoseRate(depth = -2, density = 1.7, altitude = 364,
                                    latitude = 38.1, longitude = 1.4),
                "No negative values allowed for 'depth' and 'density'")
+  expect_error(calc_CosmicDoseRate(depth = 10, density = "error"),
+               "'density' should be of class 'numeric'")
+  expect_error(calc_CosmicDoseRate(depth = 10, density = numeric(0),
+                                   latitude = 38.1, longitude = 1.4),
+               "'density' cannot be an empty numeric")
   expect_error(calc_CosmicDoseRate(depth = 2.78, density = 1.7, altitude = 364,
                                    latitude = 38.1, longitude = 1.4,
                                    corr.fieldChanges = TRUE),
                "requires an age estimate")
   expect_error(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
-                                   corr.fieldChanges = TRUE, est.age = 20,
                                    latitude = 38.06451),
                "'longitude' should be of class 'numeric'")
   expect_error(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
-                                   corr.fieldChanges = TRUE, est.age = 20,
+                                   latitude = 38.1, longitude = numeric(0)),
+               "'longitude' cannot be an empty numeric")
+  expect_error(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
                                    latitude = 38.06451, longitude = 1.49646),
                "'altitude' should be of class 'numeric'")
+  expect_error(calc_CosmicDoseRate(depth = 2.78, density = 1.7,
+                                   latitude = 38.06451, longitude = 1.49646,
+                                   altitude = numeric(0)),
+               "'altitude' cannot be an empty numeric")
   expect_error(calc_CosmicDoseRate(depth = 2.78, density = c(1.7, 2.9),
                                    corr.fieldChanges = TRUE, est.age = 20,
                                    latitude = 38.06451, longitude = 1.49646,


### PR DESCRIPTION
This fixes #595 and adds some more validation of inputs to cover other corner cases.

The code for the case in which `length(depth) == 1` can be removed because after validation it must be that also `length(density) == 1`: note that the computation done in that block is undone and then recomputed in the second block, as it's also true that `length(depth) == length(density)`. So we may as well just use the code in the second block in both cases.