### PR TITLE
.validate_integral: Warn if a length-2 non-consecutive integral is given

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1457,6 +1457,10 @@ SW <- function(expr) {
                    " and ", max(integral))
   if (any(integral != as.integer(integral)))
     .throw_error(name, " should be a vector of integers")
+  if (length(integral) == 2 && diff(integral) > 1)
+    .throw_warning(name, " was defined as c(", .format_range(integral, sep = ", "),
+                   ") but in general we would expect it to be defined as ",
+                   .format_range(integral), ", please check your input")
   sort(unique(integral))
 }
 

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -648,6 +648,12 @@ test_that("Test internals", {
                "All elements of 'list.integral' should be of class 'integer' or")
   expect_equal(.validate_integral(list.integral <- list(5:1), list.ok = TRUE),
                list(1:5))
+  expect_warning(.validate_integral(integral <- c(1, 3)),
+                 "'integral' was defined as c(1, 3) but in general we would",
+                 fixed = TRUE)
+  expect_no_warning(.validate_integral(integral <- c(1, 2)),
+                    message = "'integral' was defined as c(1, 2) but in general")
+
 
   ## .require_suggested_package() -------------------------------------------
   expect_true(.require_suggested_package("utils"))


### PR DESCRIPTION
This is meant to capture possibly wrong uses of integrals. While in theory this may have false positives, we don't expect integrals to be set to two non-consecutive values in real applications.

Fixes #1340.