### PR TITLE
Don't restore the usr parameter in .par_defaults()

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -422,18 +422,25 @@ fancy_scientific <- function(l) {
 #' Retrieve graphical parameters
 #'
 #' @return
-#' A list of graphical parameters that can be restored. The `pin` parameter
-#' is removed because at times (when a pdf file with too small size) it can
-#' become negative, and restoring it would throw an error. The `new` parameter
-#' is set to `FALSE` because calling `par()` with no graphical device open
-#' will set `par("new")` to `TRUE`, which is not what we want to restore, as
-#' otherwise the next plot may accidentally overwrite the previous one.
+#' A list of graphical parameters that can be restored, with the following
+#' exceptions:
+#' - The `pin` parameter is removed because at times (for example, when a pdf
+#' file with too small size is used) it can become negative, and restoring it
+#' would throw an error.
+#' - The `new` parameter is set to `FALSE` because calling `par()` with no
+#' graphical device open will set `par("new")` to `TRUE`, which is not what
+#' we want to restore, as otherwise the next plot may accidentally overwrite
+#' the previous one.
+#' - The `usr` parameter is removed so that additional plot elements can be
+#' added afterwards using the axis scale of the plot. If we restore that, the
+#' axis would range to the default 0-1 interval.
 #'
 #' @noRd
 .par_defaults <- function() {
   pars <- par(no.readonly = TRUE)
   pars$pin <- NULL
   pars$new <- FALSE
+  pars$usr <- NULL
   pars
 }
 

--- a/tests/testthat/_snaps/plot_RLum.Analysis/abline-after.svg
+++ b/tests/testthat/_snaps/plot_RLum.Analysis/abline-after.svg
@@ -66,5 +66,6 @@
 <text x='651.82' y='73.86' style='font-size: 9.60px; font-family: sans;' textLength='33.62px' lengthAdjust='spacingAndGlyphs'>Curve 1</text>
 <text x='651.82' y='85.38' style='font-size: 9.60px; font-family: sans;' textLength='33.62px' lengthAdjust='spacingAndGlyphs'>Curve 2</text>
 <text x='651.82' y='96.90' style='font-size: 9.60px; font-family: sans;' textLength='33.62px' lengthAdjust='spacingAndGlyphs'>Curve 3</text>
+<line x1='146.96' y1='502.56' x2='146.96' y2='59.04' style='stroke-width: 0.75;' />
 </g>
 </svg>


### PR DESCRIPTION
The `usr` parameter is no longer restored so that additional plot elements can be added afterwards to an existing plot using the same axis scale as the plot. If we restore it, the axes would be reset to the default 0-1 interval, making it impossible to position additional elements correctly.

The snapshot to show this bug was added in 3b94cd13. No `NEWS` because this bug was introduced in the current development version.

Fixes #1108.