### PR TITLE
Make the estimation of the y-scaling in calc_FiniteMixture() more robust

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -127,6 +127,10 @@ then the function crashed as a quantity computed only in that iteration was
 not available. This happened for very specific combinations of `sigmab` and
 `n.components` (#708).
 
+* Another crash occurred when height of the largest density curve could not
+be estimated due to the presence of too many `NA` values in the intermediate
+computations (#710).
+
 ### `calc_Huntley2006()`
 
 * Add support for nls-fitting control arguments `maxiter` and `trace`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -137,6 +137,10 @@
   iteration was not available. This happened for very specific
   combinations of `sigmab` and `n.components` (#708).
 
+- Another crash occurred when height of the largest density curve could
+  not be estimated due to the presence of too many `NA` values in the
+  intermediate computations (#710).
+
 ### `calc_Huntley2006()`
 
 - Add support for nls-fitting control arguments `maxiter` and `trace`.

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -694,6 +694,13 @@ calc_FiniteMixture <- function(
     max.dose <- max(object@data$data[, 1]) + sd(object@data$data[, 1]) / 2
     min.dose <- min(object@data$data[, 1]) - sd(object@data$data[, 1]) / 2
 
+    if (!pdf.weight) {
+      ## estimate the y-scaling if no weights are used
+      dens.max <- max(dnorm(0:max.dose,
+                            mean = na.exclude(c(comp.n[pos.n, ])),
+                            sd = na.exclude(c(comp.n[pos.n + 1, ]))))
+    }
+
     ## LOOP - iterate over number of components
     for (j in 1:max(n.components)) {
       ## draw random values of the ND to check for NA values
@@ -715,17 +722,6 @@ calc_FiniteMixture <- function(
                      else comp.n[pos.n[j], i] * sigmab
                 ) * if (pdf.weight) wi else 1
         }
-
-        ## x-axis scaling - determine highest dose in first cycle
-        if (i == 1 && j == 1) {
-          ## density function to determine y-scaling if no weights are used
-          fooY <- function(x) {
-            dnorm(x, mean = na.exclude(comp.n[pos.n, ]),
-                  sd = na.exclude(comp.n[pos.n + 1, ]))
-          }
-          ## set y-axis scaling
-          dens.max <- max(sapply(0:max.dose, fooY))
-        } ## EndOfIf::first cycle settings
 
         ## override y-axis scaling if weights are used
         if (pdf.weight) {

--- a/tests/testthat/test_calc_FiniteMixture.R
+++ b/tests/testthat/test_calc_FiniteMixture.R
@@ -104,5 +104,10 @@ test_that("regression tests", {
   ## issue 708
   expect_silent(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.57,
                                    n.components = 2:6, verbose = FALSE))
+
+  ## issue 710
+  expect_silent(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.54,
+                                   n.components = 2:5, pdf.weight = FALSE,
+                                   verbose = FALSE))
   })
 })


### PR DESCRIPTION
Rather than doing
```R
na.exclude(comp.n[pos.n + 1, ])
```
we now do
```R
na.exclude(c(comp.n[pos.n + 1, ]))
```
so that we only remove the `NA` elements from a vector, rather than removing any row that contains `NA`s, as that may leave a vector of length 0.

This code is now executed only if `pdf.weight` is `FALSE`, as in the other case `dens.max` is already computed elsewhere.

Fixes #710.