### PR TITLE
.validate_scalar: Don't crash on a 0-column matrix or data frame

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1289,7 +1289,7 @@ SW <- function(expr) {
                              null.ok = FALSE, name = NULL) {
   if (!missing(val) && is.null(val) && null.ok)
     return(NULL)
-  if (missing(val) || NROW(val) != 1 || is.na(val) ||
+  if (missing(val) || NROW(val) != 1 || NCOL(val) != 1 || is.na(val) ||
       (!log && !is.numeric(val)) || (log && !is.logical(val)) ||
       (int && (is.infinite(val) || val != as.integer(val))) ||
       (pos && val <= 0)) {

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -440,6 +440,8 @@ test_that("Test internals", {
                "'iris' should be a single value")
   expect_error(.validate_scalar(iris[, 1, drop = FALSE]),
                "'iris' should be a single value")
+  expect_error(.validate_scalar(iris[1, 0, drop = FALSE]),
+               "'iris' should be a single value")
   expect_error(.validate_scalar(iris, null.ok = TRUE),
                "'iris' should be a single value or NULL")
   expect_error(.validate_scalar(-1:2, name = "'var'"),


### PR DESCRIPTION
Fixes #1180.