### PR TITLE
Remove redundant tests

### DIFF
--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -76,17 +76,10 @@ test_that("Test examples from the example page", {
                                  xlim = NULL, ylim = NULL, zlim = NULL,
                                  log.z = FALSE))
 
-  ## now with output of the plot parameters
-  expect_type(plot_AbanicoPlot(data = ExampleData.DeValues,
-                            output = TRUE), "list")
-
-  ## now with adjusted z-scale limits
+  ## now with adjusted scale limits
   expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
-                   zlim = c(10, 200)))
-
-  ## now with adjusted x-scale limits
-  expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
-                   xlim = c(0, 20)))
+                                 zlim = c(10, 200),
+                                 xlim = c(0, 20)))
 
   ## now with rug to indicate individual values in KDE part
   expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
@@ -169,10 +162,6 @@ test_that("Test examples from the example page", {
   ## now with minimum, maximum and median value indicated
   expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
                    stats = c("min", "max", "median")))
-
-  ## now with a brief statistical summary as subheader
-  expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,
-                   summary = c("n", "in.2s")))
 
   ## now with another statistical summary
   expect_silent(plot_AbanicoPlot(data = ExampleData.DeValues,

--- a/tests/testthat/test_plot_DRTResults.R
+++ b/tests/testthat/test_plot_DRTResults.R
@@ -45,8 +45,6 @@ test_that("check functionality", {
   expect_silent(plot_DRTResults(df, preheat = c(200, 200, 200, 240, 240),
                                 boxplot = FALSE, given.dose = 2800))
   expect_silent(plot_DRTResults(df, preheat = c(200, 200, 200, 240, 240),
-                                boxplot = TRUE, given.dose = 2800))
-  expect_silent(plot_DRTResults(df, preheat = c(200, 200, 200, 240, 240),
                                 boxplot = TRUE, given.dose = 2800,
                                 summary = "mean", summary.pos = "sub"))
   expect_silent(plot_DRTResults(df.list, given.dose = c(2800, 2900)))
@@ -69,24 +67,7 @@ test_that("check functionality", {
   expect_silent(plot_DRTResults(df, summary = "n", summary.pos = "sub"))
   expect_silent(plot_DRTResults(df, summary.pos = "top",
                                 legend.pos = "bottom"))
-  expect_silent(plot_DRTResults(df, summary.pos = "topright",
-                                legend.pos = "topleft"))
-  expect_silent(plot_DRTResults(df, summary.pos = "left",
-                                legend.pos = "right"))
-  expect_silent(plot_DRTResults(df, summary.pos = "center",
-                                legend.pos = "center"))
-  expect_silent(plot_DRTResults(df, summary.pos = "right",
-                                legend.pos = "left"))
-  expect_silent(plot_DRTResults(df, summary.pos = "bottomleft",
-                                legend.pos = "bottomright"))
-  expect_silent(plot_DRTResults(df, summary.pos = "bottom",
-                                legend.pos = "top"))
-  expect_silent(plot_DRTResults(df, summary.pos = "bottomright",
-                                legend.pos = "bottomleft"))
   expect_silent(plot_DRTResults(df, preheat = 1:5, na.rm = TRUE))
-
-  ## plot_DRTResults(df.list, preheat = c(200, 200, 200, 240, 240),
-  ##                 given.dose = 2800, boxplot = TRUE)
 
   ## RLum.Results object
   expect_silent(plot_DRTResults(calc_CommonDose(df, plot = FALSE,

--- a/tests/testthat/test_plot_Histogram.R
+++ b/tests/testthat/test_plot_Histogram.R
@@ -39,15 +39,7 @@ test_that("check functionality", {
                                summary.pos = c(20, 0.017),
                                summary = c("n", "mean", "mean.weighted",
                                            "median", "sdrel")))
-  expect_silent(plot_Histogram(df, summary.pos = "topleft"))
-  expect_silent(plot_Histogram(df, summary.pos = "top"))
-  expect_silent(plot_Histogram(df, summary.pos = "topright"))
-  expect_silent(plot_Histogram(df, summary.pos = "left"))
-  expect_silent(plot_Histogram(df, summary.pos = "center"))
-  expect_silent(plot_Histogram(df, summary.pos = "right"))
-  expect_silent(plot_Histogram(df, summary.pos = "bottomleft"))
   expect_silent(plot_Histogram(df, summary.pos = "bottom"))
-  expect_silent(plot_Histogram(df, summary.pos = "bottomright"))
 
   ## interactive
   expect_silent(plot_Histogram(df, interactive = TRUE,

--- a/tests/testthat/test_plot_KDE.R
+++ b/tests/testthat/test_plot_KDE.R
@@ -43,15 +43,7 @@ test_that("check functionality", {
                          xlab = "x", ylab = "y", layout = "default", log = "x",
                          xlim = c(100, 180), ylim = c(0, 0.07, 0, 0.01),
                          col = 2, lty = 2, lwd = 2, cex = 1))
-  expect_silent(plot_KDE(data = df, summary.pos = "topleft"))
-  expect_silent(plot_KDE(data = df, summary.pos = "top"))
-  expect_silent(plot_KDE(data = df, summary.pos = "topright"))
-  expect_silent(plot_KDE(data = df, summary.pos = "left"))
-  expect_silent(plot_KDE(data = df, summary.pos = "center"))
-  expect_silent(plot_KDE(data = df, summary.pos = "right"))
-  expect_silent(plot_KDE(data = df, summary.pos = "bottomleft"))
-  expect_silent(plot_KDE(data = df, summary.pos = "bottom"))
-  expect_silent(plot_KDE(data = df, summary.pos = "bottomright"))
+  expect_silent(plot_KDE(data = df, summary = "mean", summary.pos = "right"))
   expect_silent(plot_KDE(data = df, sub = "test"))
 
   ## specify layout

--- a/tests/testthat/test_plot_RadialPlot.R
+++ b/tests/testthat/test_plot_RadialPlot.R
@@ -116,20 +116,6 @@ test_that("check functionality", {
                   log.z = FALSE, rug = TRUE)
   plot_RadialPlot(df, show = FALSE, centrality = "median.weighted",
                   summary.pos = "top", legend.pos = "bottom")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "topright", legend.pos = "topleft")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "left", legend.pos = "right")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "center", legend.pos = "center")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "right", legend.pos = "left")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "bottomleft", legend.pos = "bottomright")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "bottom", legend.pos = "top")
-  plot_RadialPlot(df, show = FALSE,
-                  summary.pos = "bottomright", legend.pos = "bottomleft")
 
   ## RLum.Results object
   expect_silent(plot_RadialPlot(calc_CommonDose(ExampleData.DeValues$BT998,


### PR DESCRIPTION
This should speed up a bit the total time for running tests without losing any coverage. Many of these had to do with adding coverage for the various positioning of the summary boxes, but with the code consolidation done in #291 they are no longer necessary.