### PR TITLE
Improve the logic for the multicore argument in plot_DetPlot()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -233,6 +233,11 @@ all others.
 * The function does no longer stops for differing channel resolutions, 
 but it does issue a warning. The user is responsible for the consequences.
 
+### `plot_DetPlot()`
+
+* The logic for multicore support was incorrect, which resulted in always
+starting a parallel cluster even when `multicore = FALSE` (#742).
+
 ### `plot_DoseResponseCurve()`
 
 * The response curve always tries to the get the 0 point in the mode `interpolation` and `alternate` (#677)

--- a/NEWS.md
+++ b/NEWS.md
@@ -254,6 +254,12 @@
   but it does issue a warning. The user is responsible for the
   consequences.
 
+### `plot_DetPlot()`
+
+- The logic for multicore support was incorrect, which resulted in
+  always starting a parallel cluster even when `multicore = FALSE`
+  (#742).
+
 ### `plot_DoseResponseCurve()`
 
 - The response curve always tries to the get the 0 point in the mode

--- a/tests/testthat/test_plot_DetPlot.R
+++ b/tests/testthat/test_plot_DetPlot.R
@@ -75,7 +75,7 @@ test_that("plot_DetPlot", {
 
   ## test self call with multi core
   SW({
-  results <- expect_s4_class(plot_DetPlot(
+  expect_message(expect_s4_class(plot_DetPlot(
     object = list(x = object, y = object),
     method = "shift",
     signal.integral.min = 1,
@@ -86,7 +86,25 @@ test_that("plot_DetPlot", {
       fit.method = "LIN",
       trim_channels = TRUE
     ),
-    multicore = 1,
+    multicore = 2,
+    n.channels = 2,
+    verbose = TRUE,
+    plot = FALSE),
+    "RLum.Results"),
+    "Running multicore session using 2 cores")
+
+  expect_s4_class(plot_DetPlot(
+    object = list(x = object, y = object),
+    method = "shift",
+    signal.integral.min = 1,
+    signal.integral.max = 3,
+    background.integral.min = 900,
+    background.integral.max = 1000,
+    analyse_function.control = list(
+      fit.method = "LIN",
+      trim_channels = TRUE
+    ),
+    multicore = FALSE,
     n.channels = 2,
     verbose = TRUE,
     plot = FALSE),


### PR DESCRIPTION
Locally the tests pass but I cannot get `covr::file_coverage()` on the multicore test (the same error occurred before even without code changes, just we didn't have test that set that option). Perhaps on CI coverage will run correctly, let's see!

Fixes #742.
