### PR TITLE
Let testthat run in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,3 +78,4 @@ Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
+Config/testthat/parallel: TRUE


### PR DESCRIPTION
By default it will use 2 cores, but this can be controlled by setting the desired value in the .Renviron file:

   TESTTHAT_CPUS=4

or interactively with:

```
Sys.setenv("TESTTHAT_CPUS" = 4)
```
Fixes #991.