### PR TITLE
Improve validation against lists of length 2

### DIFF
--- a/R/plot_NRt.R
+++ b/R/plot_NRt.R
@@ -134,9 +134,13 @@ plot_NRt <- function(data, log = FALSE, smooth = c("none", "spline", "rmean"), k
   if (inherits(data, "list")) {
     if (length(data) < 2)
       .throw_error("'data' contains only curve data for the natural signal")
-    if (all(sapply(data, class) == "RLum.Data.Curve") ||
-        all(sapply(data, class) == "RLum.Analysis"))
+    class.data <- sapply(data, function(x) class(x)[1])
+    if (all(class.data == "RLum.Data.Curve") || all(class.data == "RLum.Analysis"))
       curves <- lapply(data, get_RLum)
+    else if (all(class.data == "data.frame") || all(class.data == "matrix"))
+      curves <- data
+    else
+      .throw_error("'data' doesn't contain the expected type of elements")
   }
   else if (inherits(data, "data.frame") || inherits(data, "matrix")) {
     if (ncol(data) < 3)

--- a/tests/testthat/test_plot_NRt.R
+++ b/tests/testthat/test_plot_NRt.R
@@ -15,6 +15,8 @@ test_that("input validation", {
                 "'data' contains only curve data for the natural signal")
   expect_error(plot_NRt(curves[[1]]@data),
                 "'data' contains only curve data for the natural signal")
+  expect_error(plot_NRt(list(a = 1, b = 2)),
+                "'data' doesn't contain the expected type of elements")
   expect_error(plot_NRt(curves, smooth = "error"),
                "'smooth' should be one of 'none', 'spline' or 'rmean'")
 
@@ -42,6 +44,8 @@ test_that("check functionality", {
 
   ## list
   expect_silent(plot_NRt(curves))
+  expect_silent(plot_NRt(list(get_RLum(curves[[1]]),
+                              get_RLum(curves[[2]]))))
   expect_silent(plot_NRt(curves, smooth = "spline", log = "x"))
 
   small <- curves[1:3]


### PR DESCRIPTION
This also adds support for lists of data.frames or matrices, as according to the docs they are supported.

Fixes #893.