### PR TITLE
Plot results even when NAs are produced in calc_FiniteMixture()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -139,10 +139,14 @@ for high number of components have been removed (#713), as well as extra
 slices appearing due to rounding errors (#715).
 
 * The plot can be better configured via the new `plot.criteria` argument to
-control whether the statistical critera plot should be drawn. Moreover,
+control whether the statistical criteria curves should be drawn. Moreover,
 support for the `...` options has been added: `cex` to control the overall
 scaling, `main.densities`, `main.proportions` and `main.criteria` to set the
 subplot titles (#717).
+
+* Plots are now generated even when results contain `NA` values, as they in
+general don't affect the plot. However, when that happens we report it in the
+plot subtitle (#718).
 
 ### `calc_Huntley2006()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -149,10 +149,14 @@
   extra slices appearing due to rounding errors (#715).
 
 - The plot can be better configured via the new `plot.criteria` argument
-  to control whether the statistical critera plot should be draws.
-  Moreover, support for these `...` options has been added: `cex` to
+  to control whether the statistical criteria curves should be drawn.
+  Moreover, support for the `...` options has been added: `cex` to
   control the overall scaling, `main.densities`, `main.proportions` and
   `main.criteria` to set the subplot titles (#717).
+
+- Plots are now generated even when results contain `NA` values, as they
+  in general don’t affect the plot. However, when that happens we report
+  it in the plot subtitle (#718).
 
 ### `calc_Huntley2006()`
 

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -559,7 +559,7 @@ calc_FiniteMixture <- function(
 
   ##=========##
   ## PLOTTING -----------
-  if(plot && !anyNA(unlist(summary)))
+  if (plot)
     try(do.call(.plot_FiniteMixture, c(results, as.list(sys.call())[-c(1,2)])))
 
   # Return values
@@ -761,10 +761,16 @@ calc_FiniteMixture <- function(
             at = graphics::grconvertX(0.5, from = "ndc", to = "user"))
 
       ## subtitle
-      mtext(as.expression(bquote(italic(sigma[b]) == .(sigmab) ~
-                                   "|" ~ n == .(length(object@data$data[, 1])))),
+      has.nas <- anyNA(unlist(object$summary))
+      subtitle <- as.expression(bquote(italic(sigma[b]) == .(sigmab) ~
+                                         "|" ~ n == .(length(object@data$data[, 1])) ~
+                                         .(if (has.nas) "| The model produced NA values"
+                                           else "")
+                                       ))
+      mtext(subtitle,
             side = 3, font = 1, line = 2.2, adj = 0.5,
             at = graphics::grconvertX(0.5, from = "ndc", to = "user"),
+            col = ifelse(has.nas, 2, 1),
             cex = 0.9 * settings$cex)
 
       ## x-axis label

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -589,8 +589,6 @@ calc_FiniteMixture <- function(
       plot.criteria = TRUE
   )
   settings <- modifyList(settings, extraArgs)
-  plot.proportions <- settings$plot.proportions
-  plot.criteria <- settings$plot.criteria
 
   ## extract relevant data from object
   n.components <- object@data$args$n.components
@@ -606,9 +604,9 @@ calc_FiniteMixture <- function(
   ## DEVICE AND PLOT LAYOUT
   n.plots <- length(n.components) #number of PDF plots in plot area #1
   seq.matrix <- rbind(c(1:n.plots), c(1:n.plots))
-  if (plot.proportions)
+  if (settings$plot.proportions)
     seq.matrix <- rbind(seq.matrix, rep(max(seq.matrix) + 1))
-  if (plot.criteria)
+  if (settings$plot.criteria)
     seq.matrix <- rbind(seq.matrix, rep(max(seq.matrix) + 1))
 
   ## create device layout
@@ -808,7 +806,7 @@ calc_FiniteMixture <- function(
 
   ##--------------------------------------------------------------------------
   ## PLOT 2: PROPORTION OF COMPONENTS
-  if (plot.proportions) {
+  if (settings$plot.proportions) {
 
     ## create matrix with proportions from a subset of the summary matrix
     prop.matrix <- comp.n[pos.n + 2, ] * 100
@@ -843,7 +841,7 @@ calc_FiniteMixture <- function(
   ##--------------------------------------------------------------------------
   ## PLOT 3: BIC & LLIK
 
-  if (plot.criteria) {
+  if (settings$plot.criteria) {
   ## prepare scaling for both y-axes
   BIC.scale <- c(min(BIC.n) * if (min(BIC.n) < 0) 1.2 else 0.8,
                 max(BIC.n) * if (max(BIC.n) < 0) 0.8 else 1.2)


### PR DESCRIPTION
Now we always do a plot, but if we have thrown a warning because the results contained `NA` values, we show that in the plot subtitle, so that the user doesn't forget about the warning.

Fixes #718.