### PR TITLE
README: Don't generate link to CONTRIBUTING.md when releasing on CRAN

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -81,7 +81,11 @@ or contributing new functions.
 Open an [issue](https://github.com/R-Lum/Luminescence/issues) or write us an
 [e-mail](mailto:developers@r-luminescence.org) if anything crosses your mind
 or if you want your new self-written function to be to included in the package.
-See also our [workflow for contributions](CONTRIBUTING.md).
+```{r, results='asis', echo=FALSE}
+if (Sys.getenv("AS_CRAN") != "TRUE") {  # see issue 1478
+   cat("See also our [workflow for contributions](CONTRIBUTING.md).")
+}
+```
 
 You are kindly invited to bring forward the package with us!
 
@@ -138,4 +142,3 @@ led by Dr Sebastian Kreutzer (PI at Heidelberg University, DE (until 2025), LIAG
 ```{r Outro, echo=FALSE}
 detach("package:Luminescence")
 ```
-


### PR DESCRIPTION
This is now necessary because the CRAN checks flag it as a non-canonical URI which triggers a manual inspection and a request to resubmit. This requires an updated RLumBuild to fully work.

Fixes #1478.