### PR TITLE
analyse_SAR.CWOSL: Allow the signal integral to select just one channel

### DIFF
--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -398,12 +398,6 @@ analyse_SAR.CWOSL<- function(
       .throw_error("'signal.integral' or 'background.integral' is not of type integer")
     }
 
-    if (length(signal.integral) == 1) {
-      signal.integral <- signal.integral + 0:1
-      .throw_warning("Signal integral limits cannot be equal, reset to ",
-                     .format_range(signal.integral))
-    }
-
     if (length(background.integral) == 1) {
       ## we subtract 25 to avoid warnings from calc_OSLLxTxRatio()
       background.integral <- background.integral - 25:0
@@ -415,11 +409,6 @@ analyse_SAR.CWOSL<- function(
     signal.integral.Tx <- NULL
     if (length(signal.integral.min) == 2 && length(signal.integral.max) == 2) {
       signal.integral.Tx <- signal.integral.min[2]:signal.integral.max[2]
-      if (length(signal.integral.Tx) == 1) {
-        signal.integral.Tx <- signal.integral.Tx + 0:1
-        .throw_warning("Signal integral limits for Tx curves cannot be equal, reset to ",
-                       .format_range(signal.integral.Tx))
-      }
     }
 
     background.integral.Tx <- NULL

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -326,7 +326,7 @@ test_that("check functionality", {
      verbose = FALSE
    ), regexp = "Background integral out of bounds")
 
-  expect_warning(expect_warning(analyse_SAR.CWOSL(
+  expect_warning(analyse_SAR.CWOSL(
       object = object[[1]],
       signal.integral.min = 1,
       signal.integral.max = 1,
@@ -335,10 +335,9 @@ test_that("check functionality", {
       fit.method = "LIN",
       plot = FALSE,
       verbose = FALSE
-  ), "Signal integral limits cannot be equal, reset to 1:2"),
-  "Background integral limits cannot be equal, reset to 975:1000")
+  ), "Background integral limits cannot be equal, reset to 975:1000")
 
-  expect_warning(expect_warning(analyse_SAR.CWOSL(
+  expect_warning(analyse_SAR.CWOSL(
       object = object[[1]],
       signal.integral.min = c(1, 1),
       signal.integral.max = c(2, 1),
@@ -347,8 +346,7 @@ test_that("check functionality", {
       fit.method = "LIN",
       plot = FALSE,
       verbose = FALSE
-  ), "Signal integral limits for Tx curves cannot be equal, reset to 1:2"),
-  "Background integral limits for Tx curves cannot be equal, reset to 975:1000")
+  ), "Background integral limits for Tx curves cannot be equal, reset to 975:1000")
 
   expect_warning(analyse_SAR.CWOSL(
       object = object[[1]],


### PR DESCRIPTION
Fixes #1291.