### PR TITLE
Ignore frames beyond the available ones in plot_RLum.Data.Spectrum()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -49,3 +49,6 @@ generates spurious legend entries (#1017).
 
 * The function doesn't crash anymore if `bg.spectrum` is used and `ylim`
 specifies an interval that doesn't contain any background channels (#1019).
+
+* The function doesn't crash anymore if the value of `frames` given is too
+large when `plot.type = "multiple.lines"` (#1021).

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,3 +41,6 @@
 - The function doesn’t crash anymore if `bg.spectrum` is used and `ylim`
   specifies an interval that doesn’t contain any background channels
   (#1019).
+
+- The function doesn’t crash anymore if the value of `frames` given is
+  too large when `plot.type = "multiple.lines"` (#1021).

--- a/R/plot_RLum.Data.Spectrum.R
+++ b/R/plot_RLum.Data.Spectrum.R
@@ -943,6 +943,13 @@ if(plot){
     box <- extraArgs$box[1] %||% TRUE
     frames <- extraArgs$frames %||% 1:length(y)
 
+    max.frames <- ncol(temp.xyz)
+    if (any(frames > max.frames)) {
+      .throw_message("Skipped frames exceeding the maximum (", max.frames, ")",
+                     error = FALSE)
+      frames <- pmin(frames, max.frames)
+    }
+
     ##change graphic settings
     par.default <- par()[c("mfrow", "mar", "xpd")]
     par(mfrow = c(1,1), mar=c(5.1, 4.1, 4.1, 8.1), xpd = TRUE)

--- a/tests/testthat/test_plot_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_plot_RLum.Data.Spectrum.R
@@ -173,17 +173,15 @@ test_that("check functionality", {
       )
     ))
 
-    expect_silent(suppressWarnings(
+    expect_message(
       plot_RLum.Data.Spectrum(
         TL.Spectrum,
         plot.type = "multiple.lines",
         xlim = c(310, 750),
-        frames = c(1,3),
-        ylim = c(0, 100),
-        bin.rows = 10,
-        bin.cols = 1
-      )
-    ))
+        frames = c(1, 3, 100),
+        ylim = c(0, 50)),
+      "Skipped frames exceeding the maximum (3)",
+      fixed = TRUE)
 
     ## plot: image ------------
     ### plot_image: standard -------


### PR DESCRIPTION
Fixes #1021.