### PR TITLE
Fix scaling of y-axis label in analyse_portableOSL()

### DIFF
--- a/R/analyse_portableOSL.R
+++ b/R/analyse_portableOSL.R
@@ -596,7 +596,7 @@ analyse_portableOSL <- function(
           axis(2, line = 3, at = labs, labels = labs,
                cex.axis = plot_settings$cex)
           mtext(plot_settings$ylab[1], side = 2, line = 6,
-                cex = plot_settings$cex)
+                cex = plot_settings$cex * 0.8)
         }
       }
 

--- a/tests/testthat/_snaps/analyse_portableOSL/profile.svg
+++ b/tests/testthat/_snaps/analyse_portableOSL/profile.svg
@@ -143,7 +143,7 @@
 <text transform='translate(63.89,126.66) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>12</text>
 <text transform='translate(63.89,91.86) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>13</text>
 <text transform='translate(63.89,57.06) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>14</text>
-<text transform='translate(44.88,283.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='52.03px' lengthAdjust='spacingAndGlyphs'>Depth [m]</text>
+<text transform='translate(44.88,283.25) rotate(-90)' text-anchor='middle' style='font-size: 9.60px; font-family: sans;' textLength='41.62px' lengthAdjust='spacingAndGlyphs'>Depth [m]</text>
 </g>
 <defs>
   <clipPath id='cpMjA2LjY2fDI5OC4xMnwzOC45N3w1MjcuNTM='>


### PR DESCRIPTION
This makes the scaling of the y-axis more consistent with the rest of the text. Fixes #810.