### PR TITLE
extract_IrradiationTime: Fix self-call check to avoid spurious warning

### DIFF
--- a/R/extract_IrradiationTimes.R
+++ b/R/extract_IrradiationTimes.R
@@ -185,9 +185,8 @@ extract_IrradiationTimes <- function(
   .set_function_name("extract_IrradiationTimes")
   on.exit(.unset_function_name(), add = TRUE)
 
-  # SELF CALL -----------------------------------------------------------------------------------
-  if(is.list(object)){
-    ##show message for non-supported arguments
+  ## Self-call --------------------------------------------------------------
+  if (inherits(object, "list")) {
     if(!missing(file.BINX))
       .throw_warning("argument 'file.BINX' is not supported in self-call mode.")
 

--- a/tests/testthat/test_extract_IrradiationTimes.R
+++ b/tests/testthat/test_extract_IrradiationTimes.R
@@ -91,3 +91,11 @@ test_that("snapshot tests", {
                                                 recordType = list("OSL (UVVIS)")),
                        tolerance = snapshot.tolerance)
 })
+
+test_that("regression tests", {
+  testthat::skip_on_cran()
+
+  ## issue 1273
+  expect_error(extract_IrradiationTimes(iris, file.BINX = NA),
+               "'object' should be of class 'character', 'RLum.Analysis' or")
+})


### PR DESCRIPTION
Fixes #1273.