### PR TITLE
Don't crash if all simulated Lx/Tx values are identical

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -152,12 +152,17 @@ plot subtitle (#718).
 ### `calc_Huntley2006()`
 
 * Add support for nls-fitting control arguments `maxiter` and `trace`.
+
 * The fitting of the simulated curve with the GOK model has been made more
 robust: when an initial fit of the model fails, the fit is attempted again
 with 10 different values for `D0` and the best fit is used. This should
 reduce the number of occasions in which the error message "Could not fit
 simulated model curve, check suitability of model and parameters" is
 reported (#660).
+
+* The function crashed if all simulated Lx/Tx values were identical and
+approximately zero, which could happen if the `rhop` argument was set to a
+large enough value (#725).
 
 ### `calc_MinDose()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -161,12 +161,17 @@
 ### `calc_Huntley2006()`
 
 - Add support for nls-fitting control arguments `maxiter` and `trace`.
+
 - The fitting of the simulated curve with the GOK model has been made
   more robust: when an initial fit of the model fails, the fit is
   attempted again with 10 different values for `D0` and the best fit is
   used. This should reduce the number of occasions in which the error
   message “Could not fit simulated model curve, check suitability of
   model and parameters” is reported (#660).
+
+- The function crashed if all simulated Lx/Tx values were identical and
+  approximately zero, which could happen if the `rhop` argument was set
+  to a large enough value (#725).
 
 ### `calc_MinDose()`
 

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -670,6 +670,11 @@ calc_Huntley2006 <- function(
 
   # calculate Age
   positive <- which(diff(LxTx.sim) > 0)
+  if (length(positive) == 0) {
+    .throw_error("All simulated Lx/Tx values are identical and approximately ",
+                 "zero. Please verify the accuracy of your rho' value, as this ",
+                 "is likely too large and may not be realistic")
+  }
 
   data.unfaded <- data.frame(
     dose = c(0, natdosetimeGray[positive]),

--- a/tests/testthat/test_calc_Huntley2006.R
+++ b/tests/testthat/test_calc_Huntley2006.R
@@ -278,6 +278,12 @@ test_that("Further tests calc_Huntley2006", {
       rhop = rhop, ddot = ddot, readerDdot = readerDdot,
       n.MC = 2, plot = FALSE, verbose = FALSE),
     "Ln is >10 % larger than the maximum computed LxTx value")
+  expect_error(
+    calc_Huntley2006(
+      data = data,
+      rhop = c(1e-3, 1e-7), ddot = ddot, readerDdot = readerDdot,
+      n.MC = 2, plot = FALSE, verbose = FALSE),
+    "All simulated Lx/Tx values are identical and approximately zero")
 })
 
 test_that("regression tests", {


### PR DESCRIPTION
Fixes #725.