### PR TITLE
convert_CW2p[HLP]Mi: Stop early if there are duplicate time values

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -36,4 +36,12 @@ for deprecated arguments (#1483).
 * The curvature was computed but never used. As its implementation looked
 fragile, the line of code that computed it was commented out (#223).
 
+### `convert_CW2HMi()`, `convert_CW2LMi()`, `convert_CW2PMi()`
+
+* The functions stop early if the imput object contains duplicate times.
+Previously this generated a warning but produced results according to whatever
+`approx()` decided to keep. We believe that instead the user should be in
+charge of removing duplicated values, so that they can better assess which
+should be kept or why there are duplicates at all (#1485).
+
 ## Other changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,4 +26,13 @@
   looked fragile, the line of code that computed it was commented out
   (#223).
 
+### `convert_CW2HMi()`, `convert_CW2LMi()`, `convert_CW2PMi()`
+
+- The functions stop early if the imput object contains duplicate times.
+  Previously this generated a warning but produced results according to
+  whatever `approx()` decided to keep. We believe that instead the user
+  should be in charge of removing duplicated values, so that they can
+  better assess which should be kept or why there are duplicates at all
+  (#1485).
+
 ## Other changes

--- a/R/convert_CW2pHMi.R
+++ b/R/convert_CW2pHMi.R
@@ -90,7 +90,7 @@
 #' the values are removed and no further interpolation is attempted.
 #' In every case a warning message is shown.
 #'
-#' @section Function version: 0.2.6
+#' @section Function version: 0.2.7
 #'
 #' @author
 #' Sebastian Kreutzer, F2.1 Geophysical Parametrisation/Regionalisation, LIAG - Institute for Applied Geophysics (Germany)\cr
@@ -218,6 +218,9 @@ convert_CW2pHMi<- function(
 
   ##time transformation t >> t'
   t<-temp.values[,1]
+  if (anyDuplicated(t) > 0) {
+    .throw_error("'object' contains duplicated time values")
+  }
 
   ##set delta
   ##if no values for delta is set selected a delta value for a maximum of

--- a/R/convert_CW2pLMi.R
+++ b/R/convert_CW2pLMi.R
@@ -1,7 +1,8 @@
 #' @title Transform a CW-OSL curve into a pLM-OSL curve via interpolation under linear
 #' modulation conditions
 #'
-#' @description Transforms a conventionally measured continuous-wave (CW) OSL-curve into a
+#' @description
+#' Transforms a conventionally measured continuous-wave (CW) OSL-curve into a
 #' pseudo linearly modulated (pLM) curve under linear modulation conditions
 #' using the interpolation procedure described by Bos & Wallinga (2012).
 #'
@@ -81,7 +82,7 @@
 #' provided manually and more than two points are extrapolated, a warning
 #' message is returned.
 #'
-#' @section Function version: 0.3.4
+#' @section Function version: 0.3.5
 #'
 #' @author
 #' Sebastian Kreutzer, F2.1 Geophysical Parametrisation/Regionalisation, LIAG - Institute for Applied Geophysics (Germany)\cr
@@ -175,6 +176,9 @@ convert_CW2pLMi<- function(
 
   ##(b) time transformation t >> t'
   t<-temp.values[,1]
+  if (anyDuplicated(t) > 0) {
+    .throw_error("'object' contains duplicated time values")
+  }
 
   ##set P
   ##if no values for P is set selected a P value for a maximum of

--- a/R/convert_CW2pPMi.R
+++ b/R/convert_CW2pPMi.R
@@ -1,7 +1,8 @@
 #' @title Transform a CW-OSL curve into a pPM-OSL curve via interpolation under
 #' parabolic modulation conditions
 #'
-#' @description Transforms a conventionally measured continuous-wave (CW) OSL-curve into a
+#' @description
+#' Transforms a conventionally measured continuous-wave (CW) OSL-curve into a
 #' pseudo parabolic modulated (pPM) curve under parabolic modulation conditions
 #' using the interpolation procedure described by Bos & Wallinga (2012).
 #'
@@ -80,7 +81,7 @@
 #' should be limited to avoid artificial intensity data. If `P` is
 #' provided manually, not more than two points are extrapolated.
 #'
-#' @section Function version: 0.2.4
+#' @section Function version: 0.2.5
 #'
 #' @author
 #' Sebastian Kreutzer, F2.1 Geophysical Parametrisation/Regionalisation, LIAG - Institute for Applied Geophysics (Germany)\cr
@@ -174,6 +175,9 @@ convert_CW2pPMi<- function(
 
   ##time transformation t >> t'
   t<-temp.values[,1]
+  if (anyDuplicated(t) > 0) {
+    .throw_error("'object' contains duplicated time values")
+  }
 
   ##set P
   ##if no values for P is set selected a P value for a maximum of

--- a/man/convert_CW2pHMi.Rd
+++ b/man/convert_CW2pHMi.Rd
@@ -103,7 +103,7 @@ the values are removed and no further interpolation is attempted.
 In every case a warning message is shown.
 }
 \section{Function version}{
- 0.2.6
+ 0.2.7
 }
 
 \examples{

--- a/man/convert_CW2pLMi.Rd
+++ b/man/convert_CW2pLMi.Rd
@@ -91,7 +91,7 @@ provided manually and more than two points are extrapolated, a warning
 message is returned.
 }
 \section{Function version}{
- 0.3.4
+ 0.3.5
 }
 
 \examples{

--- a/man/convert_CW2pPMi.Rd
+++ b/man/convert_CW2pPMi.Rd
@@ -100,7 +100,7 @@ should be limited to avoid artificial intensity data. If \code{P} is
 provided manually, not more than two points are extrapolated.
 }
 \section{Function version}{
- 0.2.4
+ 0.2.5
 }
 
 \examples{

--- a/tests/testthat/test_convert_CW2pX.R
+++ b/tests/testthat/test_convert_CW2pX.R
@@ -35,12 +35,10 @@ test_that("check functionality", {
                             tolerance = tol),
       "t' is beyond the time resolution and more than two data points")
 
-  expect_warning(expect_error(convert_CW2pLMi(iris),
-                              "All points are outside the interpolation range"),
-                 "collapsing to unique 'x' values")
-  expect_warning(expect_error(convert_CW2pPMi(iris),
-                              "All points are outside the interpolation range"),
-                 "collapsing to unique 'x' values")
+  expect_error(convert_CW2pLMi(iris[1:5, ]),
+               "All points are outside the interpolation range")
+  expect_error(convert_CW2pPMi(iris[1:5, ]),
+               "All points are outside the interpolation range")
 
   ## deprecated argument
   expect_warning(convert_CW2pHMi(values = object),
@@ -92,6 +90,8 @@ test_that("input validation", {
                "All interpolated values are Inf/NaN/NA, check your data")
   expect_error(convert_CW2pHMi(data.frame(a = 1:10, b = NA)),
                "'object' should have at least 2 non-missing values")
+  expect_error(convert_CW2pHMi(iris),
+               "'object' contains duplicated time values")
   expect_error(convert_CW2pHMi(values, iris),
                "'delta' should be of class 'numeric' or NULL")
   expect_error(convert_CW2pHMi(values, NA_real_),
@@ -105,6 +105,8 @@ test_that("input validation", {
                "'object' should have 2 columns")
   expect_error(convert_CW2pLMi(data.frame(a = 1:10, b = NA)),
                "'object' should have at least 2 non-missing values")
+  expect_error(convert_CW2pLMi(iris),
+               "'object' contains duplicated time values")
   expect_error(convert_CW2pLMi(object, iris),
                "'P' should be a single positive value")
 
@@ -123,6 +125,8 @@ test_that("input validation", {
                "'object' should have 2 columns")
   expect_error(convert_CW2pPMi(data.frame(a = 1:10, b = NA)),
                "'object' should have at least 2 non-missing values")
+  expect_error(convert_CW2pPMi(iris),
+               "'object' contains duplicated time values")
   expect_error(convert_CW2pPMi(values, iris),
                "'P' should be a single positive value or NULL")
 


### PR DESCRIPTION
This avoids an uncaught warning and a potentially arbitrary removal of duplicates by `approx()`. It's better that duplicated values are removed explicitly by the user.

Fixes #1485.