### PR TITLE
test_use_DRAC: Remove workaround for bug in DRAC

### DIFF
--- a/tests/testthat/test_use_DRAC.R
+++ b/tests/testthat/test_use_DRAC.R
@@ -66,10 +66,7 @@ test_that("check functionality", {
  input$`External K (%)` <- 1.2
  input$`errExternal K (%)` <- 0.14
  input$`Calculate external Rb from K conc?` <- "Y"
- ## TODO(mcol): temporarily disabled due to issue 919
- if (FALSE) {
  input$`Calculate internal Rb from K conc?` <- "Y"
- }
  input$`Scale gammadoserate at shallow depths?` <- "Y"
  input$`Grain size min (microns)` <- 90L
  input$`Grain size max (microns)` <- 125L


### PR DESCRIPTION
This no longer triggers a status code 500 with DRAC v1.3.

Fixes #919.