### PR TITLE
Don't normalise data if all values are zero

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -213,6 +213,10 @@ reduce redundant calls.
 C++. This cut the required computation times in half in benchmark scenarios. More importantly, 
 this performance scales with the number of Monte Carlo runs. 
 
+### `fit_EmissionSpectra()`
+
+* Fix crash when attempting to plot a frame with non-positive counts (#761).
+
 ### `fit_LMCurve()`
 
 * If the user asks logarithmic scaling in the y-axis, using either `log = "y"`

--- a/NEWS.md
+++ b/NEWS.md
@@ -234,6 +234,11 @@
   scenarios. More importantly, this performance scales with the number
   of Monte Carlo runs.
 
+### `fit_EmissionSpectra()`
+
+- Fix crash when attempting to plot a frame with non-positive counts
+  (#761).
+
 ### `fit_LMCurve()`
 
 - If the user asks logarithmic scaling in the y-axis, using either

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -1,11 +1,13 @@
 #'@title Luminescence Emission Spectra Deconvolution
 #'
-#'@description Luminescence spectra deconvolution on [RLum.Data.Spectrum-class] and [matrix] objects
-#'on an **energy scale**. The function is optimised for emission spectra typically
-#'obtained in the context of TL, OSL and RF measurements detected between 200 and 1000 nm.
-#'The function is not prepared to deconvolve TL curves (counts against temperature;
-#'no wavelength scale). If you are interested in such analysis, please check, e.g.,
-#'the package `'tgcd'`.
+#' @description
+#' This function performes a luminescence spectra deconvolution on
+#' [RLum.Data.Spectrum-class] and [matrix] objects on an **energy scale**.
+#' The function is optimised for emission spectra typically obtained in the
+#' context of TL, OSL and RF  measurements detected between 200 and 1000 nm.
+#' The function is not designed to deconvolve TL curves (counts against
+#' temperature; no wavelength scale). If you are interested in such analysis,
+#' please check, e.g., package `'tgcd'`.
 #'
 #'@details
 #'
@@ -135,7 +137,7 @@
 #' parameter estimation. The grey band in the residual plot indicates the
 #' 10% deviation from 0 (means no residual).
 #'
-#'@section Function version: 0.1.2
+#' @section Function version: 0.1.3
 #'
 #' @author
 #' Sebastian Kreutzer, Institute of Geography, Heidelberg University (Germany)\cr
@@ -384,7 +386,7 @@ fit_EmissionSpectra <- function(
   # set data.frame ------------------------------------------------------------------------------
   df <- data.frame(x = m[,1], y = m[,2]) ##normalise values, it is just easier
 
-  if(method_control$norm[1])
+  if (method_control$norm[1] && max(m[, 2]) > 0)
     df[["y"]] <- df[["y"]]/max(m[,2]) ##normalise values, it is just easier
 
   ## check graining parameter

--- a/man/fit_EmissionSpectra.Rd
+++ b/man/fit_EmissionSpectra.Rd
@@ -94,12 +94,13 @@ parameter estimation. The grey band in the residual plot indicates the
 10\% deviation from 0 (means no residual).
 }
 \description{
-Luminescence spectra deconvolution on \linkS4class{RLum.Data.Spectrum} and \link{matrix} objects
-on an \strong{energy scale}. The function is optimised for emission spectra typically
-obtained in the context of TL, OSL and RF measurements detected between 200 and 1000 nm.
-The function is not prepared to deconvolve TL curves (counts against temperature;
-no wavelength scale). If you are interested in such analysis, please check, e.g.,
-the package \code{'tgcd'}.
+This function performes a luminescence spectra deconvolution on
+\linkS4class{RLum.Data.Spectrum} and \link{matrix} objects on an \strong{energy scale}.
+The function is optimised for emission spectra typically obtained in the
+context of TL, OSL and RF  measurements detected between 200 and 1000 nm.
+The function is not designed to deconvolve TL curves (counts against
+temperature; no wavelength scale). If you are interested in such analysis,
+please check, e.g., package \code{'tgcd'}.
 }
 \details{
 \strong{Used equation}

--- a/tests/testthat/test_fit_EmissionSpectra.R
+++ b/tests/testthat/test_fit_EmissionSpectra.R
@@ -112,3 +112,12 @@ test_that("check functionality", {
       "RLum.Results")
   })
 })
+
+test_that("regression tests", {
+  testthat::skip_on_cran()
+
+  ## issue 761
+  expect_silent(fit_EmissionSpectra(TL.Spectrum, frame = 1, plot = TRUE,
+                                    n_components = 2, verbose = FALSE,
+                                    method_control = list(max.runs = 5)))
+})


### PR DESCRIPTION
This avoids a crash when working on a frame with only negative counts after background subtraction, which by default get replaced by zeros.

Fixes #761.