### PR TITLE
.validate_file: Allow for a recursive directory traversal

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1412,6 +1412,10 @@ SW <- function(expr) {
 #' (default), no pattern is applied, which corresponds to selecting all files
 #' found. It is considered only when `file` is a path to a directory.
 #'
+#' @param recursive [logical] (*with default*):
+#' Whether the scan of a path for files should be done recursively (`FALSE`
+#' by default).
+#'
 #' @inheritParams .validate_class
 #'
 #' @return
@@ -1419,7 +1423,7 @@ SW <- function(expr) {
 #' failed with an error thrown.
 #'
 #' @noRd
-.validate_file <- function(file, ext = NULL, pattern = NULL,
+.validate_file <- function(file, ext = NULL, pattern = NULL, recursive = FALSE,
                            throw.error = TRUE, verbose = TRUE) {
   .validate_class(file, c("character", "list"))
   .validate_not_empty(file)
@@ -1437,7 +1441,7 @@ SW <- function(expr) {
   }
 
   ## check if it's a path: if we find multiple files (or none), we return
-  files_in_path <- .scan_path_for_files(file, pattern, verbose)
+  files_in_path <- .scan_path_for_files(file, pattern, recursive, verbose)
   if (length(files_in_path) != 1) {
     return(as.list(files_in_path))
   }
@@ -1499,7 +1503,7 @@ SW <- function(expr) {
 #' A vector of file names, or `NULL` if no files are found.
 #'
 #' @noRd
-.scan_path_for_files <- function(path, pattern, verbose) {
+.scan_path_for_files <- function(path, pattern, recursive, verbose) {
   ## return immediately if this is not a path to a directory
   if (!dir.exists(path) || length(dir(path)) == 0) {
     return(path)
@@ -1511,7 +1515,7 @@ SW <- function(expr) {
                    " files ...", error = FALSE)
   }
 
-  files <- dir(path, pattern = pattern, recursive = FALSE,
+  files <- dir(path, pattern = pattern, recursive = recursive,
                full.names = TRUE, include.dirs = FALSE)
   if (length(files) == 0 && verbose) {
     .throw_message("No files matching the given pattern found in directory")

--- a/R/read_XSYG2R.R
+++ b/R/read_XSYG2R.R
@@ -99,7 +99,7 @@
 #' @param file [character] or [list] (**required**):
 #' name of one or multiple XSYG files (URLs are supported); it can be the path
 #' to a directory, in which case the function tries to detect and import all
-#' XSYG files found in the directory.
+#' XSYG files found recursively from the given directory.
 #'
 #' @param recalculate.TL.curves [logical] (*with default*):
 #' if set to `TRUE`, TL curves are returned as temperature against count values
@@ -224,7 +224,8 @@ read_XSYG2R <- function(
 
   .validate_logical_scalar(verbose)
   .validate_class(pattern, "character")
-  file <- .validate_file(file, pattern = pattern, throw.error = FALSE, verbose = verbose)
+  file <- .validate_file(file, pattern = pattern, recursive = TRUE,
+                         throw.error = FALSE, verbose = verbose)
   if (length(file) == 0)
     return(NULL)
   .validate_positive_scalar(n_records, int = TRUE, null.ok = TRUE)

--- a/man/read_XSYG2R.Rd
+++ b/man/read_XSYG2R.Rd
@@ -20,7 +20,7 @@ read_XSYG2R(
 \item{file}{\link{character} or \link{list} (\strong{required}):
 name of one or multiple XSYG files (URLs are supported); it can be the path
 to a directory, in which case the function tries to detect and import all
-XSYG files found in the directory.}
+XSYG files found recursively from the given directory.}
 
 \item{recalculate.TL.curves}{\link{logical} (\emph{with default}):
 if set to \code{TRUE}, TL curves are returned as temperature against count values

--- a/tests/testthat/test_read_XSYG2R.R
+++ b/tests/testthat/test_read_XSYG2R.R
@@ -83,6 +83,11 @@ test_that("test import of XSYG files", {
                           fastForward = TRUE, import = TRUE,
                           verbose = TRUE),
               "list")
+
+  ## recursive traversal
+  expect_length(read_XSYG2R(test_path("_data"),
+                            fastForward = TRUE, verbose = FALSE),
+                7)
   })
 
   ## more tests for different TL curve calculation cases


### PR DESCRIPTION
Currently the recursive mode is activated only `for read_XSYG2R()`, consistently with the behaviour that existed prior to 62aaa824.

Fixes #1393.