### PR TITLE
calc_FiniteMixture: Allow to include 1 in n.components

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -280,6 +280,12 @@ work but generates a deprecation warning (#1434).
 * The function incorrectly disallowed setting `sigmab > 1` when `log = FALSE`
 due to excessively strict input validation (#1343).
 
+### `calc_FiniteMixture()`
+
+* The function didn't allow inputs such as `n.components = 1:3`, enforcing the
+usage of `n.components = 2:3` instead. This check, added in v1.1.0, was
+unnecessarily stringent and has been reverted (#1458).
+
 ### `calc_gSGC()`
 
 * The function no longer crashes in `n.MC` is set to 0 (#1327).

--- a/NEWS.md
+++ b/NEWS.md
@@ -293,6 +293,12 @@ More information on these changes are available at
 - The function incorrectly disallowed setting `sigmab > 1` when
   `log = FALSE` due to excessively strict input validation (#1343).
 
+### `calc_FiniteMixture()`
+
+- The function didn’t allow inputs such as `n.components = 1:3`,
+  enforcing the usage of `n.components = 2:3` instead. This check, added
+  in v1.1.0, was unnecessarily stringent and has been reverted (#1458).
+
 ### `calc_gSGC()`
 
 - The function no longer crashes in `n.MC` is set to 0 (#1327).

--- a/R/calc_FiniteMixture.R
+++ b/R/calc_FiniteMixture.R
@@ -221,7 +221,7 @@ calc_FiniteMixture <- function(
     .throw_error("'sigmab' must be a value between 0 and 1")
   }
   .validate_class(n.components, c("integer", "numeric"))
-  if (min(n.components) < 2) {
+  if (length(n.components) == 1 && n.components < 2) {
     .throw_error("'n.components' should be at least 2")
   }
   .validate_logical_scalar(grain.probability)
@@ -233,6 +233,7 @@ calc_FiniteMixture <- function(
   .validate_logical_scalar(plot)
 
   ## ensure that the chosen components are sorted
+  n.components <- setdiff(n.components, 1)
   n.components <- sort(n.components)
   multiple.components <- length(n.components) > 1
 

--- a/tests/testthat/test_calc_FiniteMixture.R
+++ b/tests/testthat/test_calc_FiniteMixture.R
@@ -150,5 +150,9 @@ test_that("regression tests", {
   expect_silent(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.54,
                                    n.components = 2:5, pdf.weight = FALSE,
                                    verbose = FALSE))
+
+  ## issue 1458
+  expect_silent(calc_FiniteMixture(ExampleData.DeValues$CA1, sigmab = 0.1,
+                                   n.components = 1:3, verbose = FALSE))
   })
 })


### PR DESCRIPTION
This reverts an unnecessarily stringent check that was added in v1.1.0. Now it's again allowed to include 1 in `n.components`, as it will be silently ignored inside the function body.

Fixes #1458.