### PR TITLE
analyse_baSAR: Don't attempt to plot a DRC if the fit failed

### DIFF
--- a/R/analyse_baSAR.R
+++ b/R/analyse_baSAR.R
@@ -1495,7 +1495,7 @@ analyse_baSAR <- function(
           verbose = verbose,
           txtProgressBar = FALSE
         ))
-      if (additional_arguments$plot_drc) {
+      if (!is.null(fitcurve) && additional_arguments$plot_drc) {
         plot_DoseResponseCurve(
             fitcurve,
             plot_extended = additional_arguments$plot_extended,
@@ -1663,11 +1663,13 @@ analyse_baSAR <- function(
       .throw_warning(sprintf(msg, "lower"))
     }
 
-    if (min(input_object[["DE"]][input_object[["DE"]] > 0], na.rm = TRUE) < method_control$lower_centralD ||
-        max(input_object[["DE"]], na.rm = TRUE) > method_control$upper_centralD) {
+  temp.DE <- input_object$DE
+  if (all(is.na(temp.DE)) ||
+      min(temp.DE[temp.DE > 0], na.rm = TRUE) < method_control$lower_centralD ||
+      max(temp.DE, na.rm = TRUE) > method_control$upper_centralD) {
       .throw_warning("Your lower_centralD and/or upper_centralD values ",
-                     "seem not to fit to your input data. This may indicate ",
-                     "a wronlgy set 'source_doserate'.")
+                     "seem not to fit to your input data, this may indicate ",
+                     "an incorrect 'source_doserate'")
     }
 
   ##>> try here is much better, as the user might run a very long preprocessing and do not

--- a/tests/testthat/test_analyse_baSAR.R
+++ b/tests/testthat/test_analyse_baSAR.R
@@ -546,6 +546,19 @@ test_that("regression tests", {
       "Adaptation incomplete")
   })
 
+  ## issue 1426
+  suppressMessages( # Error: All points have the same dose, NULL returned
+  expect_warning(expect_warning(
+      analyse_baSAR(CWOSL.sub, verbose = FALSE, plot = FALSE,
+                    source_doserate = 0,
+                    signal_integral = 1:2,
+                    background_integral = 80:100,
+                    method_control = list(n.chains = 1),
+                    n.MCMC = 60),
+      "Only multiple grain data provided, automatic selection skipped"),
+      "this may indicate an incorrect 'source_doserate'")
+  )
+
   ## check parameters irradiation times
   SW({
   expect_s4_class(suppressWarnings(analyse_baSAR(CWOSL.sub,


### PR DESCRIPTION
This also fixes these warnings that arise when no dose response curve can be fitted:

```
 In min(input_object[["DE"]][input_object[["DE"]] > 0], na.rm = TRUE) :
   no non-missing arguments to min; returning Inf
 In max(input_object[["DE"]], na.rm = TRUE) :
   no non-missing arguments to max; returning -Inf
```

Fixes #1426.