### PR TITLE
Increase the minimum R version supported to 4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ License: GPL-3
 URL: https://r-lum.github.io/Luminescence/
 BugReports: https://github.com/R-Lum/Luminescence/issues
 Depends:
-    R (>= 4.3),
+    R (>= 4.4),
     utils
 LinkingTo: Rcpp (>= 1.0.12),
     RcppArmadillo (>= 0.12.8.4.0)

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -10,6 +10,8 @@ header-includes:
 
 # Changes in version `r RLumBuild::.get_pkg_version()` (`r Sys.Date()`)
 
+**This package version requires R >= 4.4**
+
 ## New functions
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 # Changes in version 1.1.1.9000 (2025-09-15)
 
+**This package version requires R \>= 4.4**
+
 ## New functions
 
 ## Removed functions and deprecations

--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1354,25 +1354,6 @@ SW <- function(expr) {
   return(TRUE)
 }
 
-#' Default value for `NULL`
-#'
-#' Given two values, it returns the first if not `NULL` otherwise the second.
-#'
-#' @param x The value to check.
-#' @param y The default value to use in case `x` is `NULL`.
-#'
-#' @return
-#' A non-`NULL` value.
-#'
-#' @noRd
-"%||%" <- function(x, y)
-  if (is.null(x)) y else x
-
-## Reexport from base on newer versions of R to avoid conflict messages
-if (exists("%||%", envir = baseenv())) {
-  `%||%` <- get("%||%", envir = baseenv())
-}
-
 #' Create a list of objects repeated a given number of times
 #'
 #' @param x [vector] (**required**) An object to be repeated into a list.

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -486,18 +486,6 @@ test_that("Test internals", {
       expect_false(.require_suggested_package("error", throw.error = FALSE),
                    "This function requires the 'error' package: to install it"))
 
-  ## %||% -------------------------------------------------------------------
-  expect_equal(letters %||% LETTERS,
-               letters)
-  expect_equal(NULL %||% LETTERS,
-               LETTERS)
-  expect_equal(NA %||% LETTERS,
-               NA)
-  expect_equal(character(0) %||% LETTERS,
-               character(0))
-  expect_equal("" %||% LETTERS,
-               "")
-
   ## .listify() -------------------------------------------------------------
   expect_equal(.listify(1, length = 3),
                list(1, 1, 1))


### PR DESCRIPTION
Fixes #1009 and allow us to remove our own definition of `%||%` since it's already defined from R 4.4.