### PR TITLE
Fix crash in plot_DRTResults() when drawing the polygon if all preheat values are identical

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -274,6 +274,9 @@ starting a parallel cluster even when `multicore = FALSE` (#742).
 * Argument `given.dose` is now better validated against misspecifications
 (#767).
 
+* The function crashed when multiple inputs were used with `boxplot = TRUE`
+and all preheat values were identical (#769).
+
 ### `plot_GrowthCurve()`
 
 * Add support for `OTORX` fit corresponding to the underlying change in `fit_DoseReponseCurve()` (#677)

--- a/NEWS.md
+++ b/NEWS.md
@@ -302,6 +302,9 @@
 - Argument `given.dose` is now better validated against
   misspecifications (#767).
 
+- The function crashed when multiple inputs were used with
+  `boxplot = TRUE` and all preheat values were identical (#769).
+
 ### `plot_GrowthCurve()`
 
 - Add support for `OTORX` fit corresponding to the underlying change in

--- a/R/plot_DRTResults.R
+++ b/R/plot_DRTResults.R
@@ -580,10 +580,10 @@ plot_DRTResults <- function(
             border = col)
 
     ## add axis label, if necessary
-    if (length(modes.plot) == 1) {
-      axis(side = 1, at = 1, labels = modes.plot, las = las)
-
-    } else if (length(modes.plot) > length(unique(modes.plot))){
+    if (length(modes.plot) <= length(unique(modes.plot))) {
+      axis(side = 1, at = 1:length(unique(modes.plot)),
+           labels = unique(modes.plot), las = las)
+    } else {
       ticks <- seq(from = 1 + ((length(values.boxplot)/length(unique(modes.plot)) - 1)/2),
                    to = length(values.boxplot),
                    by = length(values.boxplot)/length(unique(modes.plot)))
@@ -616,9 +616,6 @@ plot_DRTResults <- function(
           col = "grey",
           border = "grey")
       }
-
-    }else{
-      axis(side = 1, at = 1:length(unique(modes.plot)), labels = unique(modes.plot), las = las)
     }
 
     ## add title

--- a/R/plot_DRTResults.R
+++ b/R/plot_DRTResults.R
@@ -601,6 +601,8 @@ plot_DRTResults <- function(
       )
 
       polygon.step <- unique(diff(polygon.x) - 1)
+      if (length(polygon.step) == 0)
+        polygon.step <- 1
 
       for (x.plyg in polygon.x) {
         polygon(

--- a/tests/testthat/test_plot_DRTResults.R
+++ b/tests/testthat/test_plot_DRTResults.R
@@ -99,3 +99,11 @@ test_that("graphical snapshot tests", {
                                               summary = c("mean", "sd.abs")))
   })
 })
+
+test_that("regression tests", {
+  testthat::skip_on_cran()
+
+  ## issue 769
+  expect_silent(plot_DRTResults(list(df, df * 2), preheat = rep(200, 5),
+                                boxplot = TRUE))
+})


### PR DESCRIPTION
Fixes #769.