### PR TITLE
analyse_SAR.CWOSL: Correct the consider.uncertainties implementation

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -177,10 +177,11 @@ sign and the threshold (as in `1.1 NA NA`) which would look ugly and confusing
 correctly, and in most cases validated to `"FAILED"` even for thresholds set
 to `NA` or `Inf` (3562bcab).
 
-* It is now possible to consider a 10% uncertainty when comparing the values
-computed for the various rejection criteria to their thresholds. This can be
-done by setting `consider.uncertainties = TRUE` in the `rejection.criteria`
-list. This is disabled by default to preserve existing behaviour (#1325).
+* It is now possible to consider value uncertainties in the computation of
+some rejection criteria (currently only `recycling.ratio`, `recuperation.rate`
+and `exceed.max.point`) by setting `consider.uncertainties = TRUE` in the
+`rejection.criteria` list. This is disabled by default to preserve existing
+behaviour (#1325).
 
 ## `analyse_SAR.TL()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -182,9 +182,9 @@ More information on these changes are available at
   correctly, and in most cases validated to `"FAILED"` even for
   thresholds set to `NA` or `Inf` (3562bcab).
 
-- It is now possible to consider a 10% uncertainty when comparing the
-  values computed for the various rejection criteria to their
-  thresholds. This can be done by setting
+- It is now possible to consider value uncertainties in the computation
+  of some rejection criteria (currently only `recycling.ratio`,
+  `recuperation.rate` and `exceed.max.point`) by setting
   `consider.uncertainties = TRUE` in the `rejection.criteria` list. This
   is disabled by default to preserve existing behaviour (#1325).
 

--- a/man/analyse_SAR.CWOSL.Rd
+++ b/man/analyse_SAR.CWOSL.Rd
@@ -233,9 +233,13 @@ be at least 50. By default it uses the value from the natural curve, but
 this can be changed by specifying the \code{sn_reference} option.
 
 By default, the computed values are compared directly to the corresponding
-thresholds to establish their result status ("OK" or "FAILED"). However, by
-setting option \code{consider.uncertainties = TRUE}, a 10\% uncertainty is
-considered when comparing a computed value with its threshold.
+thresholds to establish their result status ("OK" or "FAILED"). By setting
+the option \code{consider.uncertainties = TRUE} in the \code{rejection.criteria}
+list, quantified uncertainties are considered into the computation of the
+test value prior before comparing it to the threshold(currently supported
+only for \code{recycling.ratio}, \code{recuperation.rate} and \code{exceed.max.regpoint}).
+This reduces tests being marked as "FAILED" when the deviation from the
+threshold is smaller than the uncertainty margin.
 
 \strong{Irradiation times}
 
@@ -251,7 +255,7 @@ function does \strong{not} overwrite values preset in \code{IRR_TIME}.
 }
 }
 \section{Function version}{
- 0.13.1
+ 0.13.2
 }
 
 \examples{

--- a/tests/testthat/_snaps/analyse_SAR.CWOSL/na-rejection-criteria.svg
+++ b/tests/testthat/_snaps/analyse_SAR.CWOSL/na-rejection-criteria.svg
@@ -787,10 +787,10 @@
 <polyline points='630.08,265.24 713.28,265.24 ' style='stroke-width: 0.19;' />
 <text x='694.79' y='417.49' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='5.60px' lengthAdjust='spacingAndGlyphs'>1  </text>
 <text x='694.79' y='388.08' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='18.50px' lengthAdjust='spacingAndGlyphs'>0 &lt;= 0.1</text>
-<text x='694.79' y='358.67' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='43.69px' lengthAdjust='spacingAndGlyphs'>0.02 ± 0.002 &lt;= 0.1</text>
+<text x='694.79' y='358.67' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='25.51px' lengthAdjust='spacingAndGlyphs'>0.02 &lt;= 0.1</text>
 <text x='694.79' y='329.26' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='16.82px' lengthAdjust='spacingAndGlyphs'>17447  </text>
-<text x='694.79' y='299.85' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='43.69px' lengthAdjust='spacingAndGlyphs'>0.03 ± 0.003 &lt;= 0.1</text>
-<text x='694.79' y='270.44' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='49.30px' lengthAdjust='spacingAndGlyphs'>1534 ± 153.4 &lt;= 2550</text>
+<text x='694.79' y='299.85' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='25.51px' lengthAdjust='spacingAndGlyphs'>0.03 &lt;= 0.1</text>
+<text x='694.79' y='270.44' text-anchor='end' style='font-size: 5.04px; font-family: sans;' textLength='31.12px' lengthAdjust='spacingAndGlyphs'>1482 &lt;= 2550</text>
 <circle cx='708.66' cy='427.00' r='2.11' style='stroke-width: 0.75; stroke: #9E9E9E; fill: #9E9E9E;' />
 <circle cx='708.66' cy='397.59' r='2.11' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />
 <circle cx='708.66' cy='368.18' r='2.11' style='stroke-width: 0.75; stroke: #61D04F; fill: #61D04F;' />

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -444,10 +444,11 @@ test_that("check functionality", {
       rejection.criteria = list(
           recuperation.rate = 1,
           recuperation_reference = "R1",
+          recycling.ratio = 4,
           consider.uncertainties = FALSE),
       plot = FALSE, verbose = FALSE)
-  expect_equal(res$rejection.criteria$Status[[2]],
-               "FAILED")
+  expect_equal(res$rejection.criteria$Status[1:2],
+               c("FAILED", "FAILED"))
   res <- analyse_SAR.CWOSL(
       object = object[[1]],
       signal_integral = 1:2,
@@ -456,10 +457,11 @@ test_that("check functionality", {
       rejection.criteria = list(
           recuperation.rate = 1,
           recuperation_reference = "R1",
+          recycling.ratio = 4,
           consider.uncertainties = TRUE),
       plot = FALSE, verbose = FALSE)
-  expect_equal(res$rejection.criteria$Status[[2]],
-               "OK")
+  expect_equal(res$rejection.criteria$Status[1:2],
+               c("OK", "OK"))
 })
 
 test_that("advance tests run", {


### PR DESCRIPTION
This uses the estimated errors to adjust the computed value, adding the uncertainty in the most favourable direction, that is towards making the test pass more often.

Fixes #1325.