### PR TITLE
Make the plot_singlePanels argument of scale_GammaDose() work as expected

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -194,6 +194,11 @@ This enhancement ensures that all available arguments are fully supported (#646)
 
 * The function gained a new logical argument named `auto_scale`. When set in conjunction with either `xlim` or `ylim`, this argument automatically adjusts the plot range to align with the corresponding settings for `xlim` or `ylim`. For instance, if a user intends to plot OSL curves but initially selects the `xlim` range `c(10:30)` to examine the background, the initial count values may be excessively large, resulting in limited visibility. With the introduction of the `auto_scale` option, the `ylim` values are automatically adjusted to compensate for this scenario. The `auto_scale` argument is also accessible through `plot_RLum.Analysis()` and `plot_RLum()` (#646).
 
+### `scale_GammaDose()`
+
+* Argument `plot_singlePanels` now works as documented, that is it produces
+all plots in a single page when set to `FALSE` (default), and one plot per
+page when set to `TRUE` (#698).
 
 ### `sort_RLum()`
 * The sorting mechanism for `RLum.Analysis-class` objects has been enhanced. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -224,6 +224,12 @@
   compensate for this scenario. The `auto_scale` argument is also
   accessible through `plot_RLum.Analysis()` and `plot_RLum()` (#646).
 
+### `scale_GammaDose()`
+
+- Argument `plot_singlePanels` now works as documented, that is it
+  produces all plots in a single page when set to `FALSE` (default), and
+  one plot per page when set to `TRUE` (#698).
+
 ### `sort_RLum()`
 
 - The sorting mechanism for `RLum.Analysis-class` objects has been

--- a/R/scale_GammaDose.R
+++ b/R/scale_GammaDose.R
@@ -181,7 +181,7 @@
 #' - A barplot visualising the contribution of each layer to the total dose rate
 #' received by the sample in the target layer.
 #'
-#' @section Function version: 0.1.3
+#' @section Function version: 0.1.4
 #'
 #' @keywords datagen
 #'
@@ -321,11 +321,11 @@ scale_GammaDose <- function(
                 valid_conversion_factors))
   conversion_factors <- .validate_args(conversion_factors,
                                        valid_conversion_factors)
-
-  ## fractional gamma dose
   fractional_gamma_dose <- .validate_args(fractional_gamma_dose,
                                           names(BaseDataSet.FractionalGammaDose))
-
+  .validate_logical_scalar(verbose)
+  .validate_logical_scalar(plot)
+  .validate_logical_scalar(plot_singlePanels)
 
   ## ------------------------------------------------------------------------ ##
   ## Select tables
@@ -539,7 +539,7 @@ scale_GammaDose <- function(
     par.old <- par(no.readonly = TRUE)
     on.exit(par(par.old), add = TRUE)
 
-    if (plot_singlePanels)
+    if (!plot_singlePanels)
       layout(matrix(c(1,1, 2, 3, 4, 5,
                       1,1, 2, 3, 4, 5,
                       1,1, 6, 6, 6, 6,
@@ -549,13 +549,10 @@ scale_GammaDose <- function(
     ## --------------------------------------------------------------
 
     ## Global plot settings
-    if (plot_singlePanels)
-      par(mar = c(2, 5, 1, 4) + 0.1)
-    else
-      par(mar = c(2, 5, 4, 4) + 0.1)
+    par(mar = c(2, 5, ifelse(plot_singlePanels, 4, 1), 4) + 0.1)
 
     plot(NA, NA,
-         main = ifelse(plot_singlePanels, "", "Profile structure"),
+         main = ifelse(plot_singlePanels, "Profile structure", ""),
          xlim = c(0, 1),
          ylim = rev(range(pretty(c(sum(data$thickness), 0)))),
          xaxt = "n",
@@ -582,7 +579,7 @@ scale_GammaDose <- function(
     # right y-axis labels
     mtext(side = 4, at = c(0, cumsum(data$thickness) - data$thickness / 2, sum(data$thickness)),
           text = c("", paste(data$thickness, "cm"), ""), las = 1,
-          line = ifelse(plot_singlePanels, -4, 0.5),
+          line = ifelse(plot_singlePanels, 0.5, -4),
           cex = 0.8,
           col = "#b22222")
 
@@ -602,7 +599,7 @@ scale_GammaDose <- function(
     ## --------------------------------------------------------------
 
     # global plot settings
-    if (plot_singlePanels) {
+    if (!plot_singlePanels) {
       par(
         mar = c(4, 2, 3, 0.5) + 0.1,
         cex = 0.6,
@@ -665,7 +662,7 @@ scale_GammaDose <- function(
 
     ## Global plot settings
     # recover standard plot settings first
-    if (plot_singlePanels) {
+    if (!plot_singlePanels) {
       par(mar = c(5, 5, 1, 6) + 0.1,
           cex = 0.7)
     } else {
@@ -681,16 +678,16 @@ scale_GammaDose <- function(
     ## Contributions of each layer
     bp <- graphics::barplot(height = op$contrib[(nrow(op)-1):1],
                   horiz = TRUE,
-                  main = ifelse(plot_singlePanels, "", settings$main),
+                  main = ifelse(plot_singlePanels, settings$main, ""),
                   xlab = settings$xlab,
                   xlim = range(pretty(op$contrib[1:(nrow(op)-1)])),
                   col = cols[pos])
 
     # layer names
     mtext(side = 2, at = bp,
-          line = ifelse(plot_singlePanels, 3.5, 3),
+          line = ifelse(plot_singlePanels, 3, 3.5),
           las = 1,
-          cex = ifelse(plot_singlePanels, 0.7, 0.8),
+          cex = ifelse(plot_singlePanels, 0.8, 0.7),
           text = rev(data$id))
 
     # contribution percentage
@@ -710,8 +707,8 @@ scale_GammaDose <- function(
           at = min(bp) - diff(bp)[1] / 2,
           text = paste("=", f(op$sum[nrow(op)]), "Gy/ka"),
           col = "#b22222", las = 1,
-          line = ifelse(plot_singlePanels, -0.5, -1),
-          cex = ifelse(plot_singlePanels, 0.7, 0.8))
+          line = ifelse(plot_singlePanels, -1, -0.5),
+          cex = ifelse(plot_singlePanels, 0.8, 0.7))
 
     # recover old plot parameters
     par(par.old)

--- a/man/scale_GammaDose.Rd
+++ b/man/scale_GammaDose.Rd
@@ -208,7 +208,7 @@ density and water content is not constant for the entire section.
 \strong{cross-checked.}
 }
 \section{Function version}{
- 0.1.3
+ 0.1.4
 }
 
 \section{Acknowledgements}{

--- a/tests/testthat/_snaps/scale_GammaDose/defaults.svg
+++ b/tests/testthat/_snaps/scale_GammaDose/defaults.svg
@@ -1,0 +1,514 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='48.47' y1='30.66' x2='48.47' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='30.66' x2='43.72' y2='30.66' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='114.86' x2='43.72' y2='114.86' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='199.05' x2='43.72' y2='199.05' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='283.25' x2='43.72' y2='283.25' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='367.44' x2='43.72' y2='367.44' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='451.64' x2='43.72' y2='451.64' style='stroke-width: 0.75;' />
+<line x1='48.47' y1='535.83' x2='43.72' y2='535.83' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,535.83) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text transform='translate(37.07,451.64) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(37.07,367.44) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text transform='translate(37.07,283.25) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text transform='translate(37.07,199.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text transform='translate(37.07,114.86) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(37.07,30.66) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHwyNDAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.000000000000040' y='0.00' width='240.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHwyNDAuMDB8MC4wMHw1NzYuMDA=)'>
+<text transform='translate(18.06,283.25) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='158.05px' lengthAdjust='spacingAndGlyphs'>Depth below surface of uppermost layer (cm)</text>
+<text x='124.75' y='563.64' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='80.12px' lengthAdjust='spacingAndGlyphs'>Horizontal extent (a.u.)</text>
+</g>
+<defs>
+  <clipPath id='cpNDguNDd8MjAxLjAzfDEwLjQ1fDU1Ni4wNA=='>
+    <rect x='48.47' y='10.45' width='152.56' height='545.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDguNDd8MjAxLjAzfDEwLjQ1fDU1Ni4wNA==)'>
+<line x1='48.47' y1='30.66' x2='201.03' y2='30.66' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='114.86' x2='201.03' y2='114.86' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='156.95' x2='201.03' y2='156.95' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='207.47' x2='201.03' y2='207.47' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='228.52' x2='201.03' y2='228.52' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='270.62' x2='201.03' y2='270.62' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='312.72' x2='201.03' y2='312.72' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='333.77' x2='201.03' y2='333.77' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='354.81' x2='201.03' y2='354.81' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='481.11' x2='201.03' y2='481.11' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+<line x1='48.47' y1='481.11' x2='201.03' y2='481.11' style='stroke-width: 0.75; stroke: #7F7F7F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='95.99' y='74.62' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>E_upper</text>
+<text x='95.99' y='137.76' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='34.53px' lengthAdjust='spacingAndGlyphs'>D_upper</text>
+<text x='95.99' y='184.07' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='34.53px' lengthAdjust='spacingAndGlyphs'>C_upper</text>
+<text x='95.99' y='219.85' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>B_upper</text>
+<text x='95.99' y='251.43' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='95.99' y='293.53' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='32.52px' lengthAdjust='spacingAndGlyphs'>B_lower</text>
+<text x='95.99' y='325.10' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='33.02px' lengthAdjust='spacingAndGlyphs'>C_lower</text>
+<text x='95.99' y='346.15' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='33.02px' lengthAdjust='spacingAndGlyphs'>D_lower</text>
+<text x='95.99' y='419.82' text-anchor='end' style='font-size: 9.00px; fill: #428BCA; font-family: sans;' textLength='32.52px' lengthAdjust='spacingAndGlyphs'>E_lower</text>
+<line x1='201.03' y1='30.66' x2='201.03' y2='481.11' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='30.66' x2='202.56' y2='30.66' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='114.86' x2='202.56' y2='114.86' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='156.95' x2='202.56' y2='156.95' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='207.47' x2='202.56' y2='207.47' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='228.52' x2='202.56' y2='228.52' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='270.62' x2='202.56' y2='270.62' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='312.72' x2='202.56' y2='312.72' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='333.77' x2='202.56' y2='333.77' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='354.81' x2='202.56' y2='354.81' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='481.11' x2='202.56' y2='481.11' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='481.11' x2='202.56' y2='481.11' style='stroke-width: 0.75;' />
+<text x='163.02' y='76.06' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>20 cm</text>
+<text x='163.02' y='139.21' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>10 cm</text>
+<text x='163.02' y='185.52' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>12 cm</text>
+<text x='163.02' y='221.30' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='20.81px' lengthAdjust='spacingAndGlyphs'>5 cm</text>
+<text x='163.02' y='252.87' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>10 cm</text>
+<text x='163.02' y='294.97' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>10 cm</text>
+<text x='163.02' y='326.54' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='20.81px' lengthAdjust='spacingAndGlyphs'>5 cm</text>
+<text x='163.02' y='347.59' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='20.81px' lengthAdjust='spacingAndGlyphs'>5 cm</text>
+<text x='163.02' y='421.26' style='font-size: 9.60px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>30 cm</text>
+</g>
+<g clip-path='url(#cpNDguNDd8MjAxLjAzfDEwLjQ1fDU1Ni4wNA==)'>
+<line x1='56.23' y1='481.11' x2='48.47' y2='488.87' style='stroke-width: 0.75;' />
+<line x1='66.41' y1='481.11' x2='48.47' y2='499.05' style='stroke-width: 0.75;' />
+<line x1='76.59' y1='481.11' x2='48.47' y2='509.23' style='stroke-width: 0.75;' />
+<line x1='86.78' y1='481.11' x2='48.47' y2='519.41' style='stroke-width: 0.75;' />
+<line x1='96.96' y1='481.11' x2='48.47' y2='529.60' style='stroke-width: 0.75;' />
+<line x1='107.14' y1='481.11' x2='52.41' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='117.32' y1='481.11' x2='62.60' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='127.51' y1='481.11' x2='72.78' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='137.69' y1='481.11' x2='82.96' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='147.87' y1='481.11' x2='93.14' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='158.05' y1='481.11' x2='103.33' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='168.24' y1='481.11' x2='113.51' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='178.42' y1='481.11' x2='123.69' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='188.60' y1='481.11' x2='133.87' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='198.78' y1='481.11' x2='144.05' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='489.04' x2='154.24' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='499.22' x2='164.42' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='509.40' x2='174.60' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='519.59' x2='184.78' y2='535.83' style='stroke-width: 0.75;' />
+<line x1='201.03' y1='529.77' x2='194.97' y2='535.83' style='stroke-width: 0.75;' />
+<polygon points='48.47,481.11 201.03,481.11 201.03,535.83 48.47,535.83 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='124.75' cy='249.57' r='5.35' style='stroke-width: 1.50; stroke: #B22222;' />
+<line x1='119.41' y1='254.92' x2='130.10' y2='244.22' style='stroke-width: 1.50; stroke: #B22222;' />
+<line x1='119.41' y1='244.22' x2='130.10' y2='254.92' style='stroke-width: 1.50; stroke: #B22222;' />
+</g>
+<defs>
+  <clipPath id='cpMjU4LjE0fDM1NC44MnwyNi43OHwyNTIuNTg='>
+    <rect x='258.14' y='26.78' width='96.67' height='225.79' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjU4LjE0fDM1NC44MnwyNi43OHwyNTIuNTg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='261.72' y1='252.58' x2='351.24' y2='252.58' style='stroke-width: 0.75;' />
+<line x1='261.72' y1='252.58' x2='261.72' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='279.63' y1='252.58' x2='279.63' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='297.53' y1='252.58' x2='297.53' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='315.43' y1='252.58' x2='315.43' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='333.33' y1='252.58' x2='333.33' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='351.24' y1='252.58' x2='351.24' y2='256.90' style='stroke-width: 0.75;' />
+<text x='261.72' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='279.63' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='297.53' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='315.43' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='333.33' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='351.24' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<polygon points='258.14,252.58 354.82,252.58 354.82,26.78 258.14,26.78 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<defs>
+  <clipPath id='cpMjQwLjAwfDM2MC4wMHwwLjAwfDI4OC4wMA=='>
+    <rect x='240.00' y='0.00' width='120.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjQwLjAwfDM2MC4wMHwwLjAwfDI4OC4wMA==)'>
+<text x='306.48' y='285.41' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='43.62px' lengthAdjust='spacingAndGlyphs'>K content (%)</text>
+</g>
+<g clip-path='url(#cpMjU4LjE0fDM1NC44MnwyNi43OHwyNTIuNTg=)'>
+<line x1='261.72' y1='252.58' x2='261.72' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='279.63' y1='252.58' x2='279.63' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='297.53' y1='252.58' x2='297.53' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='315.43' y1='252.58' x2='315.43' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='333.33' y1='252.58' x2='333.33' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='351.24' y1='252.58' x2='351.24' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<circle cx='303.26' cy='35.15' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='298.24' cy='61.28' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='308.63' cy='87.41' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='307.91' cy='113.55' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='300.39' cy='139.68' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='308.99' cy='165.81' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='310.06' cy='191.95' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='304.69' cy='218.08' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='309.34' cy='244.21' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='274.61' y1='35.15' x2='331.90' y2='35.15' style='stroke-width: 0.75;' />
+<line x1='269.60' y1='61.28' x2='326.89' y2='61.28' style='stroke-width: 0.75;' />
+<line x1='281.77' y1='87.41' x2='335.48' y2='87.41' style='stroke-width: 0.75;' />
+<line x1='279.27' y1='113.55' x2='336.56' y2='113.55' style='stroke-width: 0.75;' />
+<line x1='271.75' y1='139.68' x2='329.04' y2='139.68' style='stroke-width: 0.75;' />
+<line x1='280.34' y1='165.81' x2='337.63' y2='165.81' style='stroke-width: 0.75;' />
+<line x1='281.42' y1='191.95' x2='338.70' y2='191.95' style='stroke-width: 0.75;' />
+<line x1='272.47' y1='218.08' x2='336.91' y2='218.08' style='stroke-width: 0.75;' />
+<line x1='284.28' y1='244.21' x2='334.41' y2='244.21' style='stroke-width: 0.75;' />
+<line x1='274.61' y1='37.76' x2='274.61' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='269.60' y1='63.89' x2='269.60' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='281.77' y1='90.03' x2='281.77' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='279.27' y1='116.16' x2='279.27' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='271.75' y1='142.29' x2='271.75' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='280.34' y1='168.43' x2='280.34' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='281.42' y1='194.56' x2='281.42' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='272.47' y1='220.69' x2='272.47' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='284.28' y1='246.83' x2='284.28' y2='241.60' style='stroke-width: 0.75;' />
+<line x1='331.90' y1='37.76' x2='331.90' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='326.89' y1='63.89' x2='326.89' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='335.48' y1='90.03' x2='335.48' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='336.56' y1='116.16' x2='336.56' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='329.04' y1='142.29' x2='329.04' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='337.63' y1='168.43' x2='337.63' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='338.70' y1='194.56' x2='338.70' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='336.91' y1='220.69' x2='336.91' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='334.41' y1='246.83' x2='334.41' y2='241.60' style='stroke-width: 0.75;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='258.14' y1='244.21' x2='258.14' y2='35.15' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='244.21' x2='253.82' y2='244.21' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='218.08' x2='253.82' y2='218.08' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='191.95' x2='253.82' y2='191.95' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='165.81' x2='253.82' y2='165.81' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='139.68' x2='253.82' y2='139.68' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='113.55' x2='253.82' y2='113.55' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='87.41' x2='253.82' y2='87.41' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='61.28' x2='253.82' y2='61.28' style='stroke-width: 0.75;' />
+<line x1='258.14' y1='35.15' x2='253.82' y2='35.15' style='stroke-width: 0.75;' />
+<text x='249.50' y='246.69' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='26.02px' lengthAdjust='spacingAndGlyphs'>E_lower</text>
+<text x='249.50' y='220.56' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='26.41px' lengthAdjust='spacingAndGlyphs'>D_lower</text>
+<text x='249.50' y='194.42' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='26.41px' lengthAdjust='spacingAndGlyphs'>C_lower</text>
+<text x='249.50' y='168.29' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='26.02px' lengthAdjust='spacingAndGlyphs'>B_lower</text>
+<text x='249.50' y='142.16' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='249.50' y='116.02' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='27.22px' lengthAdjust='spacingAndGlyphs'>B_upper</text>
+<text x='249.50' y='89.89' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='27.62px' lengthAdjust='spacingAndGlyphs'>C_upper</text>
+<text x='249.50' y='63.76' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='27.62px' lengthAdjust='spacingAndGlyphs'>D_upper</text>
+<text x='249.50' y='37.62' text-anchor='end' style='font-size: 7.20px; font-family: sans;' textLength='27.22px' lengthAdjust='spacingAndGlyphs'>E_upper</text>
+</g>
+<defs>
+  <clipPath id='cpMzc4LjE0fDQ3NC44MnwyNi43OHwyNTIuNTg='>
+    <rect x='378.14' y='26.78' width='96.67' height='225.79' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzc4LjE0fDQ3NC44MnwyNi43OHwyNTIuNTg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='381.72' y1='252.58' x2='471.24' y2='252.58' style='stroke-width: 0.75;' />
+<line x1='381.72' y1='252.58' x2='381.72' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='399.63' y1='252.58' x2='399.63' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='417.53' y1='252.58' x2='417.53' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='435.43' y1='252.58' x2='435.43' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='453.33' y1='252.58' x2='453.33' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='471.24' y1='252.58' x2='471.24' y2='256.90' style='stroke-width: 0.75;' />
+<text x='381.72' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='399.63' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='417.53' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='435.43' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='453.33' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>12</text>
+<text x='471.24' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>14</text>
+<polygon points='378.14,252.58 474.82,252.58 474.82,26.78 378.14,26.78 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<defs>
+  <clipPath id='cpMzYwLjAwfDQ4MC4wMHwwLjAwfDI4OC4wMA=='>
+    <rect x='360.00' y='0.00' width='120.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzYwLjAwfDQ4MC4wMHwwLjAwfDI4OC4wMA==)'>
+<text x='426.48' y='285.41' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='54.83px' lengthAdjust='spacingAndGlyphs'>Th content (ppm)</text>
+</g>
+<g clip-path='url(#cpMzc4LjE0fDQ3NC44MnwyNi43OHwyNTIuNTg=)'>
+<line x1='381.72' y1='252.58' x2='381.72' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='399.63' y1='252.58' x2='399.63' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='417.53' y1='252.58' x2='417.53' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='435.43' y1='252.58' x2='435.43' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='453.33' y1='252.58' x2='453.33' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='471.24' y1='252.58' x2='471.24' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<circle cx='446.44' cy='35.15' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='389.78' cy='61.28' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='430.06' cy='87.41' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='443.22' cy='113.55' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='430.96' cy='139.68' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='444.65' cy='165.81' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='418.42' cy='191.95' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='416.63' cy='218.08' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='453.33' cy='244.21' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='427.64' y1='35.15' x2='465.24' y2='35.15' style='stroke-width: 0.75;' />
+<line x1='381.72' y1='61.28' x2='397.84' y2='61.28' style='stroke-width: 0.75;' />
+<line x1='414.84' y1='87.41' x2='445.28' y2='87.41' style='stroke-width: 0.75;' />
+<line x1='422.63' y1='113.55' x2='463.81' y2='113.55' style='stroke-width: 0.75;' />
+<line x1='412.16' y1='139.68' x2='449.75' y2='139.68' style='stroke-width: 0.75;' />
+<line x1='424.06' y1='165.81' x2='465.24' y2='165.81' style='stroke-width: 0.75;' />
+<line x1='408.58' y1='191.95' x2='428.27' y2='191.95' style='stroke-width: 0.75;' />
+<line x1='410.37' y1='218.08' x2='422.90' y2='218.08' style='stroke-width: 0.75;' />
+<line x1='436.33' y1='244.21' x2='470.34' y2='244.21' style='stroke-width: 0.75;' />
+<line x1='427.64' y1='37.76' x2='427.64' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='381.72' y1='63.89' x2='381.72' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='414.84' y1='90.03' x2='414.84' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='422.63' y1='116.16' x2='422.63' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='412.16' y1='142.29' x2='412.16' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='424.06' y1='168.43' x2='424.06' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='408.58' y1='194.56' x2='408.58' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='410.37' y1='220.69' x2='410.37' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='436.33' y1='246.83' x2='436.33' y2='241.60' style='stroke-width: 0.75;' />
+<line x1='465.24' y1='37.76' x2='465.24' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='397.84' y1='63.89' x2='397.84' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='445.28' y1='90.03' x2='445.28' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='463.81' y1='116.16' x2='463.81' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='449.75' y1='142.29' x2='449.75' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='465.24' y1='168.43' x2='465.24' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='428.27' y1='194.56' x2='428.27' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='422.90' y1='220.69' x2='422.90' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='470.34' y1='246.83' x2='470.34' y2='241.60' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNDk4LjE0fDU5NC44MnwyNi43OHwyNTIuNTg='>
+    <rect x='498.14' y='26.78' width='96.67' height='225.79' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk4LjE0fDU5NC44MnwyNi43OHwyNTIuNTg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='501.72' y1='252.58' x2='591.24' y2='252.58' style='stroke-width: 0.75;' />
+<line x1='501.72' y1='252.58' x2='501.72' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='519.63' y1='252.58' x2='519.63' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='537.53' y1='252.58' x2='537.53' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='555.43' y1='252.58' x2='555.43' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='573.33' y1='252.58' x2='573.33' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='591.24' y1='252.58' x2='591.24' y2='256.90' style='stroke-width: 0.75;' />
+<text x='501.72' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='519.63' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='537.53' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='555.43' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='573.33' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='591.24' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='10.01px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<polygon points='498.14,252.58 594.82,252.58 594.82,26.78 498.14,26.78 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<defs>
+  <clipPath id='cpNDgwLjAwfDYwMC4wMHwwLjAwfDI4OC4wMA=='>
+    <rect x='480.00' y='0.00' width='120.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDgwLjAwfDYwMC4wMHwwLjAwfDI4OC4wMA==)'>
+<text x='546.48' y='285.41' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='51.63px' lengthAdjust='spacingAndGlyphs'>U content (ppm)</text>
+</g>
+<g clip-path='url(#cpNDk4LjE0fDU5NC44MnwyNi43OHwyNTIuNTg=)'>
+<line x1='501.72' y1='252.58' x2='501.72' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='519.63' y1='252.58' x2='519.63' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='537.53' y1='252.58' x2='537.53' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='555.43' y1='252.58' x2='555.43' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='573.33' y1='252.58' x2='573.33' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='591.24' y1='252.58' x2='591.24' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<circle cx='536.45' cy='35.15' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='516.05' cy='61.28' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='555.43' cy='87.41' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='540.04' cy='113.55' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='562.59' cy='139.68' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='540.39' cy='165.81' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='555.43' cy='191.95' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='548.27' cy='218.08' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='543.62' cy='244.21' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='531.08' y1='35.15' x2='541.83' y2='35.15' style='stroke-width: 0.75;' />
+<line x1='511.75' y1='61.28' x2='520.34' y2='61.28' style='stroke-width: 0.75;' />
+<line x1='530.37' y1='87.41' x2='580.49' y2='87.41' style='stroke-width: 0.75;' />
+<line x1='518.55' y1='113.55' x2='561.52' y2='113.55' style='stroke-width: 0.75;' />
+<line x1='541.11' y1='139.68' x2='584.07' y2='139.68' style='stroke-width: 0.75;' />
+<line x1='508.17' y1='165.81' x2='572.62' y2='165.81' style='stroke-width: 0.75;' />
+<line x1='526.79' y1='191.95' x2='584.07' y2='191.95' style='stroke-width: 0.75;' />
+<line x1='517.12' y1='218.08' x2='579.42' y2='218.08' style='stroke-width: 0.75;' />
+<line x1='516.05' y1='244.21' x2='571.19' y2='244.21' style='stroke-width: 0.75;' />
+<line x1='531.08' y1='37.76' x2='531.08' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='511.75' y1='63.89' x2='511.75' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='530.37' y1='90.03' x2='530.37' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='518.55' y1='116.16' x2='518.55' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='541.11' y1='142.29' x2='541.11' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='508.17' y1='168.43' x2='508.17' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='526.79' y1='194.56' x2='526.79' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='517.12' y1='220.69' x2='517.12' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='516.05' y1='246.83' x2='516.05' y2='241.60' style='stroke-width: 0.75;' />
+<line x1='541.83' y1='37.76' x2='541.83' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='520.34' y1='63.89' x2='520.34' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='580.49' y1='90.03' x2='580.49' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='561.52' y1='116.16' x2='561.52' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='584.07' y1='142.29' x2='584.07' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='572.62' y1='168.43' x2='572.62' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='584.07' y1='194.56' x2='584.07' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='579.42' y1='220.69' x2='579.42' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='571.19' y1='246.83' x2='571.19' y2='241.60' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNjE4LjE0fDcxNC44MnwyNi43OHwyNTIuNTg='>
+    <rect x='618.14' y='26.78' width='96.67' height='225.79' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjE4LjE0fDcxNC44MnwyNi43OHwyNTIuNTg=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='621.72' y1='252.58' x2='711.24' y2='252.58' style='stroke-width: 0.75;' />
+<line x1='621.72' y1='252.58' x2='621.72' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='636.64' y1='252.58' x2='636.64' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='651.56' y1='252.58' x2='651.56' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='666.48' y1='252.58' x2='666.48' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='681.40' y1='252.58' x2='681.40' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='696.32' y1='252.58' x2='696.32' y2='256.90' style='stroke-width: 0.75;' />
+<line x1='711.24' y1='252.58' x2='711.24' y2='256.90' style='stroke-width: 0.75;' />
+<text x='621.72' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='636.64' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='651.56' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='666.48' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='681.40' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='711.24' y='268.13' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>120</text>
+<polygon points='618.14,252.58 714.82,252.58 714.82,26.78 618.14,26.78 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<defs>
+  <clipPath id='cpNjAwLjAwfDcyMC4wMHwwLjAwfDI4OC4wMA=='>
+    <rect x='600.00' y='0.00' width='120.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjAwLjAwfDcyMC4wMHwwLjAwfDI4OC4wMA==)'>
+<text x='666.48' y='285.41' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='58.02px' lengthAdjust='spacingAndGlyphs'>Water content (%)</text>
+</g>
+<g clip-path='url(#cpNjE4LjE0fDcxNC44MnwyNi43OHwyNTIuNTg=)'>
+<line x1='621.72' y1='252.58' x2='621.72' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='636.64' y1='252.58' x2='636.64' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='651.56' y1='252.58' x2='651.56' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='666.48' y1='252.58' x2='666.48' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='681.40' y1='252.58' x2='681.40' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='696.32' y1='252.58' x2='696.32' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<line x1='711.24' y1='252.58' x2='711.24' y2='26.78' style='stroke-width: 0.75; stroke: #BEBEBE; stroke-dasharray: 1.00,3.00;' />
+<circle cx='644.10' cy='35.15' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='647.83' cy='61.28' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='673.94' cy='87.41' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='635.90' cy='113.55' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='647.83' cy='139.68' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='636.64' cy='165.81' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='638.13' cy='191.95' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='686.62' cy='218.08' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='644.10' cy='244.21' r='2.43' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='636.64' y1='35.15' x2='651.56' y2='35.15' style='stroke-width: 0.75;' />
+<line x1='640.37' y1='61.28' x2='655.29' y2='61.28' style='stroke-width: 0.75;' />
+<line x1='659.02' y1='87.41' x2='688.86' y2='87.41' style='stroke-width: 0.75;' />
+<line x1='628.44' y1='113.55' x2='643.36' y2='113.55' style='stroke-width: 0.75;' />
+<line x1='632.91' y1='139.68' x2='662.75' y2='139.68' style='stroke-width: 0.75;' />
+<line x1='629.18' y1='165.81' x2='644.10' y2='165.81' style='stroke-width: 0.75;' />
+<line x1='630.68' y1='191.95' x2='645.59' y2='191.95' style='stroke-width: 0.75;' />
+<line x1='671.70' y1='218.08' x2='701.54' y2='218.08' style='stroke-width: 0.75;' />
+<line x1='636.64' y1='244.21' x2='651.56' y2='244.21' style='stroke-width: 0.75;' />
+<line x1='636.64' y1='37.76' x2='636.64' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='640.37' y1='63.89' x2='640.37' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='659.02' y1='90.03' x2='659.02' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='628.44' y1='116.16' x2='628.44' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='632.91' y1='142.29' x2='632.91' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='629.18' y1='168.43' x2='629.18' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='630.68' y1='194.56' x2='630.68' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='671.70' y1='220.69' x2='671.70' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='636.64' y1='246.83' x2='636.64' y2='241.60' style='stroke-width: 0.75;' />
+<line x1='651.56' y1='37.76' x2='651.56' y2='32.53' style='stroke-width: 0.75;' />
+<line x1='655.29' y1='63.89' x2='655.29' y2='58.67' style='stroke-width: 0.75;' />
+<line x1='688.86' y1='90.03' x2='688.86' y2='84.80' style='stroke-width: 0.75;' />
+<line x1='643.36' y1='116.16' x2='643.36' y2='110.93' style='stroke-width: 0.75;' />
+<line x1='662.75' y1='142.29' x2='662.75' y2='137.07' style='stroke-width: 0.75;' />
+<line x1='644.10' y1='168.43' x2='644.10' y2='163.20' style='stroke-width: 0.75;' />
+<line x1='645.59' y1='194.56' x2='645.59' y2='189.33' style='stroke-width: 0.75;' />
+<line x1='701.54' y1='220.69' x2='701.54' y2='215.47' style='stroke-width: 0.75;' />
+<line x1='651.56' y1='246.83' x2='651.56' y2='241.60' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpMjQwLjAwfDcyMC4wMHwyODguMDB8NTc2LjAw'>
+    <rect x='240.00' y='288.00' width='480.00' height='288.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjQwLjAwfDcyMC4wMHwyODguMDB8NTc2LjAw)'>
+<rect x='291.41' y='496.54' width='9.78' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='472.90' width='8.99' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='449.27' width='19.22' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='425.63' width='102.74' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='401.99' width='349.45' height='19.70' style='stroke-width: 0.75; fill: #428BCA;' />
+<rect x='291.41' y='378.35' width='66.26' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='354.72' width='48.17' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='331.08' width='5.93' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<rect x='291.41' y='307.44' width='1.30' height='19.70' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<text x='474.96' y='562.90' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='244.68px' lengthAdjust='spacingAndGlyphs'>Contribution to total gamma dose rate (%) received by the sample</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='291.41' y1='524.59' x2='658.51' y2='524.59' style='stroke-width: 0.75;' />
+<line x1='291.41' y1='524.59' x2='291.41' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='352.59' y1='524.59' x2='352.59' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='413.78' y1='524.59' x2='413.78' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='474.96' y1='524.59' x2='474.96' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='536.14' y1='524.59' x2='536.14' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='597.33' y1='524.59' x2='597.33' y2='529.63' style='stroke-width: 0.75;' />
+<line x1='658.51' y1='524.59' x2='658.51' y2='529.63' style='stroke-width: 0.75;' />
+<text x='291.41' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='352.59' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='413.78' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='474.96' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='536.14' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='597.33' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='658.51' y='542.74' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='256.13' y='509.28' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='30.35px' lengthAdjust='spacingAndGlyphs'>E_lower</text>
+<text x='256.13' y='485.64' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='30.81px' lengthAdjust='spacingAndGlyphs'>D_lower</text>
+<text x='256.13' y='462.01' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='30.81px' lengthAdjust='spacingAndGlyphs'>C_lower</text>
+<text x='256.13' y='438.37' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='30.35px' lengthAdjust='spacingAndGlyphs'>B_lower</text>
+<text x='256.13' y='414.73' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='5.60px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='256.13' y='391.09' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='31.76px' lengthAdjust='spacingAndGlyphs'>B_upper</text>
+<text x='256.13' y='367.45' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='32.23px' lengthAdjust='spacingAndGlyphs'>C_upper</text>
+<text x='256.13' y='343.82' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='32.23px' lengthAdjust='spacingAndGlyphs'>D_upper</text>
+<text x='256.13' y='320.18' text-anchor='end' style='font-size: 8.40px; font-family: sans;' textLength='31.76px' lengthAdjust='spacingAndGlyphs'>E_upper</text>
+<text x='286.37' y='320.18' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>0.21 %</text>
+<text x='286.37' y='343.82' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='26.15px' lengthAdjust='spacingAndGlyphs'>0.97 %</text>
+<text x='286.37' y='367.45' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='21.48px' lengthAdjust='spacingAndGlyphs'>7.9 %</text>
+<text x='286.37' y='391.09' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='19.15px' lengthAdjust='spacingAndGlyphs'>11 %</text>
+<text x='286.37' y='414.73' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='19.15px' lengthAdjust='spacingAndGlyphs'>57 %</text>
+<text x='286.37' y='438.37' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='19.15px' lengthAdjust='spacingAndGlyphs'>17 %</text>
+<text x='286.37' y='462.01' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='21.48px' lengthAdjust='spacingAndGlyphs'>3.1 %</text>
+<text x='286.37' y='485.64' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='21.48px' lengthAdjust='spacingAndGlyphs'>1.5 %</text>
+<text x='286.37' y='509.28' text-anchor='end' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='21.48px' lengthAdjust='spacingAndGlyphs'>1.6 %</text>
+<text x='653.47' y='320.18' style='font-size: 8.40px; font-family: sans;' textLength='52.31px' lengthAdjust='spacingAndGlyphs'>   0.002 Gy/ka</text>
+<text x='653.47' y='343.82' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.009 Gy/ka</text>
+<text x='653.47' y='367.45' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.073 Gy/ka</text>
+<text x='653.47' y='391.09' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.100 Gy/ka</text>
+<text x='653.47' y='414.73' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.530 Gy/ka</text>
+<text x='653.47' y='438.37' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.156 Gy/ka</text>
+<text x='653.47' y='462.01' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.029 Gy/ka</text>
+<text x='653.47' y='485.64' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.014 Gy/ka</text>
+<text x='653.47' y='509.28' style='font-size: 8.40px; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>+ 0.015 Gy/ka</text>
+<text x='653.47' y='521.10' style='font-size: 8.40px; fill: #B22222; font-family: sans;' textLength='52.55px' lengthAdjust='spacingAndGlyphs'>= 0.927 Gy/ka</text>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+</g>
+</svg>

--- a/tests/testthat/test_scale_GammaDose.R
+++ b/tests/testthat/test_scale_GammaDose.R
@@ -95,3 +95,14 @@ test_that("snapshot tests", {
                                        plot = FALSE, verbose = FALSE),
                        tolerance = snapshot.tolerance)
 })
+
+test_that("graphical snapshot tests", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("vdiffr")
+  testthat::skip_if_not(getRversion() >= "4.4.0")
+
+  SW({
+  vdiffr::expect_doppelganger("defaults",
+                              scale_GammaDose(ExampleData.ScaleGammaDose))
+  })
+})


### PR DESCRIPTION
When in eef9aa5 the `plot_single` argument was renamed to `plot_singlePanels`, it was noted that the option behaved in the opposite way. However, only its default value was changed but not the actual implementation. This now makes the argument work as expected and conforming to other functions.

Fixes #698.