### PR TITLE
analyse_SAR.TL: Rename integral_input option to "measurement"

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -202,6 +202,11 @@ number represents the consecutive number of objects processed.
 * Argument `signal.integral` has been renamed to `signal_integral`. The older
 name will still work but generate a deprecation warning (#1290).
 
+* The `integral_input` argument now accepts options "channel" (as before) and
+"measurement" (instead of "temperature"). This was done to uniform the choices
+accepted by the argument throughout the package. The older name will still
+work but generates a deprecation warning (#1396).
+
 ### `apply_EfficiencyCorrection()`
 
 * The function no longer produces an invalid object when the interpolation

--- a/NEWS.md
+++ b/NEWS.md
@@ -208,6 +208,12 @@ More information on these changes are available at
 - Argument `signal.integral` has been renamed to `signal_integral`. The
   older name will still work but generate a deprecation warning (#1290).
 
+- The `integral_input` argument now accepts options “channel” (as
+  before) and “measurement” (instead of “temperature”). This was done to
+  uniform the choices accepted by the argument throughout the package.
+  The older name will still work but generates a deprecation warning
+  (#1396).
+
 ### `apply_EfficiencyCorrection()`
 
 - The function no longer produces an invalid object when the

--- a/R/analyse_SAR.TL.R
+++ b/R/analyse_SAR.TL.R
@@ -26,9 +26,9 @@
 #' vector of inputs (as defined by `integral_input`) for the signal integral.
 #'
 #' @param integral_input [character] (*with default*):
-#' defines the input for `signal_integral`. These limits can be either provided
-#' as `"channel"` number (default) or `"temperature"`. For `"temperature"`,
-#' the best matching channel is selected.
+#' input type for `signal_integral`, one of `"channel"` (default) or
+#' `"measurement"`. If set to `"measurement"`, the best matching channels
+#' corresponding to the given temperature range are selected.
 #'
 #' @param sequence.structure [vector] [character] (*with default*):
 #' specifies the general sequence structure. Three steps are allowed
@@ -65,7 +65,7 @@
 #'
 #' No TL curves will be removed from the input object without further warning.
 #'
-#' @section Function version: 0.3.2
+#' @section Function version: 0.3.3
 #'
 #' @author
 #' Sebastian Kreutzer, F2.1 Geophysical Parametrisation/Regionalisation, LIAG - Institute for Applied Geophysics (Germany)
@@ -120,6 +120,12 @@ analyse_SAR.TL <- function(
                 since = "1.2.0")
     signal_integral <- list(...)$signal.integral
   }
+  if (integral_input == "temperature") {
+    .deprecated(old = "integral_input = \"temperature\"",
+                new = "integral_input = \"measurement\"",
+                since = "1.2.0")
+    integral_input <- "measurement"
+  }
 
   # Self-call -----------------------------------------------------------------------------------
   if(inherits(object, "list")){
@@ -153,8 +159,9 @@ analyse_SAR.TL <- function(
   ## Integrity checks -------------------------------------------------------
 
   .validate_class(object, "RLum.Analysis")
-  signal_integral <- .validate_integral(signal_integral)
-  integral_input <- .validate_args(integral_input, c("channel", "temperature"))
+  integral_input <- .validate_args(integral_input, c("channel", "measurement"))
+  signal_integral <- .validate_integral(signal_integral,
+                                        int = integral_input == "channel")
 
   # Protocol Integrity Checks --------------------------------------------------
 
@@ -215,7 +222,7 @@ analyse_SAR.TL <- function(
   }
 
   ## convert integral limits from temperature to channel
-  if(integral_input == "temperature"){
+  if (integral_input == "measurement") {
     temp.obj <- get_RLum(object, record.id = TL.signal.ID[1])
     signal_integral <- .convert_to_channels(temp.obj, signal_integral,
                                             unit = "temperature")

--- a/man/analyse_SAR.TL.Rd
+++ b/man/analyse_SAR.TL.Rd
@@ -26,9 +26,9 @@ input object containing data for analysis}
 vector of inputs (as defined by \code{integral_input}) for the signal integral.}
 
 \item{integral_input}{\link{character} (\emph{with default}):
-defines the input for \code{signal_integral}. These limits can be either provided
-as \code{"channel"} number (default) or \code{"temperature"}. For \code{"temperature"},
-the best matching channel is selected.}
+input type for \code{signal_integral}, one of \code{"channel"} (default) or
+\code{"measurement"}. If set to \code{"measurement"}, the best matching channels
+corresponding to the given temperature range are selected.}
 
 \item{sequence.structure}{\link{vector} \link{character} (\emph{with default}):
 specifies the general sequence structure. Three steps are allowed
@@ -85,7 +85,7 @@ background see Aitken and Smith (1988)
 No TL curves will be removed from the input object without further warning.
 }
 \section{Function version}{
- 0.3.2
+ 0.3.3
 }
 
 \examples{

--- a/tests/testthat/test_analyse_SAR.TL.R
+++ b/tests/testthat/test_analyse_SAR.TL.R
@@ -33,6 +33,17 @@ test_that("input validation", {
                "[analyse_SAR.TL()] 'integral_input' should be one of ",
                fixed = TRUE)
 
+  SW({
+  expect_warning(analyse_SAR.TL(object, signal_integral = c(0, 1.5),
+                                sequence.structure = c("SIGNAL", "BACKGROUND"),
+                                integral_input = "measurement"),
+                 "Conversion of integrals from temperature to channels failed")
+  expect_warning(analyse_SAR.TL(object, signal_integral = 2000:2100,
+                                sequence.structure = c("SIGNAL", "BACKGROUND"),
+                                integral_input = "measurement"),
+                 "Conversion of integrals from temperature to channels failed")
+  })
+
   obj.rm <- object
   obj.rm@records[[1]]@data <- obj.rm@records[[1]]@data[1:225, ]
   expect_error(analyse_SAR.TL(obj.rm, signal_integral = 210:220,
@@ -51,6 +62,12 @@ test_that("input validation", {
                                 sequence.structure = c("SIGNAL", "BACKGROUND"),
                                 verbose = FALSE),
                  "was deprecated in v1.2.0, use 'signal_integral'")
+  expect_warning(analyse_SAR.TL(object,
+                                signal_integral = 210:220,
+                                integral_input = "temperature",
+                                sequence.structure = c("SIGNAL", "BACKGROUND"),
+                                verbose = FALSE),
+                 "was deprecated in v1.2.0, use 'integral_input = \"measurement\"")
 })
 
 test_that("snapshot tests", {
@@ -62,7 +79,7 @@ test_that("snapshot tests", {
         list(object, object),
         signal_integral = 210:220,
         dose.points = 1:7,
-        integral_input = "temperature",
+        integral_input = "measurement",
         sequence.structure = c("SIGNAL", "BACKGROUND"))
   )
 


### PR DESCRIPTION
This is in preparation of further uses of the `integral_input` argument in other functions, where we have time instead of temperature. Uniforming the names of the options throughout helps with consistency.

Part of #1396.