### PR TITLE
Fix z-axis ticks and labels if log.z = FALSE

### DIFF
--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -1841,7 +1841,7 @@ plot_AbanicoPlot <- function(
 
     ## plot minor z-ticks
     for(i in 1:length(tick.values.minor)) {
-      lines(x = y.max + c(0, 0.15 * layout$abanico$dimension$ztcl / 100),
+      lines(x = y.max * c(1, 1 + 0.007 * layout$abanico$dimension$ztcl / 100),
             y = c(tick.values.minor[i] - z.central.global,
                   tick.values.minor[i] - z.central.global) * min(ellipse[, 1]),
             col = layout$abanico$colour$ztck)
@@ -1849,7 +1849,7 @@ plot_AbanicoPlot <- function(
 
     ## plot major z-ticks
     for(i in 1:length(tick.values.major)) {
-      lines(x = y.max + c(0, 0.3 * layout$abanico$dimension$ztcl / 100),
+      lines(x = y.max * c(1, 1 + 0.015 * layout$abanico$dimension$ztcl / 100),
             y = c(tick.values.major[i] - z.central.global,
                   tick.values.major[i] - z.central.global) * min(ellipse[, 1]),
             col = layout$abanico$colour$ztck)
@@ -1860,9 +1860,8 @@ plot_AbanicoPlot <- function(
     lines(rep(par()$usr[2], nrow(ellipse)), ellipse[,2],
           col = layout$abanico$colour$ztck)
 
-
     ## plot z-axis text
-    text(x = y.max + 0.4 * layout$abanico$dimension$ztcl / 100,
+    text(x = y.max * (1 + 0.02 * layout$abanico$dimension$ztcl / 100),
          y = (tick.values.major - z.central.global) * min(ellipse[,1]),
          labels = label.z.text,
          adj = c(0, 0.5),
@@ -2173,7 +2172,7 @@ plot_AbanicoPlot <- function(
 
     ## plot minor z-ticks
     for(i in 1:length(tick.values.minor)) {
-      lines(y = y.max + c(0, 0.15 * layout$abanico$dimension$ztcl / 100),
+      lines(y = y.max * c(1, 1 + 0.007 * layout$abanico$dimension$ztcl / 100),
             x = c((tick.values.minor[i] - z.central.global) *
                     min(ellipse[,2]),
                   (tick.values.minor[i] - z.central.global) *
@@ -2183,7 +2182,7 @@ plot_AbanicoPlot <- function(
 
     ## plot major z-ticks
     for(i in 1:length(tick.values.major)) {
-      lines(y = y.max + c(0, 0.3 * layout$abanico$dimension$ztcl / 100),
+      lines(y = y.max * c(1, 1 + 0.015 * layout$abanico$dimension$ztcl / 100),
             x = c((tick.values.major[i] - z.central.global) *
                     min(ellipse[,2]),
                   (tick.values.major[i] - z.central.global) *
@@ -2198,7 +2197,7 @@ plot_AbanicoPlot <- function(
           col = layout$abanico$colour$ztck)
 
     ## plot z-axis text
-    text(y = y.max + 0.4 * layout$abanico$dimension$ztcl / 100,
+    text(y = y.max * (1 + 0.02 * layout$abanico$dimension$ztcl / 100),
          x = (tick.values.major - z.central.global) * min(ellipse[,2]),
          labels = label.z.text,
          adj = c(0.5, 0),

--- a/tests/testthat/_snaps/plot_AbanicoPlot/default.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/default.svg
@@ -67,43 +67,43 @@
 <text x='50.40' y='210.84' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
 <text x='50.40' y='193.36' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
 <text x='50.40' y='175.88' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='619.20,348.66 623.27,348.66 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,317.29 623.27,317.29 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,291.65 623.27,291.65 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,269.98 623.27,269.98 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,251.21 623.27,251.21 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,234.65 623.27,234.65 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,219.83 623.27,219.83 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,206.43 623.27,206.43 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,194.20 623.27,194.20 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,182.95 623.27,182.95 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,172.53 623.27,172.53 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,162.83 623.27,162.83 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,153.75 623.27,153.75 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,145.23 623.27,145.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,137.19 623.27,137.19 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,129.59 623.27,129.59 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,122.38 623.27,122.38 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,115.52 623.27,115.52 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,108.98 623.27,108.98 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,102.73 623.27,102.73 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,96.75 623.27,96.75 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,91.01 623.27,91.01 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,85.49 623.27,85.49 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,348.66 627.34,348.66 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,251.21 627.34,251.21 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,194.20 627.34,194.20 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,153.75 627.34,153.75 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,122.38 627.34,122.38 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,96.75 627.34,96.75 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,348.66 623.08,348.66 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,317.29 623.08,317.29 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,291.65 623.08,291.65 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,269.98 623.08,269.98 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,251.21 623.08,251.21 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,234.65 623.08,234.65 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,219.83 623.08,219.83 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,206.43 623.08,206.43 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,194.20 623.08,194.20 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,182.95 623.08,182.95 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,172.53 623.08,172.53 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,162.83 623.08,162.83 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,153.75 623.08,153.75 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,145.23 623.08,145.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,137.19 623.08,137.19 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,129.59 623.08,129.59 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,122.38 623.08,122.38 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,115.52 623.08,115.52 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,108.98 623.08,108.98 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,102.73 623.08,102.73 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,96.75 623.08,96.75 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,91.01 623.08,91.01 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,85.49 623.08,85.49 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,348.66 627.52,348.66 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,251.21 627.52,251.21 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,194.20 627.52,194.20 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,153.75 627.52,153.75 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,122.38 627.52,122.38 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,96.75 627.52,96.75 ' style='stroke-width: 0.75;' />
 <polyline points='501.39,368.10 501.39,82.44 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,368.10 619.20,82.44 ' style='stroke-width: 0.75;' />
-<text x='630.06' y='352.79' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='630.06' y='255.34' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='630.06' y='198.33' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='630.06' y='157.88' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='630.06' y='126.51' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='630.06' y='100.88' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='630.29' y='352.79' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='630.29' y='255.34' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='630.29' y='198.33' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='630.29' y='157.88' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='630.29' y='126.51' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='630.29' y='100.88' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
 <text transform='translate(678.63,244.61) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text transform='translate(680.85,235.94) rotate(-90)' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text transform='translate(678.63,231.27) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>

--- a/tests/testthat/_snaps/plot_AbanicoPlot/dispersion-error-bars.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/dispersion-error-bars.svg
@@ -90,20 +90,20 @@
 <polyline points='619.20,83.80 623.08,83.80 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,77.88 623.08,77.88 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,72.19 623.08,72.19 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,343.58 626.95,343.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,243.08 626.95,243.08 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,184.29 626.95,184.29 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,142.58 626.95,142.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,110.23 626.95,110.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,83.80 626.95,83.80 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,343.58 627.52,343.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,243.08 627.52,243.08 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,184.29 627.52,184.29 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,142.58 627.52,142.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,110.23 627.52,110.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,83.80 627.52,83.80 ' style='stroke-width: 0.75;' />
 <polyline points='480.60,363.63 480.60,69.04 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,363.63 619.20,69.04 ' style='stroke-width: 0.75;' />
-<text x='629.54' y='347.71' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='629.54' y='247.21' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='629.54' y='188.42' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='629.54' y='146.71' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='629.54' y='114.36' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='629.54' y='87.92' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='630.29' y='347.71' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='630.29' y='247.21' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='630.29' y='188.42' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='630.29' y='146.71' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='630.29' y='114.36' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='630.29' y='87.92' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
 <text transform='translate(678.63,235.68) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text transform='translate(680.85,227.01) rotate(-90)' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text transform='translate(678.63,222.34) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>

--- a/tests/testthat/_snaps/plot_AbanicoPlot/dots-cex.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/dots-cex.svg
@@ -112,43 +112,43 @@
 <line x1='64.80' y1='161.14' x2='57.60' y2='161.14' style='stroke-width: 0.75;' />
 <text x='50.40' y='205.45' text-anchor='end' style='font-size: 24.00px; font-family: sans;' textLength='21.34px' lengthAdjust='spacingAndGlyphs'>-2</text>
 <text x='50.40' y='169.40' text-anchor='end' style='font-size: 24.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='619.20,343.58 623.27,343.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,311.23 623.27,311.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,284.79 623.27,284.79 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,262.44 623.27,262.44 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,243.08 623.27,243.08 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,226.00 623.27,226.00 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,210.73 623.27,210.73 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,196.91 623.27,196.91 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,184.29 623.27,184.29 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,172.69 623.27,172.69 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,161.94 623.27,161.94 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,151.94 623.27,151.94 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,142.58 623.27,142.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,133.79 623.27,133.79 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,125.51 623.27,125.51 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,117.67 623.27,117.67 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,110.23 623.27,110.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,103.16 623.27,103.16 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,96.41 623.27,96.41 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,89.97 623.27,89.97 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,83.80 623.27,83.80 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,77.88 623.27,77.88 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,72.19 623.27,72.19 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,343.58 627.34,343.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,243.08 627.34,243.08 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,184.29 627.34,184.29 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,142.58 627.34,142.58 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,110.23 627.34,110.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,83.80 627.34,83.80 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,343.58 623.08,343.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,311.23 623.08,311.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,284.79 623.08,284.79 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,262.44 623.08,262.44 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,243.08 623.08,243.08 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,226.00 623.08,226.00 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,210.73 623.08,210.73 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,196.91 623.08,196.91 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,184.29 623.08,184.29 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,172.69 623.08,172.69 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,161.94 623.08,161.94 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,151.94 623.08,151.94 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,142.58 623.08,142.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,133.79 623.08,133.79 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,125.51 623.08,125.51 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,117.67 623.08,117.67 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,110.23 623.08,110.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,103.16 623.08,103.16 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,96.41 623.08,96.41 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,89.97 623.08,89.97 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,83.80 623.08,83.80 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,77.88 623.08,77.88 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,72.19 623.08,72.19 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,343.58 627.52,343.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,243.08 627.52,243.08 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,184.29 627.52,184.29 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,142.58 627.52,142.58 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,110.23 627.52,110.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,83.80 627.52,83.80 ' style='stroke-width: 0.75;' />
 <polyline points='501.39,363.63 501.39,69.04 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,363.63 619.20,69.04 ' style='stroke-width: 0.75;' />
-<text x='630.06' y='351.84' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='630.06' y='251.34' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='630.06' y='192.55' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='630.06' y='150.84' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='630.06' y='118.49' style='font-size: 24.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='630.06' y='92.05' style='font-size: 24.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='630.29' y='351.84' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='630.29' y='251.34' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='630.29' y='192.55' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='630.29' y='150.84' style='font-size: 24.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='630.29' y='118.49' style='font-size: 24.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='630.29' y='92.05' style='font-size: 24.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>120</text>
 <text transform='translate(686.22,255.02) rotate(-90)' style='font-size: 24.00px; font-family: sans;' textLength='17.34px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text transform='translate(690.66,237.68) rotate(-90)' style='font-size: 16.80px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text transform='translate(686.22,228.34) rotate(-90)' style='font-size: 24.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'> </text>

--- a/tests/testthat/_snaps/plot_AbanicoPlot/line-frame-legend-rotated.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/line-frame-legend-rotated.svg
@@ -71,45 +71,45 @@
 <line x1='360.00' y1='518.40' x2='360.00' y2='525.60' style='stroke-width: 0.75;' />
 <line x1='369.90' y1='518.40' x2='369.90' y2='525.60' style='stroke-width: 0.75;' />
 <text x='350.10' y='544.32' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='12.80px' lengthAdjust='spacingAndGlyphs'>-2</text>
-<polyline points='198.39,115.20 198.39,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='211.13,115.20 211.13,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='223.88,115.20 223.88,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='236.62,115.20 236.62,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='249.36,115.20 249.36,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='262.10,115.20 262.10,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='274.84,115.20 274.84,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='287.58,115.20 287.58,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='300.33,115.20 300.33,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='313.07,115.20 313.07,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='325.81,115.20 325.81,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='338.55,115.20 338.55,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='351.29,115.20 351.29,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='364.03,115.20 364.03,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='376.77,115.20 376.77,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='389.52,115.20 389.52,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='402.26,115.20 402.26,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='415.00,115.20 415.00,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='427.74,115.20 427.74,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='440.48,115.20 440.48,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='453.22,115.20 453.22,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='465.97,115.20 465.97,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='478.71,115.20 478.71,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='491.45,115.20 491.45,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='504.19,115.20 504.19,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='516.93,115.20 516.93,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='529.67,115.20 529.67,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='542.42,115.20 542.42,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='555.16,115.20 555.16,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='567.90,115.20 567.90,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='580.64,115.20 580.64,22.67 ' style='stroke-width: 0.75;' />
-<polyline points='274.84,115.20 274.84,-69.87 ' style='stroke-width: 0.75;' />
-<polyline points='402.26,115.20 402.26,-69.87 ' style='stroke-width: 0.75;' />
-<polyline points='529.67,115.20 529.67,-69.87 ' style='stroke-width: 0.75;' />
+<polyline points='198.39,115.20 198.39,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='211.13,115.20 211.13,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='223.88,115.20 223.88,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='236.62,115.20 236.62,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='249.36,115.20 249.36,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='262.10,115.20 262.10,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='274.84,115.20 274.84,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='287.58,115.20 287.58,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='300.33,115.20 300.33,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='313.07,115.20 313.07,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='325.81,115.20 325.81,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='338.55,115.20 338.55,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='351.29,115.20 351.29,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='364.03,115.20 364.03,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='376.77,115.20 376.77,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='389.52,115.20 389.52,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='402.26,115.20 402.26,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='415.00,115.20 415.00,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='427.74,115.20 427.74,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='440.48,115.20 440.48,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='453.22,115.20 453.22,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='465.97,115.20 465.97,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='478.71,115.20 478.71,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='491.45,115.20 491.45,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='504.19,115.20 504.19,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='516.93,115.20 516.93,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='529.67,115.20 529.67,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='542.42,115.20 542.42,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='555.16,115.20 555.16,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='567.90,115.20 567.90,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='580.64,115.20 580.64,112.38 ' style='stroke-width: 0.75;' />
+<polyline points='274.84,115.20 274.84,109.15 ' style='stroke-width: 0.75;' />
+<polyline points='402.26,115.20 402.26,109.15 ' style='stroke-width: 0.75;' />
+<polyline points='529.67,115.20 529.67,109.15 ' style='stroke-width: 0.75;' />
 <polyline points='192.00,200.88 586.07,200.88 ' style='stroke-width: 0.75;' />
 <polyline points='192.00,115.20 586.07,115.20 ' style='stroke-width: 0.75;' />
-<text x='274.84' y='-131.56' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text x='402.26' y='-131.56' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='529.67' y='-131.56' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>150</text>
+<text x='274.84' y='107.14' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='402.26' y='107.14' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='529.67' y='107.14' text-anchor='middle' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>150</text>
 <text x='336.79' y='82.11' style='font-size: 14.40px; font-family: sans;' textLength='10.40px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text x='347.19' y='84.78' style='font-size: 10.08px; font-family: sans;' textLength='5.61px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text x='352.80' y='82.11' style='font-size: 14.40px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'> </text>

--- a/tests/testthat/_snaps/plot_AbanicoPlot/line-frame-legend.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/line-frame-legend.svg
@@ -73,45 +73,45 @@
 <line x1='64.80' y1='251.56' x2='57.60' y2='251.56' style='stroke-width: 0.75;' />
 <text x='50.40' y='271.07' text-anchor='end' style='font-size: 14.40px; font-family: sans;' textLength='12.80px' lengthAdjust='spacingAndGlyphs'>-2</text>
 <text x='50.40' y='256.52' text-anchor='end' style='font-size: 14.40px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='619.20,394.34 746.43,394.34 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,384.98 746.43,384.98 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,375.62 746.43,375.62 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,366.27 746.43,366.27 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,356.91 746.43,356.91 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,347.55 746.43,347.55 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,338.19 746.43,338.19 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,328.83 746.43,328.83 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,319.47 746.43,319.47 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,310.11 746.43,310.11 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,300.75 746.43,300.75 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,291.39 746.43,291.39 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,282.03 746.43,282.03 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,272.67 746.43,272.67 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,263.31 746.43,263.31 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,253.95 746.43,253.95 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,244.59 746.43,244.59 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,235.23 746.43,235.23 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,225.87 746.43,225.87 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,216.52 746.43,216.52 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,207.16 746.43,207.16 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,197.80 746.43,197.80 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,188.44 746.43,188.44 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,179.08 746.43,179.08 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,169.72 746.43,169.72 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,160.36 746.43,160.36 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,151.00 746.43,151.00 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,141.64 746.43,141.64 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,132.28 746.43,132.28 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,122.92 746.43,122.92 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,113.56 746.43,113.56 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,338.19 873.67,338.19 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,244.59 873.67,244.59 ' style='stroke-width: 0.75;' />
-<polyline points='619.20,151.00 873.67,151.00 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,394.34 623.08,394.34 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,384.98 623.08,384.98 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,375.62 623.08,375.62 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,366.27 623.08,366.27 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,356.91 623.08,356.91 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,347.55 623.08,347.55 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,338.19 623.08,338.19 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,328.83 623.08,328.83 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,319.47 623.08,319.47 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,310.11 623.08,310.11 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,300.75 623.08,300.75 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,291.39 623.08,291.39 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,282.03 623.08,282.03 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,272.67 623.08,272.67 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,263.31 623.08,263.31 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,253.95 623.08,253.95 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,244.59 623.08,244.59 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,235.23 623.08,235.23 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,225.87 623.08,225.87 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,216.52 623.08,216.52 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,207.16 623.08,207.16 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,197.80 623.08,197.80 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,188.44 623.08,188.44 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,179.08 623.08,179.08 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,169.72 623.08,169.72 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,160.36 623.08,160.36 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,151.00 623.08,151.00 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,141.64 623.08,141.64 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,132.28 623.08,132.28 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,122.92 623.08,122.92 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,113.56 623.08,113.56 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,338.19 627.52,338.19 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,244.59 627.52,244.59 ' style='stroke-width: 0.75;' />
+<polyline points='619.20,151.00 627.52,151.00 ' style='stroke-width: 0.75;' />
 <polyline points='501.39,399.04 501.39,109.58 ' style='stroke-width: 0.75;' />
 <polyline points='619.20,399.04 619.20,109.58 ' style='stroke-width: 0.75;' />
-<text x='958.49' y='343.14' style='font-size: 14.40px; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text x='958.49' y='249.55' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='958.49' y='155.96' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>150</text>
+<text x='630.29' y='343.14' style='font-size: 14.40px; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='630.29' y='249.55' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='630.29' y='155.96' style='font-size: 14.40px; font-family: sans;' textLength='24.03px' lengthAdjust='spacingAndGlyphs'>150</text>
 <text transform='translate(680.15,277.52) rotate(-90)' style='font-size: 14.40px; font-family: sans;' textLength='10.40px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text transform='translate(682.81,267.12) rotate(-90)' style='font-size: 10.08px; font-family: sans;' textLength='5.61px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text transform='translate(680.15,261.51) rotate(-90)' style='font-size: 14.40px; font-family: sans;' textLength='4.00px' lengthAdjust='spacingAndGlyphs'> </text>

--- a/tests/testthat/_snaps/plot_AbanicoPlot/rotated.svg
+++ b/tests/testthat/_snaps/plot_AbanicoPlot/rotated.svg
@@ -135,20 +135,20 @@
 <polyline points='446.86,86.40 446.86,83.38 ' style='stroke-width: 0.75;' />
 <polyline points='452.25,86.40 452.25,83.38 ' style='stroke-width: 0.75;' />
 <polyline points='457.43,86.40 457.43,83.38 ' style='stroke-width: 0.75;' />
-<polyline points='210.26,86.40 210.26,80.36 ' style='stroke-width: 0.75;' />
-<polyline points='301.79,86.40 301.79,80.36 ' style='stroke-width: 0.75;' />
-<polyline points='355.33,86.40 355.33,80.36 ' style='stroke-width: 0.75;' />
-<polyline points='393.32,86.40 393.32,80.36 ' style='stroke-width: 0.75;' />
-<polyline points='422.78,86.40 422.78,80.36 ' style='stroke-width: 0.75;' />
-<polyline points='446.86,86.40 446.86,80.36 ' style='stroke-width: 0.75;' />
+<polyline points='210.26,86.40 210.26,79.92 ' style='stroke-width: 0.75;' />
+<polyline points='301.79,86.40 301.79,79.92 ' style='stroke-width: 0.75;' />
+<polyline points='355.33,86.40 355.33,79.92 ' style='stroke-width: 0.75;' />
+<polyline points='393.32,86.40 393.32,79.92 ' style='stroke-width: 0.75;' />
+<polyline points='422.78,86.40 422.78,79.92 ' style='stroke-width: 0.75;' />
+<polyline points='446.86,86.40 446.86,79.92 ' style='stroke-width: 0.75;' />
 <polyline points='192.00,194.40 460.30,194.40 ' style='stroke-width: 0.75;' />
 <polyline points='192.00,86.40 460.30,86.40 ' style='stroke-width: 0.75;' />
-<text x='210.26' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='301.79' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='355.33' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='393.32' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='422.78' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='446.86' y='78.34' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='210.26' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='301.79' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='355.33' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='393.32' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='422.78' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='446.86' y='77.76' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
 <text x='340.66' y='55.83' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
 <text x='349.33' y='58.05' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text x='354.00' y='55.83' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'> </text>


### PR DESCRIPTION
This fixes a regression introduced in 66a21349. Only the two snapshots with `log.z = FALSE` have a visible improvement, the others have only an almost imperceptible change

Fixes #877.