### PR TITLE
Compute the correct dimension in report_RLum()

### DIFF
--- a/R/report_RLum.R
+++ b/R/report_RLum.R
@@ -662,10 +662,10 @@ report_RLum <- function(
   length(strsplit(x, split = "\\$|@|\\[\\[")[[1]]) - 1
 }
 .dimension <- function(x) {
-  if (!is.null(dim(x)))
-    dim <- paste(dim(x), collapse = "|")
-  else
-    dim <- c(0, 0)
+  ## ensure `dim` is padded with zeros if its length is shorter than 2
+  dim <- numeric(2)
+  dim[seq_along(dim(x))] <- dim(x)
+  dim
 }
 .class <- function(x) {
   paste(class(x), collapse = "/")

--- a/tests/testthat/test_report_RLum.R
+++ b/tests/testthat/test_report_RLum.R
@@ -2,7 +2,7 @@
 data(ExampleData.DeValues, envir = environment())
 data(ExampleData.RLum.Analysis, envir = environment())
 
-test_that("Test Simple RLum Report", {
+test_that("test functionality", {
   testthat::skip_on_cran()
 
   ## the test fails on AppVeyor for no obvious reason on the windows
@@ -31,6 +31,9 @@ test_that("Test Simple RLum Report", {
 
   ## list of RLum objects
   report_RLum(IRSAR.RF.Data@records)
+
+  ## array()
+  expect_null(report_RLum(array()))
 
   ## names with spaces or missing
   ll <- as.list(ExampleData.DeValues$CA1)


### PR DESCRIPTION
The function is supposed to produce a vector of length at least 2, for the way it's used downstream. Therefore, if the input has dimension of length less than 2, we pad it with zeros.

Fixes #938.