### PR TITLE
Set the originator in calc_AliquotSize() and calc_FiniteMixture()

### DIFF
--- a/R/calc_AliquotSize.R
+++ b/R/calc_AliquotSize.R
@@ -68,7 +68,7 @@
 #' diameter (mm) of the targeted area on the sample carrier.
 #'
 #' @param packing.density [numeric] (*with default*):
-#' empirical value for mean packing density. \cr
+#' empirical value for the mean packing density. \cr
 #' If `packing.density = Inf`, a hexagonal structure on an infinite
 #' plane with a packing density of \eqn{\pi / \sqrt{12} \approx 0.9069}
 #' is assumed.
@@ -368,6 +368,7 @@ calc_AliquotSize <- function(
   # create S4 object
   newRLumResults.calc_AliquotSize <- set_RLum(
     class = "RLum.Results",
+    originator = "calc_AliquotSize",
     data = list(
       summary=summary,
       MC=list(estimates=MC.n,

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -565,6 +565,7 @@ calc_FiniteMixture <- function(
   # create S4 object
   newRLumResults.calc_FiniteMixture <- set_RLum(
     class = "RLum.Results",
+    originator = "calc_FiniteMixture",
     data = list(
       summary=summary,
       data=data,

--- a/man/calc_AliquotSize.Rd
+++ b/man/calc_AliquotSize.Rd
@@ -24,7 +24,7 @@ mean grain size is computed (e.g. \code{c(100,200)}).}
 diameter (mm) of the targeted area on the sample carrier.}
 
 \item{packing.density}{\link{numeric} (\emph{with default}):
-empirical value for mean packing density. \cr
+empirical value for the mean packing density. \cr
 If \code{packing.density = Inf}, a hexagonal structure on an infinite
 plane with a packing density of \eqn{\pi / \sqrt{12} \approx 0.9069}
 is assumed.}


### PR DESCRIPTION
This allows supporting those functions in RLumShiny, as otherwise the calls to `plot_RLum.Results()` fail. Fixes #669.