### PR TITLE
analyse_SAR.CWOSL: Ensure that legend names are not cut off

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -66,6 +66,10 @@ is somewhat malformed (#1144).
 * The function no longer crashes when `n.MC = NULL` is used with the `FIT`
 method (#1055).
 
+### `analyse_pIRIRSequence()`
+
+* The names in the curves legend are no longer cut off (#1206).
+
 ### `analyse_portableOSL()`
 
 * The size of the contour labels for `mode = "surface"` can now be controlled

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,10 @@
 - The function no longer crashes when `n.MC = NULL` is used with the
   `FIT` method (#1055).
 
+### `analyse_pIRIRSequence()`
+
+- The names in the curves legend are no longer cut off (#1206).
+
 ### `analyse_portableOSL()`
 
 - The size of the contour labels for `mode = "surface"` can now be

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -1009,7 +1009,7 @@ if(is.list(object)){
 
         ## add legend text
         text(x, y, paste0(LnLxTnTx$Name, "\n(", LnLxTnTx$Dose, ")"),
-             offset = 1, pos = 1)
+             offset = 1, pos = 1, xpd = NA)
 
         ##add line
         abline(h = 10,lwd = 0.5)

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/ch-tl-log-x.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/ch-tl-log-x.svg
@@ -246,6 +246,8 @@
 <circle cx='471.11' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='23.21px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -260,6 +262,8 @@
 <text x='582.22' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='16.81px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDYwLjgwfDU3Ni4wMA==)'>
 <line x1='0.000000000000080' y1='465.07' x2='720.00' y2='465.07' style='stroke-width: 0.38;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/default.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/default.svg
@@ -276,6 +276,8 @@
 <circle cx='471.11' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='23.21px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -290,6 +292,8 @@
 <text x='582.22' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='16.81px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDYwLjgwfDU3Ni4wMA==)'>
 <line x1='0.000000000000080' y1='465.07' x2='720.00' y2='465.07' style='stroke-width: 0.38;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/list-cex.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/list-cex.svg
@@ -267,6 +267,8 @@
 <circle cx='471.11' cy='497.07' r='8.21' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='497.07' r='8.21' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='497.07' r='8.21' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='518.59' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='44.10px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='535.01' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='16.72px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='518.59' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='17.49px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -281,6 +283,8 @@
 <text x='582.22' y='535.01' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='31.94px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='518.59' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='17.49px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='535.01' text-anchor='middle' style='font-size: 13.68px; font-family: sans;' textLength='16.72px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDYwLjgwfDU3Ni4wMA==)'>
 <line x1='0.000000000000080' y1='465.07' x2='720.00' y2='465.07' style='stroke-width: 0.38;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/no-tl-log-xy.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/no-tl-log-xy.svg
@@ -209,6 +209,8 @@
 <circle cx='471.11' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='23.21px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -223,6 +225,8 @@
 <text x='582.22' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='16.81px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDYwLjgwfDU3Ni4wMA==)'>
 <line x1='0.000000000000080' y1='465.07' x2='720.00' y2='465.07' style='stroke-width: 0.38;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/onlylxtxtable.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/onlylxtxtable.svg
@@ -278,6 +278,8 @@
 <circle cx='471.11' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='497.07' r='4.32' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='23.21px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -292,6 +294,8 @@
 <text x='582.22' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='16.81px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='508.40' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='9.21px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='517.04' text-anchor='middle' style='font-size: 7.20px; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDYwLjgwfDU3Ni4wMA==)'>
 <line x1='0.000000000000080' y1='465.07' x2='720.00' y2='465.07' style='stroke-width: 0.38;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/analyse_pIRIRSequence/default.svg
+++ b/tests/testthat/_snaps/analyse_pIRIRSequence/default.svg
@@ -819,6 +819,8 @@
 <circle cx='471.11' cy='420.06' r='5.04' style='stroke-width: 0.75; stroke: #FFB90F; fill: #FFB90F;' />
 <circle cx='582.22' cy='420.06' r='5.04' style='stroke-width: 0.75; stroke: #8B6914; fill: #8B6914;' />
 <circle cx='693.33' cy='420.06' r='5.04' style='stroke-width: 0.75; stroke: #FF00FF; fill: #FF00FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='26.67' y='433.28' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='27.08px' lengthAdjust='spacingAndGlyphs'>Natural</text>
 <text x='26.67' y='443.36' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>(0)</text>
 <text x='137.78' y='433.28' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='10.74px' lengthAdjust='spacingAndGlyphs'>R1</text>
@@ -833,6 +835,8 @@
 <text x='582.22' y='443.36' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>(450)</text>
 <text x='693.33' y='433.28' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='10.74px' lengthAdjust='spacingAndGlyphs'>R0</text>
 <text x='693.33' y='443.36' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='10.27px' lengthAdjust='spacingAndGlyphs'>(0)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDExLjQzfDQzOC44Ng==)'>
 <line x1='0.00' y1='412.44' x2='720.00' y2='412.44' style='stroke-width: 0.38;' />
 </g>
 <defs>


### PR DESCRIPTION
This helps mainly `analyse_pIRIRSequence()`. Other changes in snapshots have no visual impact.

Fixes #1206.