### PR TITLE
.validate_integral: Return a clearer error if min > max

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1448,6 +1448,9 @@ SW <- function(expr) {
                   name = paste("All elements of", name)))
   }
   orig.length <- length(integral)
+  if (min > max)
+    .throw_error(name, " is expected to be at least ", min,
+                 ", but the maximum allowed is ", max)
   integral <- integral[!is.na(integral) & between(integral, min, max)]
   if (length(integral) == 0)
     .throw_error(name, " is of length 0 after removing values smaller than ",

--- a/tests/testthat/test_calc_OSLLxTxRatio.R
+++ b/tests/testthat/test_calc_OSLLxTxRatio.R
@@ -80,7 +80,7 @@ test_that("input validation", {
     Tx.data,
     signal_integral = 1:2000,
     background_integral = 85:100
-  ), "'background_integral' is of length 0 after removing values smaller than 101"),
+  ), "'background_integral' is expected to be at least 101, but the maximum allowed is 100"),
   "'signal_integral' reset to be between 1 and 100")
 
   SW({
@@ -124,7 +124,7 @@ test_that("input validation", {
     signal_integral_Tx = 1:1000,
     background_integral = 85:100,
     background_integral_Tx = 85:100
-  ), "background_integral_Tx' is of length 0 after removing values smaller than 101"),
+  ), "background_integral_Tx' is expected to be at least 101, but the maximum"),
   "'signal_integral_Tx' reset to be between 1 and 100")
 
   expect_error(calc_OSLLxTxRatio(

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -643,6 +643,8 @@ test_that("Test internals", {
                "'integral' is of length 0 after removing values smaller than 1$")
   expect_error(.validate_integral(integral <- 1:10, min = 50, max = 100),
                "after removing values smaller than 50 and greater than 100")
+  expect_error(.validate_integral(integral <- 1:10, min = 150, max = 100),
+               "is expected to be at least 150, but the maximum allowed is 100")
   expect_error(.validate_integral(integral <- 1:5 + 0.1),
                "'integral' should be a vector of integers")
   expect_error(.validate_integral(list.integral <- list(1:4)),


### PR DESCRIPTION
Fixes #1359.