### PR TITLE
Fix x-axis label for TL plots in plot_Risoe.BINfileData()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -178,6 +178,9 @@ fixed including affected functions such as `analyse_SAR.CWOSL()` and `analyse_pI
 * Input arguments are validate more strictly to avoid unexpected crashes in
 case of misspecification (#964).
 
+* The x-axis label for TL curves now reports temperature rather than time,
+consistently with the data shown (#971).
+
 ### `plot_RLum.Analysis()`
 
 * The legend text now scales better at non-default `cex` settings (#854).

--- a/NEWS.md
+++ b/NEWS.md
@@ -186,6 +186,9 @@
 - Input arguments are validate more strictly to avoid unexpected crashes
   in case of misspecification (#964).
 
+- The x-axis label for TL curves now reports temperature rather than
+  time, consistently with the data shown (#971).
+
 ### `plot_RLum.Analysis()`
 
 - The legend text now scales better at non-default `cex` settings

--- a/R/plot_Risoe.BINfileData.R
+++ b/R/plot_Risoe.BINfileData.R
@@ -173,11 +173,12 @@ plot_Risoe.BINfileData<- function(
   ##(3) plot curves
   for(i in 1:length(temp@METADATA[,"ID"])){
     ##print only if SEL == TRUE
-    if(temp@METADATA[i,"SEL"]==TRUE)
-    {
+    if (temp@METADATA[i, "SEL"]) {
+      ltype <- temp@METADATA[i, "LTYPE"]
+      is.TL <- ltype == "TL"
 
       ##find measured unit
-      measured_unit<-if(temp@METADATA[i,"LTYPE"]=="TL"){" \u00B0C"}else{"s"}
+      measured_unit <- if (is.TL) temp.lab else "s"
 
       ##set x and y values
       values.x <- seq(temp@METADATA[i,"HIGH"]/temp@METADATA[i,"NPOINTS"],
@@ -201,7 +202,7 @@ plot_Risoe.BINfileData<- function(
            type="l",
            ylab=paste(temp@METADATA[i,"LTYPE"]," [cts/",round(temp@METADATA[i,"HIGH"]/temp@METADATA[i,"NPOINTS"],digits=3)," ",
                       measured_unit,"]",sep=""),
-           xlab=if(measured_unit=="\u00B0C"){paste("temp. [",temp.lab,"]",sep="")}else{"time [s]"},
+           xlab = if (is.TL) paste0("temp. [", temp.lab, "]") else "time [s]",
            col=if(temp@METADATA[i,"LTYPE"]=="IRSL" | temp@METADATA[i,"LTYPE"]=="RIR"){"red"}
            else if(temp@METADATA[i,"LTYPE"]=="OSL" | temp@METADATA[i,"LTYPE"]=="RBR"){"blue"}
            else{"black"},

--- a/tests/testthat/_snaps/plot_Risoe.BINfileData/tl.svg
+++ b/tests/testthat/_snaps/plot_Risoe.BINfileData/tl.svg
@@ -55,8 +55,8 @@
 <polygon points='59.04,502.56 689.76,502.56 689.76,59.04 59.04,59.04 ' style='stroke-width: 0.75; fill: none;' />
 <text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='128.53px' lengthAdjust='spacingAndGlyphs'>pos=1, run=2, set=5</text>
 <text x='374.40' y='571.68' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='35.34px' lengthAdjust='spacingAndGlyphs'>(5 K/s)</text>
-<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='38.68px' lengthAdjust='spacingAndGlyphs'>time [s]</text>
-<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='86.18px' lengthAdjust='spacingAndGlyphs'>TL [cts/0.64  °C]</text>
+<text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='53.49px' lengthAdjust='spacingAndGlyphs'>temp. [°C]</text>
+<text transform='translate(12.96,280.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='82.84px' lengthAdjust='spacingAndGlyphs'>TL [cts/0.64 °C]</text>
 <text x='374.40' y='56.16' text-anchor='middle' style='font-size: 10.80px; font-family: sans;' textLength='60.76px' lengthAdjust='spacingAndGlyphs'>TL to 160 °C</text>
 </g>
 </svg>


### PR DESCRIPTION
This also ensures that if a custom temperature label is specified, this is used in both the x and y axes.

Fixes #971.