### PR TITLE
Revert "Add header to provide a definition for Rf_rnbeta()"

### DIFF
--- a/inst/include/RLum_Rf_rnbeta.h
+++ b/inst/include/RLum_Rf_rnbeta.h
@@ -1,8 +1,0 @@
-#ifndef RLUM_RF_RNBETA_H_
-#define RLUM_RF_RNBETA_H_
-
-namespace {
-  inline double Rf_rnbeta(double a, double b, double np) { return 0.0; }
-}
-
-#endif /* RLUM_RF_RNBETA_H_ */

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
-PKG_CPPFLAGS=-include ../inst/include/RLum_Rf_rnbeta.h -I../inst/include -DARMA_USE_CURRENT
+PKG_CPPFLAGS=-I../inst/include -DARMA_USE_CURRENT
 CXX_STD = CXX17

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,2 @@
-PKG_CPPFLAGS=-include ../inst/include/RLum_Rf_rnbeta.h -I../inst/include -DARMA_USE_CURRENT
+PKG_CPPFLAGS=-I../inst/include -DARMA_USE_CURRENT
 CXX_STD = CXX17


### PR DESCRIPTION
This reverts commit 786abc6d as R-devel seems to have been fixed to support the current version of Rcpp.

Fixes #1240.