### PR TITLE
Disable the windows-latest devel workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -28,7 +28,6 @@ jobs:
         config:
           - {os: windows-latest, r: 'oldrel', not_cran: 'true'}
           - {os: windows-latest, r: 'release', not_cran: 'true'}
-          - {os: windows-latest, r: 'devel', not_cran: 'true'}
           - {os: macos-13,   r: 'release', not_cran: 'true'}
           - {os: macos-13,   r: 'oldrel', not_cran: 'true'}
           - {os: ubuntu-latest,   r: 'devel', not_cran: 'true'}


### PR DESCRIPTION
This workflow at the moment never completes. This is caused by `devel` now pointing to R 4.6, and this leads to try to read some inexistent path from the package repository:

   https://cran.rstudio.com/bin/windows/contrib/4.6/PACKAGES.gz

We should reenable it when the link above starts working, presumably early next week.