### PR TITLE
Relax check on the number of preheat temperatures

### DIFF
--- a/R/plot_DRTResults.R
+++ b/R/plot_DRTResults.R
@@ -247,8 +247,9 @@ plot_DRTResults <- function(
 
     ##check for preheat temperature values
     if(missing(preheat) == FALSE) {
-      if(length(preheat) != nrow(values[[i]])){
-        .throw_error("Number of preheat temperatures != De values")
+      if (length(preheat) < nrow(values[[i]])) {
+        .throw_error("'preheat' should have length equal to the number ",
+                     "of De values")
       }
     }
 

--- a/tests/testthat/test_plot_DRTResults.R
+++ b/tests/testthat/test_plot_DRTResults.R
@@ -12,7 +12,7 @@ test_that("input validation", {
   expect_error(plot_DRTResults(list("error")),
                "'values' should be of class 'data.frame' or 'RLum.Results'")
   expect_error(plot_DRTResults(df, preheat = c(200, 240, 240)),
-               "Number of preheat temperatures != De values")
+               "'preheat' should have length equal to the number of De values")
   expect_error(plot_DRTResults(df, given.dose = "error"),
                "'given.dose' should be of class 'numeric'")
   expect_error(plot_DRTResults(df, given.dose = numeric(0)),


### PR DESCRIPTION
With this, it's not a problem anymore to indicate more preheat temperatures than De values, as the entries in excess are ignored. This reduces errors in RLumShiny when a user inputs the secondary dataset manually and this dataset has fewer entries than the primary one.

Fixes #771.