### PR TITLE
Add more flexibility to the message reported by .throw_message()

### DIFF
--- a/R/analyse_IRSAR.RF.R
+++ b/R/analyse_IRSAR.RF.R
@@ -1183,8 +1183,8 @@ analyse_IRSAR.RF<- function(
         }
 
         if (verbose)
-          message("[analyse_IRSAR.RF()] Using ", cores,
-                  ifelse(cores == 1, " core", " cores"), " ...")
+          .throw_message("Using ", cores, ifelse(cores == 1, " core", " cores"),
+                         " ...", error = FALSE)
       }
 
       ## SINGLE CORE -----

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -377,13 +377,11 @@ analyse_SAR.TL <- function(
   signal.integral.temperature <- c(object@records[[TL.signal.ID[1]]]@data[signal.integral.min,1] :
                                      object@records[[TL.signal.ID[1]]]@data[signal.integral.max,1])
 
-
   ## warning if number of curves exceeds colour values
   if(length(col)<length(TL.signal.ID/2)){
-    message("\n[analyse_SAR.TL.R()] Warning: Too many curves, ",
-            "only the first ", length(col), " curves are plotted")
+    .throw_message("Too many curves, only the first ", length(col),
+                   " curves are plotted", error = FALSE)
   }
-
 
   # # Plotting TL LnLx Curves ----------------------------------------------------
   ##matrix with LnLx curves

--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -527,8 +527,8 @@ analyse_baSAR <- function(
       ##check and correct for distribution name
       if (!is.null(baSAR_model) && distribution != "user_defined") {
         distribution <- "user_defined"
-        message("[analyse_basAR()] 'baSAR_model' provided, setting ",
-                "distribution to 'user_defined'")
+        .throw_message("'baSAR_model' provided, setting distribution to ",
+                       "'user_defined'", error = FALSE)
       }
 
       # Bayesian Models ----------------------------------------------------------------------------
@@ -1080,8 +1080,8 @@ analyse_baSAR <- function(
 
     if (!all(record.selected)) {
       if (verbose) {
-        message("[analyse_baSAR()] Record pre-selection in BIN-file detected, ",
-                "record reduced to selection\n")
+        .throw_message("Record pre-selection in BIN-file detected, ",
+                       "record reduced to selection\n", error = FALSE)
       }
       if (sum(record.selected) == 0) {
         .throw_warning("No records selected, NULL returned")
@@ -1129,7 +1129,7 @@ analyse_baSAR <- function(
       msg <- paste(.collapse(object.filenames[is.duplicated]),
                    "is a duplicate and therefore removed from the input")
       if(verbose){
-        message("[analyse_baSAR()] ", msg)
+        .throw_message(msg, error = FALSE)
       }
       .throw_warning(msg)
 

--- a/R/analyse_portableOSL.R
+++ b/R/analyse_portableOSL.R
@@ -303,8 +303,8 @@ analyse_portableOSL <- function(
 
   if (mode == "surface" && plot && all(range(summary$COORD_X) == c(0, 0))) {
     plot <- FALSE
-    message("[analyse_portableOSL()] Surface plot is not available when ",
-            "all x-coordinates are 0, plot reset to FALSE")
+    .throw_message("Surface plot is not available when all x-coordinates ",
+                   "are 0, plot reset to FALSE", error = FALSE)
   }
 
   # PLOTTING -------------------------------------------------------------------

--- a/R/calc_CentralDose.R
+++ b/R/calc_CentralDose.R
@@ -118,8 +118,8 @@ calc_CentralDose <- function(
 
   ##remove NA values
   if (anyNA(data)) {
-    message("[calc_CentralDose()] ", length(which(is.na(data))),
-            " NA values removed from dataset")
+    .throw_message(length(which(is.na(data))), " NA values removed from dataset",
+                   error = FALSE)
     data <- na.exclude(data)
   }
 

--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -351,8 +351,8 @@ calc_MinDose <- function(
   }
 
   if (any(!stats::complete.cases(data))) {
-    message("\n[calc_MinDose] Warning: Input data contained NA/NaN values, ",
-            "which were removed prior to calculations!")
+    .throw_message("Warning: Input data contained NA/NaN values, ",
+                   "which were removed prior to calculations", error = FALSE)
     data <- data[stats::complete.cases(data), ]
   }
 

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -101,8 +101,8 @@ calc_WodaFuchs2008 <- function(
 
   ## estimate bin width based on Woda and Fuchs (2008)
   if (all(is.na(data[, 2]))) {
-    message("[calc_WodaFuchs2008()] No errors provided, bin width set ",
-            "by 10 percent of input data")
+    .throw_message("No errors provided, bin width set by 10 percent ",
+                   "of input data", error = FALSE)
     bin_width <- median(data[,1] / 10,
                         na.rm = TRUE)
   } else {

--- a/R/convert_Concentration2DoseRate.R
+++ b/R/convert_Concentration2DoseRate.R
@@ -122,8 +122,8 @@ convert_Concentration2DoseRate <- function(
 
   ## return a template if no input is given
   if (missing(input)) {
-    message("[convert_Concentration2DoseRate()] Input template returned: ",
-            "please fill this data frame and use it as input to the function")
+    .throw_message("Input template returned, please fill this data frame ",
+                   "and use it as input to the function", error = FALSE)
     return(template)
   }
 

--- a/R/convert_Wavelength2Energy.R
+++ b/R/convert_Wavelength2Energy.R
@@ -170,7 +170,8 @@ convert_Wavelength2Energy <- function(
     ##this only works on RLum.Data.Spectrum objects and is sugar for using RLum-objects
     if(any("curveDescripter" %in% names(object@info))){
      if(any(grepl(pattern = "energy", x = tolower(object@info$curveDescripter), fixed = TRUE))){
-         message("[convert_Wavelength2Energy()] Your object has already an energy scale, nothing done!")
+        .throw_message("'object' has already an energy scale, nothing done",
+                       error = FALSE)
          return(object)
      }
     }

--- a/R/extract_IrradiationTimes.R
+++ b/R/extract_IrradiationTimes.R
@@ -414,7 +414,10 @@ extract_IrradiationTimes <- function(
 
       ##set message on the format definition
       if(!inherits(x = try, 'try-error')){
-        message("[extract_IrradiationTimes()] 'Time Since Irradiation' was redefined in the exported BINX-file to: 'Time Since Irradiation' plus the 'Irradiation Time' to be compatible with the Analyst.")
+        .throw_message("'Time Since Irradiation' was redefined in the ",
+                       "exported BINX-file to: 'Time Since Irradiation' plus ",
+                       "'Irradiation Time' to be compatible with the Analyst",
+                       error = FALSE)
       }
     } else {
       .throw_message("XSYG-file and BINX-file do not contain similar entries, ",

--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -574,7 +574,7 @@ fit_DoseResponseCurve <- function(
                  num.params, "dose points, 'fit.method' changed to 'LIN'")
     .throw_warning(msg)
     if (verbose)
-      message("[fit_DoseResponseCurve()] ", msg)
+      .throw_message(msg, error = FALSE)
   }
 
   ## helper to report the fit

--- a/R/fit_LMCurve.R
+++ b/R/fit_LMCurve.R
@@ -403,8 +403,8 @@ fit_LMCurve<- function(
     }
 
     if (verbose) {
-      message("[fit_LMCurve()] >> Background subtracted (method = '",
-              bg.subtraction, "')")
+      .throw_message(">> Background subtracted (method = '",
+                     bg.subtraction, "')", error = FALSE)
     }
   }
 

--- a/R/fit_SurfaceExposure.R
+++ b/R/fit_SurfaceExposure.R
@@ -308,7 +308,7 @@ fit_SurfaceExposure <- function(
   if (anyNA(data)) {
     data <- data[stats::complete.cases(data), ]
     if (settings$verbose)
-      message("[fit_SurfaceExposure()] NA values in 'data' were removed")
+      .throw_message("NA values in 'data' were removed", error = FALSE)
   }
 
   ## extract errors into separate variable
@@ -585,11 +585,11 @@ fit_SurfaceExposure <- function(
     cat("\n")
 
     if (!is.null(age)) {
-      message(paste0("To apply the estimated parameters to a sample of unknown age run:\n\n",
-                     "fit_SurfaceExposure(data = ", capture.output(results$args[[1]]),
-                     ", sigmaphi = ", signif(unique(results$summary$sigmaphi), 3),
-                     ", mu = c(", .collapse(signif(results$summary$mu, 3), quote = FALSE),
-                     "))\n\n"))
+      message("To apply the estimated parameters to a sample of unknown age run:\n\n",
+              "fit_SurfaceExposure(data = ", capture.output(results$args[[1]]),
+              ", sigmaphi = ", signif(unique(results$summary$sigmaphi), 3),
+              ", mu = c(", .collapse(signif(results$summary$mu, 3), quote = FALSE),
+              "))\n")
     }
   }
 

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1065,13 +1065,16 @@ fancy_scientific <- function(l) {
 
 #'@title Throws a Custom Tailored Message
 #'
-#'@param ... the message to throw, preceded by "Error:"
+#' @param ... the message to throw
+#' @param error Whether the message should be preceded by "Error:" (`TRUE` by
+#' default).
 #'
 #'@md
 #'@noRd
-.throw_message <- function(...) {
+.throw_message <- function(..., error = TRUE) {
   top.idx <- length(.LuminescenceEnv$fn_stack)
-  message("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] Error: ", ...)
+  message("[", .LuminescenceEnv$fn_stack[[top.idx]], "()] ",
+          if (error) "Error: ", ...)
 }
 
 #' @title Silence Output and Warnings during Tests

--- a/R/merge_Risoe.BINfileData.R
+++ b/R/merge_Risoe.BINfileData.R
@@ -91,7 +91,8 @@ merge_Risoe.BINfileData <- function(
 
   .validate_class(input.objects, c("character", "list"))
   if(length(input.objects) < 2){
-    message("[merge_Risoe.BINfileData()] Nothing done: at least two input objects are needed!")
+    .throw_message("At least two input objects are needed, nothing done",
+                   error = FALSE)
     return(input.objects)
   }
 

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -502,8 +502,8 @@ plot_AbanicoPlot <- function(
       n.NA <- sum(!stats::complete.cases(data[[i]]))
 
       if (n.NA > 0) {
-        message("[plot_AbanicoPlot()] Data set (", i, "): ", n.NA,
-                " NA value", ifelse (n.NA > 1, "s", ""), " excluded")
+        .throw_message("Data set (", i, "): ", n.NA, " NA value",
+                       ifelse (n.NA > 1, "s", ""), " excluded", error = FALSE)
         data[[i]] <- na.exclude(data[[i]])
       }
     }
@@ -881,7 +881,8 @@ plot_AbanicoPlot <- function(
   ## print message for too small scatter
   if(max(abs(1 / data.global[6])) < 0.02) {
     small.sigma <- TRUE
-    message("[plot_AbanicoPlot()] Attention, small standardised estimate scatter. Toggle off y.axis?")
+    .throw_message("Small standardised estimate scatter, toggle off y.axis?",
+                   error = FALSE)
   }
 
   ## read out additional arguments---------------------------------------------

--- a/R/plot_DetPlot.R
+++ b/R/plot_DetPlot.R
@@ -194,8 +194,8 @@ plot_DetPlot <- function(
       on.exit(parallel::stopCluster(cl), add = TRUE)
 
       if (verbose)
-        message("\n[plot_DetPlot()] Running multicore session using ", cores,
-                " cores ...")
+        .throw_message("Running multicore session using ", cores,
+                       " cores ...", error = FALSE)
       res_list <- parallel::parLapply(cl = cl, X = object, fun = nested.fun)
     } else {
       ## run in serial
@@ -242,7 +242,8 @@ plot_DetPlot <- function(
       (background.integral.min - 1 - signal.integral.max) / (signal.integral.max - signal.integral.min)
     )
     if (verbose) {
-      message("'n.channels' not specified, set to ", n.channels)
+      .throw_message("'n.channels' not specified, set to ", n.channels,
+                     error = FALSE)
     }
   }
 

--- a/R/plot_GrowthCurve.R
+++ b/R/plot_GrowthCurve.R
@@ -165,7 +165,7 @@ plot_GrowthCurve <- function(
 
   if (is.null(fit)) {
     if (verbose)
-      message("[plot_GrowthCurve()] Fitting failed, no plot possible")
+      .throw_message("Fitting failed, no plot possible")
     return(NULL)
   }
 

--- a/R/plot_RLum.Data.Spectrum.R
+++ b/R/plot_RLum.Data.Spectrum.R
@@ -275,8 +275,8 @@ plot_RLum.Data.Spectrum <- function(
     }
 
     object <- set_RLum(class = "RLum.Data.Spectrum", data = object)
-    message("[plot_RLum.Data.Spectrum()] Input has been converted to a ",
-            "'RLum.Data.Spectrum' object using set_RLum()")
+    .throw_message("Input has been converted to an 'RLum.Data.Spectrum' ",
+                   "object using set_RLum()", error = FALSE)
   }
 
   if (length(object@data) < 2) {

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -158,8 +158,8 @@ read_BIN2R <- function(
       ##If this is not really a path we skip this here
       if (all(dir.exists(file)) & length(dir(file)) > 0) {
         if (verbose)
-          message("[read_BIN2R()] Directory detected, trying to extract ",
-                  "'*.bin'/'*.binx' files ...\n")
+          .throw_message("Directory detected, trying to extract ",
+                         "'*.bin'/'*.binx' files ...\n", error = FALSE)
 
         ##get files
         file <- as.list(list.files(
@@ -293,8 +293,8 @@ read_BIN2R <- function(
     if(!is.null(forced.VersionNumber)){
       temp.VERSION <- as.raw(forced.VersionNumber)
       if (verbose)
-        message("[read_BIN2R()] 'forced.VersionNumber' set to ", temp.VERSION,
-                ", but this version may not match your input file")
+        .throw_message("'forced.VersionNumber' set to ", temp.VERSION,
+                       ", but this version may not match your input file", error = FALSE)
     }
 
     ##stop input if wrong VERSION
@@ -332,9 +332,11 @@ read_BIN2R <- function(
     if (num.toread > 0) {
       seek.connection(con, num.toread, origin = "current")
     } else {
-      if (verbose)
-        message("\n[read_BIN2R()] Record #", temp.ID + 1,
-                " skipped due to wrong record length")
+      if (verbose) {
+        message("") # add a newline
+        .throw_message("Record #", temp.ID + 1,
+                       " skipped due to wrong record length", error = FALSE)
+      }
       next()
     }
     temp.ID <- temp.ID + 1
@@ -596,11 +598,13 @@ read_BIN2R <- function(
         ## we can check for a specific value for temp.RECTYPE
         if(inherits(ignore.RECTYPE[1], "numeric") && temp.RECTYPE == ignore.RECTYPE[1]) {
           seek.connection(con, temp.LENGTH - 15, origin = "current")
-            if(verbose)
-              message("\n[read_BIN2R()] Record #", temp.ID + 1,
-                      " skipped due to ignore.RECTYPE setting")
-            next()
+          if(verbose) {
+            message("") # add a newline
+            .throw_message("Record #", temp.ID + 1,
+                           " skipped due to ignore.RECTYPE setting", error = FALSE)
           }
+          next()
+        }
 
         if(temp.RECTYPE != 0 & temp.RECTYPE != 1 & temp.RECTYPE != 128) {
           ##jump to the next record by stepping the record length minus the already read bytes
@@ -612,8 +616,10 @@ read_BIN2R <- function(
           }
 
           ## skip to next record
-          if (verbose)
-            message("\n[read_BIN2R()] ", msg, ", record skipped")
+          if (verbose) {
+            message("") # add a newline
+            .throw_message(msg, ", record skipped", error = FALSE)
+          }
           temp.ID <- temp.ID + 1
           next()
         }
@@ -1102,8 +1108,8 @@ read_BIN2R <- function(
       results.RESERVED <- results.RESERVED[keep.positions]
 
       if (verbose) {
-        message("[read_BIN2R()] Kept records matching 'position': ",
-                .collapse(position, quote = FALSE))
+        .throw_message("Kept records matching 'position': ",
+                       .collapse(position, quote = FALSE), error = FALSE)
       }
     }else{
       .throw_warning("At least one position number is not valid, ",
@@ -1131,7 +1137,7 @@ read_BIN2R <- function(
   ## if nothing is left, return an empty object
   if (nrow(results.METADATA) == 0) {
     if (verbose)
-      message("[read_BIN2R()] Empty object returned")
+      .throw_message("Empty object returned", error = FALSE)
     return(set_Risoe.BINfileData())
   }
 
@@ -1157,8 +1163,8 @@ read_BIN2R <- function(
 
         ##message
         if(verbose) {
-          message("[read_BIN2R()] Duplicated records detected and removed: ",
-                  .collapse(duplication.check, quote = FALSE))
+          .throw_message("Duplicated records detected and removed: ",
+                         .collapse(duplication.check, quote = FALSE), error = FALSE)
         }
 
       } else{
@@ -1174,7 +1180,7 @@ read_BIN2R <- function(
   if (results.METADATA[, .N != n.length || max(ID) > n.length]) {
     results.METADATA[, ID := 1:.N]
     if (verbose)
-      message("[read_BIN2R()] The record index has been recalculated")
+      .throw_message("The record index has been recalculated", error = FALSE)
   }
 
   # Convert Translation Matrix Values ---------------------------------------

--- a/R/read_PSL2R.R
+++ b/R/read_PSL2R.R
@@ -86,8 +86,8 @@ read_PSL2R <- function(
       file <- list.files(file, pattern = ".psl$", full.names = TRUE, ignore.case = TRUE)
       if (length(file) == 0)
         .throw_error("No .psl files found")
-      message("[read_PSL2R()] The following files were found and imported:\n",
-              paste(" ..", file, collapse = "\n"))
+      .throw_message("The following files were found and imported:\n",
+                     paste(" ..", file, collapse = "\n"), error = FALSE)
     }
   }
   if (!all(file.exists(file)))

--- a/R/read_XSYG2R.R
+++ b/R/read_XSYG2R.R
@@ -214,8 +214,8 @@ read_XSYG2R <- function(
     ##If this is not really a path we skip this here
     if (dir.exists(file) & length(dir(file)) > 0) {
       if (verbose)
-        message("\n[read_XSYG2R()] Directory detected, trying to extract ",
-                "'*.xsyg' files ...\n")
+        .throw_message("Directory detected, trying to extract ",
+                       "'*.xsyg' files ...\n", error = FALSE)
       file <- as.list(dir(file, recursive = TRUE, pattern = pattern, full.names = TRUE))
       if (length(file) == 0) {
         if (verbose)

--- a/R/verify_SingleGrainData.R
+++ b/R/verify_SingleGrainData.R
@@ -401,8 +401,8 @@ verify_SingleGrainData <- function(
         if(selection_id_text == "")
           selection_id_text <- "<none>"
 
-        message("[verify_SingleGrainData()] RLum.Analysis object reduced to records: ",
-                selection_id_text)
+        .throw_message("RLum.Analysis object reduced to records: ",
+                       selection_id_text, error = FALSE)
       }
 
       ##selected wanted elements

--- a/R/write_RLum2CSV.R
+++ b/R/write_RLum2CSV.R
@@ -132,7 +132,7 @@ write_RLum2CSV <- function(
   if (export == TRUE) {
     if (is.null(path)) {
       path <- getwd()
-      message("[write_RLum2CSV()] Path automatically set to: ", path)
+      .throw_message("Path automatically set to: ", path, error = FALSE)
     } else if (!dir.exists(path)) {
       .throw_error("Directory provided via the argument 'path' does not exist")
     }

--- a/tests/testthat/test_convert_Wavelength2Energy.R
+++ b/tests/testthat/test_convert_Wavelength2Energy.R
@@ -50,7 +50,8 @@ test_that("check functionality", {
 
   ##test special treatment of RLum.Data.Spectrum objects
   object@info[["curveDescripter"]] <- "energy"
-  expect_message(convert_Wavelength2Energy(object), regexp = "Your object has already an energy scale, nothing done!")
+  expect_message(convert_Wavelength2Energy(object),
+                 "'object' has already an energy scale, nothing done")
   object@info[["curveDescripter"]] <- "wavelength"
   res <- convert_Wavelength2Energy(object)
   expect_equal(res@info[["curveDescripter"]],

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -226,6 +226,32 @@ test_that("Test internals", {
   expect_warning(fun.docall_do(),
                  "[fun.int()] Warning message", fixed = TRUE)
 
+  ## .throw_message() -------------------------------------------------------
+  fun.int <- function(error = TRUE) {
+    .set_function_name("fun.int")
+    on.exit(.unset_function_name(), add = TRUE)
+    .throw_message("Simple message", error = error)
+  }
+  fun.ext <- function(error = TRUE) fun.int(error)
+  fun.docall <- function(error = TRUE) do.call(fun.ext, args = list(error = error))
+  fun.docall_do <- function(error = TRUE) fun.docall(error)
+  expect_message(fun.int(),
+                 "[fun.int()] Error: Simple message", fixed = TRUE)
+  expect_message(fun.ext(),
+                 "[fun.int()] Error: Simple message", fixed = TRUE)
+  expect_message(fun.docall(),
+                 "[fun.int()] Error: Simple message", fixed = TRUE)
+  expect_message(fun.docall_do(),
+                 "[fun.int()] Error: Simple message", fixed = TRUE)
+  expect_message(fun.int(error = FALSE),
+                 "[fun.int()] Simple message", fixed = TRUE)
+  expect_message(fun.ext(error = FALSE),
+                 "[fun.int()] Simple message", fixed = TRUE)
+  expect_message(fun.docall(error = FALSE),
+                 "[fun.int()] Simple message", fixed = TRUE)
+  expect_message(fun.docall_do(error = FALSE),
+                 "[fun.int()] Simple message", fixed = TRUE)
+
   ## SW() ------------------------------------------------------------------
   expect_silent(SW(cat("silenced message")))
   expect_silent(SW(message("silenced message")))

--- a/tests/testthat/test_merge_Risoe.BINfileData.R
+++ b/tests/testthat/test_merge_Risoe.BINfileData.R
@@ -12,7 +12,7 @@ test_that("Test merging", {
   ## nothing done
   input <- "data"
   expect_message(res <- merge_Risoe.BINfileData(input.objects = input),
-                 "Nothing done: at least two input objects are needed")
+                 "At least two input objects are needed, nothing done")
   expect_equal(res, input)
 
   ## expect success

--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -277,7 +277,7 @@ test_that("more coverage", {
   df[,1] <- -df[,1]
   expect_message(
     object = plot_AbanicoPlot(data = df),
-    regexp = "Attention, small standardised estimate scatter. Toggle off y.axis?")
+    regexp = "Small standardised estimate scatter, toggle off y.axis?")
 
   ## test boundaries
   expect_warning(

--- a/tests/testthat/test_plot_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_plot_RLum.Data.Spectrum.R
@@ -38,13 +38,13 @@ test_that("check functionality", {
 
     ##try a matrix as input
     expect_message(plot_RLum.Data.Spectrum(object = m, xaxis.energy = TRUE),
-                   "Input has been converted to a 'RLum.Data.Spectrum' object")
+                   "Input has been converted to an 'RLum.Data.Spectrum' object")
 
     ##remove rownames and column names
     rownames(m) <- NULL
     colnames(m) <- NULL
     expect_message(plot_RLum.Data.Spectrum(object = m),
-        regexp = "Input has been converted to a 'RLum.Data.Spectrum' object")
+                   "Input has been converted to an 'RLum.Data.Spectrum' object")
 
     ## test duplicated column names
     t <- TL.Spectrum


### PR DESCRIPTION
This adds the 'error' argument, with `TRUE` as default value. When it is set to `FALSE`, the message is reported without having "Error: " prepended to it, which allows us to use .throw_message() a bit more often.