### PR TITLE
Recover a few lines of lost coverage

### DIFF
--- a/R/analyse_FadingMeasurement.R
+++ b/R/analyse_FadingMeasurement.R
@@ -861,9 +861,11 @@ analyse_FadingMeasurement <- function(
     if (3 %in% plot_singlePanels) {
 
       if(all(is.na(LxTx_table[["LxTx_NORM"]]))){
+        ## FIXME(mcol): this block seems unreachable since 5f63c1f1
+        # nocov start
           shape::emptyplot()
           text(x = .5, y = .5, labels = "All NA values!")
-
+        # nocov end
       }else{
         plot(
           NA,

--- a/tests/testthat/test_plot_RLum.R
+++ b/tests/testthat/test_plot_RLum.R
@@ -21,7 +21,8 @@ test_that("check functionality", {
       set_RLum("RLum.Data.Curve", data = matrix(1:10, ncol = 2)),
       set_RLum("RLum.Data.Curve", data = matrix(1:20, ncol = 2)))))
 
-  expect_silent(plot_RLum(l, main = list("test", "test2"), mtext = "test"))
+  expect_silent(plot_RLum(l, main = list("test", "test2"), mtext = "test",
+                          subset = NA))
 
   ## empty object
   expect_silent(plot_RLum(set_RLum("RLum.Analysis")))
@@ -39,5 +40,5 @@ test_that("check functionality", {
     background.integral.min = 900,
     background.integral.max = 1000,
     fit.method = "LIN")
-  expect_null(plot_RLum.Results(results))
+  expect_null(plot_RLum(results))
 })

--- a/tests/testthat/test_plot_RLum.Results.R
+++ b/tests/testthat/test_plot_RLum.Results.R
@@ -45,6 +45,7 @@ test_that("check functionality", {
   expect_silent(plot_RLum.Results(d4, main = "Title", plot.proportions = FALSE,
                                   pdf.weight = FALSE, pdf.sigma = "sigmab"))
   expect_silent(plot_RLum.Results(d4, main = "Title", plot.proportions = FALSE,
+                                  dose.scale = c(0, 100),
                                   pdf.weight = TRUE, pdf.sigma = "se",
                                   pdf.scale = 1))
 


### PR DESCRIPTION
The changes in #637 have actually lost 2 lines of coverage. The changes in #617 caused 2 other lines not to be covered anymore, and I could not find a way to reach them: I suppose that the early returns added in that PR have made this block of code as unreachable, so I've marked it as `nocov`.
