### PR TITLE
Warn if loess fitting cannot be done as there are not enough data

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -158,6 +158,11 @@ reduce the number of occasions in which the error message "Could not fit
 simulated model curve, check suitability of model and parameters" is
 reported (#660).
 
+### `calc_MinDose()`
+
+* The function now warns if the number of bootstrap replicates is too low to
+perform the loess fitting (#721).
+
 ### `calc_OSLLxTxRatio()`
 * The function returned a warning for wrong integral settings for the `Tx` curve even if no `Tx` curve was provided; fixed. 
 * The function does not check any more of different object types for `Lx.data` and `Tx.data` but validate objects for allowed types (this should have no user-visible effects)

--- a/NEWS.md
+++ b/NEWS.md
@@ -168,6 +168,11 @@
   message “Could not fit simulated model curve, check suitability of
   model and parameters” is reported (#660).
 
+### `calc_MinDose()`
+
+- The function now warns if the number of bootstrap replicates is too
+  low to perform the loess fitting (#721).
+
 ### `calc_OSLLxTxRatio()`
 
 - The function returned a warning for wrong integral settings for the

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -917,7 +917,13 @@ calc_MinDose <- function(
     # distribution where actually none is given. The non-parametric
     # LOESS (LOcal polynomial regrESSion) often yields better results than
     # standard polynomials.
-    loess <- loess(pairs[ ,2] ~ pairs[ ,1])
+    if (nrow(pairs) >= 7) {
+      loess <- loess(pairs[, 2] ~ pairs[, 1])
+    } else {
+      loess <- NA
+      .throw_warning("Not enough bootstrap replicates for loess fitting, try ",
+                     "increasing `bs.M`")
+    }
 
   }#EndOf::Bootstrap
 

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -624,7 +624,7 @@ calc_MinDose <- function(
   )
 
   if (debug)
-    print(bbmle::summary(ests))
+    print(suppressWarnings(bbmle::summary(ests)))
 
   if (any(is.nan(coef_err)))
     coef_err[which(is.nan(coef_err))] <- t(as.data.frame(ests@coef))[which(is.nan(coef_err))] / 100

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -588,7 +588,7 @@ calc_MinDose <- function(
       )
 
     }, error = function(e) {
-      .throw_error("Sorry, seems like I encountered an error: ", e)
+      .throw_error("Sorry, seems like I encountered an error: ", e) # nocov
     })
     return(mle)
   }

--- a/R/plot_RLum.Results.R
+++ b/R/plot_RLum.Results.R
@@ -301,6 +301,7 @@ plot_RLum.Results<- function(
       ### possibly integrate this in the prior polynomial plot loop
 
       ### LOESS PLOT
+      if (!anyNA(object@data$bootstrap$loess.fit)) {
       pairs<- object@data$bootstrap$pairs$gamma
       pred<- predict(object@data$bootstrap$loess.fit)
       loess<- cbind(pairs[,1], pred)
@@ -315,6 +316,7 @@ plot_RLum.Results<- function(
 
       # add LOESS line
       lines(loess, type = "l", col = "black")
+      }
 
       ### ------ PLOT BOOTSTRAP LIKELIHOOD FIT
 

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -64,7 +64,7 @@ test_that("check functionality", {
                  "Recycled Bootstrap")
   expect_message(calc_MinDose(ExampleData.DeValues$CA1, sigmab = 0.1,
                               bootstrap = TRUE, bs.M = 10, bs.N = 5, bs.h = 5,
-                              sigmab.sd = 0.04, debug = TRUE,
+                              sigmab.sd = 0.04, debug = TRUE, log = FALSE,
                               multicore = TRUE, cores = 2),
                  "bootstrap replicates using 2 cores")
   })

--- a/tests/testthat/test_calc_MinDose.R
+++ b/tests/testthat/test_calc_MinDose.R
@@ -94,6 +94,10 @@ test_that("check functionality", {
                               par = 4, gamma.lower = 2, log.output = TRUE,
                               bootstrap = TRUE, bs.M = 10, bs.N = 5, bs.h=100),
                  "Gamma is larger than mu, consider running the model with new")
+  expect_warning(calc_MinDose(ExampleData.DeValues$CA1[1:9, ], sigmab = 0.8,
+                             bootstrap = TRUE, bs.M = 5, bs.N = 5, bs.h = 5,
+                             debug = TRUE, log = FALSE),
+                 "Not enough bootstrap replicates for loess fitting")
   expect_output(calc_MinDose(ExampleData.DeValues$CA1 / 100, sigmab = 0.1,
                              verbose = TRUE, log.output = TRUE, par = 4))
   expect_silent(calc_MinDose(ExampleData.DeValues$CA1, sigmab = 0.1,


### PR DESCRIPTION
This replaces a bunch of ugly warnings that would be throw by `simpleLoess()` with an actionable warning from `calc_MinDose()`.

Fixes #721.