### PR TITLE
calc_MinDose: Avoid propagating NaNs if invert = TRUE

### DIFF
--- a/R/calc_MinDose.R
+++ b/R/calc_MinDose.R
@@ -573,7 +573,7 @@ calc_MinDose <- function(
   if (log) {
     lcd <- log(data[, 1]) * ifelse(invert, -1, 1)
     if (invert) {
-      x.offset <- abs(min(lcd))
+      x.offset <- abs(min(lcd, na.rm = TRUE))
       lcd <- lcd+x.offset
     }
     lse <- sqrt((data[ ,2]/data[ ,1])^2 + sigmab^2)

--- a/tests/testthat/test_calc_MaxDose.R
+++ b/tests/testthat/test_calc_MaxDose.R
@@ -38,3 +38,17 @@ test_that("check functionality", {
   expect_equal(round(results$Lmax, digits = 2), -19.79)
   expect_equal(round(results$BIC, digits = 2), 58.87)
 })
+
+test_that("regression tests", {
+  testthat::skip_on_cran()
+
+  ## issue 1320
+  set.seed(9)
+  SW({
+  expect_warning(calc_MaxDose(data = data.frame(De = c(rnorm(4) + 5, -1),
+                                                De_Err = rnorm(5) + 1),
+                              sigmab = 1, log = TRUE, bootstrap = TRUE,
+                              bs.M = 10, bs.N = 5, bs.h = 2, plot = FALSE),
+                 "De values must be positive with 'log = TRUE', 1 values set to NA")
+  })
+})


### PR DESCRIPTION
Setting `na.rm = TRUE` allows to remove `NaN` values that get generated in a log model when there are negative De values and `invert = TRUE` (which is what is used by `calc_MaxDose()`).

Fixes #1320.