### PR TITLE
Use the correct screen indices reported by split.screen()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -21,9 +21,17 @@ in the corresponding `convert_CW2*()` functions (#992).
 
 ## Bugfixes and changes
 
+### `fit_EmissionSpectra()`
+
+* The function uses the correct indices reported by `split.screen()`, which
+prevents some graphical errors if run in a parallel setting (#1007).
+
 ### `fit_OSLLifeTimes()`
 
 * The function throws a warning when the fit fails (#1005).
+
+* The function uses the correct indices reported by `split.screen()`, which
+prevents some graphical errors if run in a parallel setting (#1007).
 
 ### `plot_AbanicoPlot()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,9 +12,19 @@
 
 ## Bugfixes and changes
 
+### `fit_EmissionSpectra()`
+
+- The function uses the correct indices reported by `split.screen()`,
+  which prevents some graphical errors if run in a parallel setting
+  (#1007).
+
 ### `fit_OSLLifeTimes()`
 
 - The function throws a warning when the fit fails (#1005).
+
+- The function uses the correct indices reported by `split.screen()`,
+  which prevents some graphical errors if run in a parallel setting
+  (#1007).
 
 ### `plot_AbanicoPlot()`
 

--- a/R/fit_EmissionSpectra.R
+++ b/R/fit_EmissionSpectra.R
@@ -546,20 +546,17 @@ fit_EmissionSpectra <- function(
       legend = TRUE,
       legend.pos = "topright",
       legend.text = c("sum", paste0("c",1:length(mu),": ", round(mu,2), " eV"))
-
     ), val = list(...))
 
     if (!is.na(fit[1]) && !inherits(fit, "try-error")) {
-    ##make sure that the screen closes if something is wrong
-    on.exit(graphics::close.screen(n = c(1,2)), add = TRUE)
+      screen.idx <- graphics::split.screen(rbind(c(0.1, 1, 0.32, 0.98),
+                                                 c(0.1, 1, 0.10, 0.315)))
 
-    ##set split screen settings
-    graphics::split.screen(rbind(
-      c(0.1,1,0.32, 0.98),
-      c(0.1,1,0.1, 0.315)))
+      ## make sure to close the screen
+      on.exit(graphics::close.screen(n = screen.idx), add = TRUE)
 
     ##SCREEN 1 ----------
-    graphics::screen(1)
+    graphics::screen(screen.idx[1])
     par(mar = c(0, 4, 3, 4))
     plot(
       df,
@@ -620,7 +617,7 @@ fit_EmissionSpectra <- function(
     }
 
     ## SCREEN 2 -----
-    graphics::screen(2)
+    graphics::screen(screen.idx[2])
     par(mar = c(4, 4, 0, 4))
     plot(NA, NA,
       ylim = range(residuals(fit)),

--- a/R/fit_OSLLifeTimes.R
+++ b/R/fit_OSLLifeTimes.R
@@ -667,14 +667,13 @@ if(plot) {
   if (!inherits(fit, 'try-error')) {
 
     if(!plot_simple){
-      ##make sure that the screen closes if something is wrong
-      on.exit(graphics::close.screen(all.screens = TRUE), add = TRUE)
+      screen.idx <- graphics::split.screen(rbind(c(0.1, 1, 0.32, 0.98),
+                                                 c(0.1, 1, 0.10, 0.32)))
 
-      graphics::split.screen(rbind(
-        c(0.1,1,0.32, 0.98),
-        c(0.1,1,0.1, 0.32)))
+      ## make sure to close the screen
+      on.exit(graphics::close.screen(n = screen.idx), add = TRUE)
 
-      graphics::screen(1)
+      graphics::screen(screen.idx[1])
       par(mar = c(0, 4, 3, 4))
     }
 
@@ -730,7 +729,7 @@ if(plot) {
     )
 
     if(!plot_simple){
-      graphics::screen(2)
+      graphics::screen(screen.idx[2])
       par(mar = c(4, 4, 0, 4))
       plot(
         x = df[[1]],


### PR DESCRIPTION
Fixes #1007.