### PR TITLE
calc_OSLLxTxDecomposed: Return the SN_Ratio_* columns

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -40,9 +40,9 @@ objects after the first curve in a record. This will allow an easier way to
 differentiate the curves to analyse (for example, "OSL (UVVIS") from those
 that are not useful in the analysis (for example, "_OSL (NA)") (#1276).
 
-* Function `calc_OSLLxTxRatio()` adds two new columns, `SN_RATIO_LnLx` and
-`SN_RATIO_TnTx`, to the output. This may potentially disrupt code that relies
-on column indices instead of column names (#1281).
+* Functions `calc_OSLLxTxRatio()` and `calc_OSLLxTxDecomposed()` add two new
+columns to the output, `SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This may disrupt
+code that relies on column indices instead of column names (#1281, #1330).
 
 ## New functions
 
@@ -187,10 +187,17 @@ name will still work but generate a deprecation warning (#1290).
 * The function now set non-positive De values to `NA` when `log = TRUE`, which
 used to lead to a crash when combined with `bootstrap = TRUE` (#1313).
 
+### `calc_OSLLxTxDecomposed()`
+
+* The data frame returned by the function now contains two additional columns,
+`SN_RATIO_LnLx` and `SN_RATIO_TnTx` (containing `NA`) for consistency with the
+output produced by `calc_OSLLxTxRatio()` (#1330).
+
 ### `calc_OSLLxTxRatio()`
 
-* The function now returns `SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This is the 
-signal-to-noise ratio for the respective shine-down curves for `Lx` and `Tx` (#1281). 
+* The data frame returned by the function now contains two additional columns,
+`SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This is the signal-to-noise ratio for the
+respective shine-down curves for `Lx` and `Tx` (#1281).
 
 * Arguments `signal.integral`, `background.integral`, `signal.integral.Tx` and
 `background.integral.Tx` have been renamed to `signal_integral`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,9 +33,10 @@ More information on these changes are available at
   example, “OSL (UVVIS”) from those that are not useful in the analysis
   (for example, “\_OSL (NA)“) (#1276).
 
-- Function `calc_OSLLxTxRatio()` adds two new columns, `SN_RATIO_LnLx`
-  and `SN_RATIO_TnTx`, to the output. This may potentially disrupt code
-  that relies on column indices instead of column names (#1281).
+- Functions `calc_OSLLxTxRatio()` and `calc_OSLLxTxDecomposed()` add two
+  new columns to the output, `SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This
+  may disrupt code that relies on column indices instead of column names
+  (#1281, \#1330).
 
 ## New functions
 
@@ -192,11 +193,18 @@ More information on these changes are available at
   which used to lead to a crash when combined with `bootstrap = TRUE`
   (#1313).
 
+### `calc_OSLLxTxDecomposed()`
+
+- The data frame returned by the function now contains two additional
+  columns, `SN_RATIO_LnLx` and `SN_RATIO_TnTx` (containing `NA`) for
+  consistency with the output produced by `calc_OSLLxTxRatio()` (#1330).
+
 ### `calc_OSLLxTxRatio()`
 
-- The function now returns `SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This is
-  the signal-to-noise ratio for the respective shine-down curves for
-  `Lx` and `Tx` (#1281).
+- The data frame returned by the function now contains two additional
+  columns, `SN_RATIO_LnLx` and `SN_RATIO_TnTx`. This is the
+  signal-to-noise ratio for the respective shine-down curves for `Lx`
+  and `Tx` (#1281).
 
 - Arguments `signal.integral`, `background.integral`,
   `signal.integral.Tx` and `background.integral.Tx` have been renamed to

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -808,13 +808,17 @@ analyse_SAR.CWOSL<- function(
                    colnames(Recuperation) %||% NA_character_,
                    "Testdose error",
                    "Signal-to-noise ratio"),
-      Value = c(RecyclingRatio, Recuperation, Testdose.error, SN.ratio %||% NA_real_),
+      Value = c(RecyclingRatio, Recuperation, Testdose.error, SN.ratio),
       Threshold = c(recycling.threshold, recuperation.threshold,
                     testdose.threshold, SN.threshold),
       Status = c(status.RecyclingRatio, status.Recuperation,
                  status.Testdose, status.SN.ratio),
       stringsAsFactors = FALSE
   )
+
+  ## remove rejection criteria that have a NA value (it can happen for sn.ratio
+  ## if OSL.component is used)
+  RejectionCriteria <- RejectionCriteria[!is.na(RejectionCriteria$Value), ]
 
   ## Plotting ---------------------------------------------------------------
   if (plot) {

--- a/R/calc_OSLLxTxDecomposed.R
+++ b/R/calc_OSLLxTxDecomposed.R
@@ -33,18 +33,17 @@
 #' **@data**
 #' ```
 #' $LxTx.table (data.frame)
-#' .. $ LnLx
-#' .. $ TnTx
 #' .. $ Net_LnLx
 #' .. $ Net_LnLx.Error
 #' .. $ Net_TnTx
 #' .. $ Net_TnTx.Error
+#' .. $ SN_RATIO_LnLx = NA,
+#' .. $ SN_RATIO_TnTx = NA
 #' .. $ LxTx
-#' .. $ LxTx.relError
 #' .. $ LxTx.Error
 #' ```
 #'
-#' @section Function version: 0.1.0
+#' @section Function version: 0.1.1
 #'
 #' @author Dirk Mittelstrass
 #'
@@ -142,21 +141,16 @@ calc_OSLLxTxDecomposed <- function(
     TnTx.Error <- Tx.data$n.error[component_index]
   }
 
-  ##combine results
-  LnLxTnTx <- cbind(
-    LnLx,
-    LnLx.Error,
-    TnTx,
-    TnTx.Error
-  )
-
   ##--------------------------------------------------------------------------##
   ##(4) Calculate LxTx error according Galbraith (2014)
 
   ## transform results to a data.frame
-  LnLxTnTx <- as.data.frame(LnLxTnTx)
-  colnames(LnLxTnTx)<-c("Net_LnLx", "Net_LnLx.Error",
-                        "Net_TnTx", "Net_TnTx.Error")
+  LnLxTnTx <- data.frame(Net_LnLx = LnLx,
+                         Net_LnLx.Error = LnLx.Error,
+                         Net_TnTx = TnTx,
+                         Net_TnTx.Error = TnTx.Error,
+                         SN_RATIO_LnLx = NA,
+                         SN_RATIO_TnTx = NA)
 
   temp <- .calculate_LxTx_error(LnLxTnTx, sig0, digits)
 

--- a/man/calc_OSLLxTxDecomposed.Rd
+++ b/man/calc_OSLLxTxDecomposed.Rd
@@ -44,14 +44,13 @@ Slot \code{data} contains a \link{list} with the following structure:
 \strong{@data}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{$LxTx.table (data.frame)
-.. $ LnLx
-.. $ TnTx
 .. $ Net_LnLx
 .. $ Net_LnLx.Error
 .. $ Net_TnTx
 .. $ Net_TnTx.Error
+.. $ SN_RATIO_LnLx = NA,
+.. $ SN_RATIO_TnTx = NA
 .. $ LxTx
-.. $ LxTx.relError
 .. $ LxTx.Error
 }\if{html}{\out{</div>}}
 }
@@ -60,7 +59,7 @@ Calculate \code{Lx/Tx} ratios from a given set of decomposed
 CW-OSL curves decomposed by \code{OSLdecomposition::RLum.OSL_decomposition}.
 }
 \section{Function version}{
- 0.1.0
+ 0.1.1
 }
 
 \references{

--- a/tests/testthat/_snaps/calc_OSLLxTxDecomposed.md
+++ b/tests/testthat/_snaps/calc_OSLLxTxDecomposed.md
@@ -19,7 +19,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "LxTx", "LxTx.Error"]
+                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "SN_RATIO_LnLx", "SN_RATIO_TnTx", "LxTx", "LxTx.Error"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -52,6 +52,16 @@
                   "type": "double",
                   "attributes": {},
                   "value": [4638]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
                 },
                 {
                   "type": "double",
@@ -121,7 +131,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "LxTx", "LxTx.Error"]
+                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "SN_RATIO_LnLx", "SN_RATIO_TnTx", "LxTx", "LxTx.Error"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -154,6 +164,16 @@
                   "type": "double",
                   "attributes": {},
                   "value": [2765]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
                 },
                 {
                   "type": "double",
@@ -223,7 +243,7 @@
                 "names": {
                   "type": "character",
                   "attributes": {},
-                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "LxTx", "LxTx.Error"]
+                  "value": ["Net_LnLx", "Net_LnLx.Error", "Net_TnTx", "Net_TnTx.Error", "SN_RATIO_LnLx", "SN_RATIO_TnTx", "LxTx", "LxTx.Error"]
                 },
                 "row.names": {
                   "type": "integer",
@@ -256,6 +276,16 @@
                   "type": "double",
                   "attributes": {},
                   "value": [1655]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
+                },
+                {
+                  "type": "double",
+                  "attributes": {},
+                  "value": ["NA"]
                 },
                 {
                   "type": "double",


### PR DESCRIPTION
This updates the function to return the columns that were added in #1281, and makes `analyse_SAR.CWOSL()` handle the case in which the value of a rejection criterion is `NA` (by dropping it).

Fixes #1330.