### PR TITLE
Use the CRAN version of covr.

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -36,11 +36,6 @@ jobs:
           extra-packages: any::covr
           needs: coverage
 
-      - name: Install development version of covr
-        run: |
-          pak::pkg_install("r-lib/covr")
-        shell: Rscript {0}
-
       - name: Test coverage
         run: |
           covr::codecov(


### PR DESCRIPTION
This reverts the workaround introduced for #994.