### PR TITLE
Don't leave FNAME empty in read_BIN2R()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -158,6 +158,13 @@ the fit was obtained with mode other than `"extrapolation"` (#820).
 jagged or even as a straight line, as it could happen that too few points
 were actually used when drawing the curve (#843).
 
+### `read_BIN2R()`
+
+* The `FNAME` metadata field is no longer left empty if the BIN-file didn't
+specify one, but it's populated with the BIN-file name without extension.
+This is the behaviour that was present up to version 0.9.26, but version 1.0.0
+had regressed it.
+
 ### `read_XSYG2R()`
 
 * Add support for the new function `correct_PMTLinearity()` (#920).

--- a/NEWS.md
+++ b/NEWS.md
@@ -168,6 +168,13 @@
   jagged or even as a straight line, as it could happen that too few
   points were actually used when drawing the curve (#843).
 
+### `read_BIN2R()`
+
+- The `FNAME` metadata field is no longer left empty if the BIN-file
+  didn’t specify one, but it’s populated with the BIN-file name without
+  extension. This is the behaviour that was present up to version
+  0.9.26, but version 1.0.0 had regressed it.
+
 ### `read_XSYG2R()`
 
 - Add support for the new function `correct_PMTLinearity()` (#920).

--- a/R/read_BIN2R.R
+++ b/R/read_BIN2R.R
@@ -1210,7 +1210,7 @@ read_BIN2R <- function(
 
   ## check for empty BIN-files names ... if so, set the name of the file as BIN-file name
   ## This can happen if the user uses different equipment
-  if (results.METADATA[, all(is.na(FNAME))]) {
+  if (results.METADATA[, all(FNAME == "")]) {
     results.METADATA[, FNAME := tools::file_path_sans_ext(basename(file))]
   }
 

--- a/tests/testthat/_snaps/read_BIN2R.md
+++ b/tests/testthat/_snaps/read_BIN2R.md
@@ -116,7 +116,7 @@
             {
               "type": "character",
               "attributes": {},
-              "value": ["", ""]
+              "value": ["read_BIN22R_FILE", "read_BIN22R_FILE"]
             },
             {
               "type": "character",
@@ -604,7 +604,7 @@
             {
               "type": "character",
               "attributes": {},
-              "value": ["", ""]
+              "value": ["BINfile_V4", "BINfile_V4"]
             },
             {
               "type": "character",

--- a/tests/testthat/test_read_BIN2R.R
+++ b/tests/testthat/test_read_BIN2R.R
@@ -83,8 +83,11 @@ test_that("test the import of various BIN-file versions", {
                           "raw/archive/dev_0.9.x/tests/testthat/_data")
   if (!httr::http_error(github.url)) {
     ## V3
-    expect_snapshot_plain(read_BIN2R(file.path(github.url, "BINfile_V3.bin"),
-                                     verbose = FALSE))
+    bin <- read_BIN2R(file.path(github.url, "BINfile_V3.bin"),
+                      verbose = FALSE)
+    ## remove randomness in FNAME due to the use of a temporary file
+    bin@METADATA$FNAME <- substr(bin@METADATA$FNAME, 1, 16)
+    expect_snapshot_plain(bin)
   }
 
   ## V4


### PR DESCRIPTION
Since 57e48422, FNAME is initialised to the empty string rather than to NA, so checking for NA to establish if the field is empty is wrong.

This fixes #928 and brings coverage for this file to 100%.