### PR TITLE
merge_RLum.Data.Spectrum: Avoid spurious warnings if colnames are NULL

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -432,6 +432,11 @@ enough to fit the requested number of components (#1448).
 * Argument `input.objects` has been renamed to `objects`. The older name will
 still work but generates a deprecation warning (#1434).
 
+### `merge_RLum.Data.Spectrum()`
+
+* The function no longer warns unnecessarily if the RLum.Data.Spectrum object
+contains no column names (#1450).
+
 ### `plot_DetPlot()`
 
 * When operating on a list with the default setting of `multicore = TRUE`, the

--- a/NEWS.md
+++ b/NEWS.md
@@ -456,6 +456,11 @@ More information on these changes are available at
 - Argument `input.objects` has been renamed to `objects`. The older name
   will still work but generates a deprecation warning (#1434).
 
+### `merge_RLum.Data.Spectrum()`
+
+- The function no longer warns unnecessarily if the RLum.Data.Spectrum
+  object contains no column names (#1450).
+
 ### `plot_DetPlot()`
 
 - When operating on a list with the default setting of

--- a/R/merge_RLum.Data.Spectrum.R
+++ b/R/merge_RLum.Data.Spectrum.R
@@ -181,9 +181,11 @@ merge_RLum.Data.Spectrum <- function(
 
     ## for time/temperature data we allow some small differences: we report
     ## a warning if they are too high, but continue anyway
-    if (max(abs(as.numeric(colnames(x@data)) - y.vals)) > max.temp.diff) {
-      .throw_warning("The time/temperatures recorded are too different, ",
-                     "proceed with caution")
+    if (!is.null(colnames(x@data))) {
+      if (max(abs(as.numeric(colnames(x@data)) - y.vals)) > max.temp.diff) {
+        .throw_warning("The time/temperatures recorded are too different, ",
+                       "proceed with caution")
+      }
     }
 
     x@data

--- a/tests/testthat/test_merge_RLum.Data.Spectrum.R
+++ b/tests/testthat/test_merge_RLum.Data.Spectrum.R
@@ -46,6 +46,8 @@ test_that("input validation", {
                  "The time/temperatures recorded are too different")
   expect_silent(merge_RLum.Data.Spectrum(list(TL.Spectrum, TL.Spectrum_other),
                                          max.temp.diff = 1))
+  spectrum <- set_RLum("RLum.Data.Spectrum", data = matrix(1:10, ncol = 2))
+  expect_no_warning(merge_RLum(list(spectrum, spectrum)))
 })
 
 test_that("check functionality", {


### PR DESCRIPTION
There's no point in trying to check the difference in column names if they are not present. Attempting it produces these warnings:
```
  In max(abs(as.numeric(colnames(x@data)) - y.vals)) :
     no non-missing arguments to max; returning -Inf
```

Fixes #1450.