### PR TITLE
Account for cex when setting the margins around the summary text in calc_Huntley2006()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -173,6 +173,9 @@ much unused horizontal space, especially for `mode = "extrapolation"` (#731).
 
 * The scaling of the plot can now be controlled via the `cex` argument (#735).
 
+* The plot margins are set more precisely and avoid the summary text to be
+cut off (#737).
+
 ### `calc_MinDose()`
 
 * The function now warns if the number of bootstrap replicates is too low to

--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,9 @@
 - The scaling of the plot can now be controlled via the `cex` argument
   (#735).
 
+- The plot margins are set more precisely and avoid the summary text to
+  be cut off (#737).
+
 ### `calc_MinDose()`
 
 - The function now warns if the number of bootstrap replicates is too

--- a/R/calc_Huntley2006.R
+++ b/R/calc_Huntley2006.R
@@ -891,7 +891,7 @@ calc_Huntley2006 <- function(
 
     # set graphical parameters
     par(mfrow = c(1,1), mar = c(4.5, 4, 4, 4), cex = 0.8 * plot.settings$cex,
-        oma = c(0, 0, 0, if (summary) 12 else 0))
+        oma = c(0, 0, 0, if (summary) 12 / plot.settings$cex else 0))
 
     # Find a good estimate of the x-axis limits
     if (mode_is_extrapolation && !force_through_origin) {


### PR DESCRIPTION
Further refinement to 8472388 to account for the `cex` setting. Fixes #737.