### PR TITLE
Don't crash if both trim_range values exceed the number of channels

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -70,3 +70,8 @@ the fit was obtained with mode other than `"extrapolation"` (#820).
 * The normal curve drawn as part of the histogram plot could appear very
 jagged or even as a straight line, as it could happen that too few points
 were actually used when drawing the curve (#843).
+
+## `trim_RLum.Data()`
+
+* The function crashed if both values specified in the `trim_range` argument
+  exceeded the number of channels available (#871).

--- a/NEWS.md
+++ b/NEWS.md
@@ -70,3 +70,8 @@
 - The normal curve drawn as part of the histogram plot could appear very
   jagged or even as a straight line, as it could happen that too few
   points were actually used when drawing the curve (#843).
+
+## `trim_RLum.Data()`
+
+- The function crashed if both values specified in the `trim_range`
+  argument exceeded the number of channels available (#871).

--- a/R/trim_RLum.Data.R
+++ b/R/trim_RLum.Data.R
@@ -97,7 +97,7 @@ trim_RLum.Data <- function(
   .trim_RLum.Data.Curve <- function(object, type, range){
     ## only if type is matched
     if  (any(object@recordType[1] %in% type)) {
-      range[2] <- min(nrow(object@data), range[2])
+      range <- pmin(nrow(object@data), range)
       object@data <- object@data[range[1]:range[2], , drop = FALSE]
     }
     object
@@ -107,7 +107,7 @@ trim_RLum.Data <- function(
   .trim_RLum.Data.Spectrum <- function(object, type, range){
     ## only if type is matched
     if (any(object@recordType[1] %in% type)) {
-      range[2] <- min(ncol(object@data), range[2])
+      range <- pmin(ncol(object@data), range)
       object@data <- object@data[, range[1]:range[2], drop = FALSE]
     }
     object

--- a/tests/testthat/test_trim_RLum.Data.R
+++ b/tests/testthat/test_trim_RLum.Data.R
@@ -21,8 +21,6 @@ test_that("RLum.Data.Curve", {
   t <- testthat::expect_type(
     object = trim_RLum.Data(temp$TL, trim_range = c(20,50)),
     type = "list")
-
-  ## check output length
   testthat::expect_length(
     object = t[[1]]@data[,1], n = 31)
 
@@ -30,8 +28,6 @@ test_that("RLum.Data.Curve", {
   t <- testthat::expect_type(
     object = trim_RLum.Data(temp$TL, trim_range = c(50)),
     type = "list")
-
-  ## check output length
   testthat::expect_length(
     object = t[[1]]@data[,1], n = 50)
 
@@ -39,8 +35,6 @@ test_that("RLum.Data.Curve", {
   t <- testthat::expect_type(
     object = trim_RLum.Data(temp$TL, trim_range = NULL),
     type = "list")
-
-  ## check output length
   testthat::expect_length(
     object = t[[1]]@data[,1], n = 250)
 
@@ -50,8 +44,6 @@ test_that("RLum.Data.Curve", {
   t <- testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], recordType = "OSL", trim_range = NULL),
     class = "RLum.Data.Curve")
-
-  ## check output length
   testthat::expect_length(
     object = t@data[,1], n = 250)
 
@@ -68,19 +60,27 @@ test_that("RLum.Data.Curve", {
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(-1)),
     class = "RLum.Data.Curve")
+
   ## c(0, 1)
   t <- trim_RLum.Data(temp@records[[1]], trim_range = c(0, 1))
   expect_equal(nrow(t@data), 1)
+
   ## c(-10, -20)
   t <- trim_RLum.Data(temp@records[[1]], trim_range = c(-10, -20))
   expect_equal(nrow(t@data), 11)
+
   ## c(1025, 2)
   t <- trim_RLum.Data(temp@records[[1]], trim_range = c(1025, 2))
   expect_equal(nrow(t@data), 249)
+
   ## c(1,2,3)
   testthat::expect_s4_class(
     object = trim_RLum.Data(temp@records[[1]], trim_range = c(1:3)),
     class = "RLum.Data.Curve")
+
+  ## c(265, 270)
+  t <- trim_RLum.Data(temp@records[[1]], trim_range = c(265, 270))
+  expect_equal(nrow(t@data), 1)
 })
 
 test_that("RLum.Data.Spectrum", {
@@ -94,6 +94,11 @@ test_that("RLum.Data.Spectrum", {
     object = trim_RLum.Data(TL.Spectrum, trim_range = c(2, 4)),
     class = "RLum.Data.Spectrum")
   testthat::expect_length(object = t@data[1,], n = 3)
+
+  ## both values in the range exceeding the number of channels
+  t <- expect_s4_class(trim_RLum.Data(TL.Spectrum, trim_range = c(265, 270)),
+                       "RLum.Data.Spectrum")
+  expect_length(ncol(t@data), 1)
 
   ## RLum.Analysis object with RLum.Data.Spectrum data
   obj <- set_RLum("RLum.Analysis", records = list(TL.Spectrum))
@@ -138,18 +143,15 @@ test_that("RLum.Analysis", {
  t <- testthat::expect_s4_class(
    object = trim_RLum.Data(temp, trim_range = c(10,20)),
    class = "RLum.Analysis")
-
- ## check for two curves
  testthat::expect_length(
    object = t@records[[4]]@data[,1], n = 11)
  testthat::expect_length(
    object = t@records[[1]]@data[,1], n = 11)
 
- ## apply a trimming to TL curves only
+ ## apply a trimming to OSL curves only
  t <- testthat::expect_s4_class(
    object = trim_RLum.Data(temp, recordType = "OSL", trim_range = c(10,20)),
    class = "RLum.Analysis")
- ## check for two curves
  testthat::expect_length(
    object = t@records[[4]]@data[,1], n = 11)
  testthat::expect_length(


### PR DESCRIPTION
Fixes #871.