### PR TITLE
Try to get debug info from coverage runs

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           covr::codecov(
             quiet = FALSE,
-            clean = TRUE,
+            clean = FALSE,
             token = "${{ secrets.CODECOV_TOKEN }}",
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
 
@@ -50,7 +50,7 @@ jobs:
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results


### PR DESCRIPTION
The `test-coverage` workflow reports these messages:

```
find: ‘/home/runner/work/_temp/package’: No such file or directory
Warning: No files were found with the provided path: /home/runner/work/_temp/package. No artifacts will be uploaded.
```

This means that in case of an error, it's not possible to download the artifacts produced on the CI machines. Perhaps this will fix it.