### PR TITLE
calc_WodaFuchs: Comment out an unused and potentially wrong bit of code

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -26,4 +26,9 @@ correctly initialised when `n.MC = 1`. This was spotted by the `valgrind`
 memory debugger run by CRAN, and triggered a request to resubmit the
 package (#1479).
 
+### `calc_WodaFuchs()`
+
+* The curvature was computed but never used. As its implementation looked
+fragile, the line of code that computed it was commented out (#223).
+
 ## Other changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,4 +15,10 @@
   `valgrind` memory debugger run by CRAN, and triggered a request to
   resubmit the package (#1479).
 
+### `calc_WodaFuchs()`
+
+- The curvature was computed but never used. As its implementation
+  looked fragile, the line of code that computed it was commented out
+  (#223).
+
 ## Other changes

--- a/R/calc_WodaFuchs2008.R
+++ b/R/calc_WodaFuchs2008.R
@@ -139,9 +139,10 @@ calc_WodaFuchs2008 <- function(
   ## log counts
   counts_log <- log(H_c)
 
-  ## estimate curvature
-  curvature <- (counts_log[1] - counts_log[2]) /
-    (counts_log[1] - counts_log[3])
+  ## commented out for issue 223
+  ## ## estimate curvature
+  ## curvature <- (counts_log[1] - counts_log[2]) /
+  ##   (counts_log[1] - counts_log[3])
 
   ## do some other black magic
   class_center <- H$mids[H_c == max(H_c)]


### PR DESCRIPTION
Fixes #223 in the easiest way, given that most of the criticism was in the computation of the curvature, but that value was not even used.