### PR TITLE
Don't assume that class always returns a single value in .rm_nonRLum()

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -581,7 +581,7 @@ fancy_scientific <- function(l) {
   if(is.null(class))
     return(x[vapply(x, inherits, logical(1), "RLum")])
 
-  x[vapply(x, function(x) class(x)[1] == class[1], logical(1))]
+  x[vapply(x, \(x) class(x)[1] == class[1], logical(1))]
 }
 
 #++++++++++++++++++++++++++++++

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -581,7 +581,7 @@ fancy_scientific <- function(l) {
   if(is.null(class))
     return(x[vapply(x, inherits, logical(1), "RLum")])
 
-  x[vapply(x, "class", character(1)) == class[1]]
+  x[vapply(x, function(x) class(x)[1] == class[1], logical(1))]
 }
 
 #++++++++++++++++++++++++++++++

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -144,6 +144,10 @@ test_that("Test internals", {
       c(list(set_RLum("RLum.Analysis"), set_RLum("RLum.Analysis")), 2), class = "RLum.Analysis"),
     "list")
 
+  ## regression test for issue 907
+  expect_length(Luminescence:::.rm_nonRLum(list(matrix(iris)), "RLum.Analysis"),
+                0)
+
   # .rm_NULL_elements() -----------------------------------------------------------
   expect_type(.rm_NULL_elements(list("a", NULL)),
     "list")


### PR DESCRIPTION
For example, a matrix has classes "matrix" and "array".

Fixes #907.