### PR TITLE
Don't crash when sorting an empty RLum.Analysis object

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -81,3 +81,6 @@ from `analyse_FadingMeasurement()` (#589).
 
 * The function doesn't crash when multiple fields are specified, although
 the actual sort at the moment occurs only on the first field (#606).
+
+* Attempting to sort an empty object returns the object itself instead of
+crashing (#608).

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,3 +75,6 @@
 - The function doesn’t crash when multiple fields are specified,
   although the actual sort at the moment occurs only on the first field
   (#606).
+
+- Attempting to sort an empty object returns the object itself instead
+  of crashing (#608).

--- a/R/RLum.Analysis-class.R
+++ b/R/RLum.Analysis-class.R
@@ -895,6 +895,10 @@ setMethod(
     .set_function_name("sort_RLum")
     on.exit(.unset_function_name(), add = TRUE)
 
+    ## an empty object has nothing to sort
+    if (length(object) == 0)
+      return(object)
+
     ## input validation
     sort.by.slot <- FALSE
     if (!is.null(slot)) {

--- a/tests/testthat/test_RLum.Analysis-class.R
+++ b/tests/testthat/test_RLum.Analysis-class.R
@@ -158,6 +158,10 @@ test_that("sort_RLum", {
   ## check functionality
   expect_snapshot_RLum(sort_RLum(sar, slot = "recordType"))
   expect_snapshot_RLum(sort_RLum(sar, info_element = "curveDescripter"))
+
+  empty <- as(list(), "RLum.Analysis")
+  expect_equal(sort_RLum(empty, slot = "curveType"),
+               empty)
 })
 
 test_that("structure_RLum", {


### PR DESCRIPTION
Fix #608.