### PR TITLE
.validate_args: Ensure that only one validated argument is returned

### DIFF
--- a/R/internals_RLum.R
+++ b/R/internals_RLum.R
@@ -1242,7 +1242,7 @@ SW <- function(expr) {
   if (all(idx.match == 0L))
     .throw_error(name %||% .first_argument(), " should be one of ",
                  .collapse(choices.extra, quote = FALSE, last_sep = " or "))
-  idx <- idx.match[idx.match > 0L]
+  idx <- idx.match[idx.match > 0L][1]
   choices[idx]
 }
 

--- a/tests/testthat/test_internals.R
+++ b/tests/testthat/test_internals.R
@@ -367,6 +367,8 @@ test_that("Test internals", {
   expect_equal(fun1(arg = "val1"), "val1")
   expect_equal(fun1(arg = c("val1", "val2")), "val1")
   expect_equal(fun1(arg = c("val3", "val2")), "val3")
+  expect_equal(.validate_args(matrix(letters), c("reciprocal", "square")),
+               "reciprocal")
   expect_error(fun1(arg = c("error", "val1")),
                "[test()] 'arg' contains multiple values but not all of them",
                fixed = TRUE)


### PR DESCRIPTION
Fixes #1499.