### PR TITLE
plot_RLum.[Analysis|Data.Curve]: Use on normalise_RLum() for normalisation

### DIFF
--- a/R/plot_RLum.Analysis.R
+++ b/R/plot_RLum.Analysis.R
@@ -352,7 +352,7 @@ plot_RLum.Analysis <- function(
               lty = plot.settings$lty[[i]],
               xlim = xlim.set,
               ylim = ylim.set,
-              norm = plot.settings$norm,
+              norm = plot.settings$norm[[i]],
               pch = plot.settings$pch[[i]],
               cex = plot.settings$cex[[i]],
               legend.col = plot.settings$legend.col[[i]],
@@ -465,16 +465,10 @@ plot_RLum.Analysis <- function(
           object.list[[x]] <- get(curve.transformation)(object.list[[x]])
         }
 
-        temp.data <- as(object.list[[x]], "data.frame")
-
         ## curve normalisation
-        if (isTRUE(plot.settings$norm[[k]][1]) ||
-            plot.settings$norm[[k]][1] %in% c("max", "last", "huot")) {
-          temp.data[[2]] <- .normalise_curve(temp.data[[2]],
-                                             plot.settings$norm[[k]])
-        }
-
-        return(temp.data)
+        object.list[[x]] <- normalise_RLum(object.list[[x]],
+                                           plot.settings$norm[[k]][1])
+        as(object.list[[x]], "data.frame")
       })
 
       ##set plot parameters

--- a/R/plot_RLum.Data.Curve.R
+++ b/R/plot_RLum.Data.Curve.R
@@ -104,12 +104,7 @@ plot_RLum.Data.Curve<- function(
     return(NULL)
   }
 
-  if (is.logical(norm))
-    norm <- norm[1]
-  else
-    norm <- .validate_args(norm, c("max", "last", "huot"),
-                           extra = "a logical value")
-
+  ## `norm` is not validated here but will be validated by normalise_RLum()
   .validate_logical_scalar(par.local)
   .validate_logical_scalar(smooth)
   .validate_logical_scalar(auto_scale)
@@ -164,7 +159,7 @@ plot_RLum.Data.Curve<- function(
 
   ## curve normalisation
   if (!isFALSE(norm)) {
-    object@data[, 2] <- .normalise_curve(object@data[, 2], norm)
+    object <- normalise_RLum(object, norm)
   }
 
   extraArgs <- list(...)

--- a/tests/testthat/test_plot_RLum.Analysis.R
+++ b/tests/testthat/test_plot_RLum.Analysis.R
@@ -27,6 +27,8 @@ test_that("input validation", {
                "'ncols' should be a single positive integer value")
   expect_error(plot_RLum.Analysis(temp, combine = -1),
                "'combine' should be a single logical value")
+  expect_error(plot_RLum.Analysis(temp, norm = -3),
+               "'norm' should be a single positive value or one of 'max', 'min'")
 
   expect_error(plot_RLum.Analysis(
       set_RLum("RLum.Analysis", records = list(c1@records[[1]],
@@ -80,7 +82,7 @@ test_that("check functionality", {
       c1@records[[1]],
       set_RLum("RLum.Data.Curve", recordType = "OSL")
       )), norm = TRUE, combine = TRUE),
-    "[plot_RLum.Analysis()] Curve normalisation produced Inf/NaN values",
+    "[normalise_RLum()] Curve normalisation produced Inf/NaN values, values replaced",
     fixed = TRUE))
 
   ##Basic plot

--- a/tests/testthat/test_plot_RLum.Data.Curve.R
+++ b/tests/testthat/test_plot_RLum.Data.Curve.R
@@ -8,7 +8,9 @@ test_that("input validation", {
   expect_error(plot_RLum.Data.Curve("error"),
                "'object' should be of class 'RLum.Data.Curve'")
   expect_error(plot_RLum.Data.Curve(temp, norm = "error"),
-               "'norm' should be one of 'max', 'last', 'huot'")
+               "'norm' should be one of 'max', 'min', 'first', 'last' or 'huot'")
+  expect_error(plot_RLum.Data.Curve(temp, norm = -2),
+               "'norm' should be a single positive value or one of 'max', 'min'")
 
   temp_NA <- temp
   temp_NA@data[] <- suppressWarnings(NA_real_)


### PR DESCRIPTION
Before calling `.normalise_curve()`, one must validate the arguments. This means that whenever there are new options added to `.normalise_curve()`, all functions that call it must also update their validation step.

By relying on `normalise_RLum()`, we can skip those validations, and ensure that in the future our checks and error messages stay consistent and up to date.

Fixes #1301.