### PR TITLE
Reduce the right margin in plot_Histogram() if errors are not plotted

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -255,6 +255,9 @@ starting a parallel cluster even when `multicore = FALSE` (#742).
 * The function now doesn't produce warnings when the input consists of a
 single-column data frame, as it assumes that the De error is 10^-9 (#744).
 
+* The right margin is now smaller when errors are not plotted, as there is
+no need to leave space for the standard error axis (#748).
+
 ### `plot_KDE()`
 
 * The function validates its input values more thoroughly (#635).

--- a/NEWS.md
+++ b/NEWS.md
@@ -281,6 +281,9 @@
   single-column data frame, as it assumes that the De error is 10^-9
   (#744).
 
+- The right margin is now smaller when errors are not plotted, as there
+  is no need to leave space for the standard error axis (#748).
+
 ### `plot_KDE()`
 
 - The function validates its input values more thoroughly (#635).

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -142,11 +142,6 @@ plot_Histogram <- function(
     data <- get_RLum(data)[,1:2]
   }
 
-  ## handle error-free data sets
-  if (length(data) < 2 || all(is.na(data[, 2]))) {
-    data[, 2] <- 1e-9
-  }
-
   .validate_class(summary, "character")
   .validate_class(summary.pos, c("numeric", "character"))
   if (is.numeric(summary.pos)) {
@@ -162,6 +157,12 @@ plot_Histogram <- function(
   .validate_logical_scalar(rug)
   .validate_logical_scalar(normal_curve)
   .validate_length(colour, 4)
+
+  ## handle error-free data sets
+  if (length(data) < 2 || all(is.na(data[, 2]))) {
+    data[, 2] <- 1e-9
+    se <- FALSE
+  }
 
   ## Set general parameters ---------------------------------------------------
   ## Check/set default parameters
@@ -253,7 +254,7 @@ plot_Histogram <- function(
     pch.plot <- 1
   }
   ## Set plot area format
-  par(mar = c(4.5, 4.5, 4.5, 4.5),
+  par(mar = c(4.5, 4.5, 4.5, if (se) 4.5 else 1),
       cex = cex.global)
 
   ## Plot histogram -----------------------------------------------------------
@@ -442,9 +443,6 @@ plot_Histogram <- function(
   }
 
   ## Optionally, add standard error plot --------------------------------------
-  if (all(data[, 2] == 1e-9)) {
-    se <- FALSE
-  }
 
   if(se == TRUE) {
     par(new = TRUE)

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -272,7 +272,9 @@ plot_Histogram <- function(
         main = main.plot)
 
   ## Optionally, add rug ------------------------------------------------------
-  if (rug) graphics::rug(data[, 1], col = colour[2])
+  if (rug) {
+    graphics::rug(data[, 1], col = colour[2], quiet = TRUE)
+  }
 
   ## Optionally, add a normal curve based on the data -------------------------
   if(normal_curve == TRUE){

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -157,6 +157,10 @@ plot_Histogram <- function(
                                   "topleft", "top", "topright",
                                   "bottomleft", "bottom", "bottomright"))
   }
+  .validate_logical_scalar(na.rm)
+  .validate_logical_scalar(se)
+  .validate_logical_scalar(rug)
+  .validate_logical_scalar(normal_curve)
   .validate_length(colour, 4)
 
   ## Set general parameters ---------------------------------------------------

--- a/R/plot_Histogram.R
+++ b/R/plot_Histogram.R
@@ -63,8 +63,8 @@
 #'
 #' @param colour [numeric] or [character] (*with default*):
 #' optional vector of length 4 which specifies the colours of the following
-#' plot items in exactly this order: histogram bars, rug lines, normal
-#' distribution curve and standard error points
+#' plot items in exactly this order: histogram bars, rug lines and summary
+#' text, normal distribution curve, standard error points
 #' (e.g., `c("grey", "black", "red", "grey")`).
 #'
 #' @param interactive [logical] (*with default*):
@@ -127,7 +127,7 @@ plot_Histogram <- function(
   normal_curve = FALSE,
   summary = "",
   summary.pos = "sub",
-  colour,
+  colour = c("white", "black", "red", "black"),
   interactive = FALSE,
   ...
 ) {
@@ -157,15 +157,12 @@ plot_Histogram <- function(
                                   "topleft", "top", "topright",
                                   "bottomleft", "bottom", "bottomright"))
   }
+  .validate_length(colour, 4)
 
   ## Set general parameters ---------------------------------------------------
   ## Check/set default parameters
   if(missing(cex.global) == TRUE) {
     cex.global <- 1
-  }
-
-  if(missing(colour) == TRUE) {
-    colour = c("white", "black", "red", "black")
   }
 
   ## read out additional arguments list

--- a/man/plot_Histogram.Rd
+++ b/man/plot_Histogram.Rd
@@ -14,7 +14,7 @@ plot_Histogram(
   normal_curve = FALSE,
   summary = "",
   summary.pos = "sub",
-  colour,
+  colour = c("white", "black", "red", "black"),
   interactive = FALSE,
   ...
 )
@@ -58,8 +58,8 @@ specification, y-coordinate refers to the right y-axis.}
 
 \item{colour}{\link{numeric} or \link{character} (\emph{with default}):
 optional vector of length 4 which specifies the colours of the following
-plot items in exactly this order: histogram bars, rug lines, normal
-distribution curve and standard error points
+plot items in exactly this order: histogram bars, rug lines and summary
+text, normal distribution curve, standard error points
 (e.g., \code{c("grey", "black", "red", "grey")}).}
 
 \item{interactive}{\link{logical} (\emph{with default}):

--- a/tests/testthat/test_plot_Histogram.R
+++ b/tests/testthat/test_plot_Histogram.R
@@ -21,6 +21,8 @@ test_that("input validation", {
                "'summary.pos' should have length 2")
   expect_error(plot_Histogram(df, summary.pos = "error"),
                "'summary.pos' should be one of 'sub', 'left', 'center', 'right'")
+  expect_error(plot_Histogram(df, colour = "black"),
+               "'colour' should have length 4")
   expect_error(plot_Histogram(df, ylim = c(0, 1)),
                "'ylim' should have length 4")
 })


### PR DESCRIPTION
The right margin can be smaller when errors are not plotted, as there is no need to leave space for the standard error axis.

Fixes #748.