### PR TITLE
Don't leave unfilled areas in the density plots in calc_FiniteMixture()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -118,6 +118,10 @@ non-consecutive values (#691).
 * The function sometimes failed to plot some of the densities when the number
 of components was set to a value of 8 or more (#704).
 
+* The density plots would not always be coloured completely, but especially
+for high values of `sigmab` there would be an unfilled area at the base of the
+densities (#706).
+
 ### `calc_Huntley2006()`
 
 * Add support for nls-fitting control arguments `maxiter` and `trace`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -128,6 +128,10 @@
 - The function sometimes failed to plot some of the densities when the
   number of components was set to a value of 8 or more (#704).
 
+- The density plots would not always be coloured completely, but
+  especially for high values of `sigmab` there would be an unfilled area
+  at the base of the densities (#706).
+
 ### `calc_Huntley2006()`
 
 - Add support for nls-fitting control arguments `maxiter` and `trace`.

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -788,8 +788,8 @@ calc_FiniteMixture <- function(
              ann = FALSE, xpd = FALSE)
 
         # draw coloured polygons under curve
-        polygon(x = c(min(sapply), sapply,  min(sapply)),
-                y = c(0, 0:max.dose,  0),
+        polygon(x = c(0, min(sapply), sapply, 0),
+                y = c(0, 0, 0:max.dose, max.dose),
                 col = adjustcolor(col.n[j], alpha.f = 0.66),
                 yaxt = "n", border = poly.border, xpd = FALSE, lty = 2, lwd = 1.5)
       } else {


### PR DESCRIPTION
This is ensured by adding two extra points to the polygons corresponding to the base of the density.

Fixes #706.