### PR TITLE
fit_DoseResponseCurve: Recyle weights only if of length 1

### DIFF
--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -131,9 +131,9 @@
 #' common nls fitting methods.*
 #'
 #' If the option `fit.weights =  NULL` all weights are set to 1, which disables
-#' weighting all along. If `fit.weights` is a [numeric] vector of correct length (same number of rows
-#' such as the input `LxTx`), then those fit weights are used. This comes in
-#' handy if you want to compare different fitting algorithms that have
+#' weighting all along. If `fit.weights` is a [numeric] vector of correct length
+#' (same number of rows as the input `LxTx`), then those fit weights are used.
+#' This may be helpful to compare different fitting algorithms that have
 #' implemented fit weights differently.
 #'
 #' **Error estimation using Monte Carlo simulation**
@@ -188,10 +188,8 @@
 #' @param fit.weights [character] [numeric] (*with default*):
 #' weighting approach to be used for the fitting. Options are `inverse_var`
 #' (default), `inverse_std`, `norm_inverse_std`, a [numeric] vector, or `NULL`
-#' (no weighting).
-#' If the input is a numeric vector, is must of the same length as the
-#' number of data points to fit (usually the `LxTx` values). If the number differs,
-#' they are recycled or reduced to the desired length with a warning. See details.
+#' (no weighting). If the input is a numeric vector, it must have length equal
+#' to the number of data points to fit (usually the `LxTx` values). See details.
 #'
 #' @param fit.includingRepeatedRegPoints [logical] (*with default*):
 #' includes repeated points for fitting (`TRUE`/`FALSE`).
@@ -528,12 +526,15 @@ fit_DoseResponseCurve <- function(
     fit.weights <- rep(1, length(y.Error))
 
   } else if (inherits(fit.weights, "numeric")) {
-    ## numeric case
-    ## we automatically expand but throw a warning
-    .validate_length(fit.weights, length(y.Error), throw.error = FALSE)
-
-    ## recycle fit weights ... so we get only the warning
-    fit.weights <- rep(fit.weights, length.out = length(y.Error))
+    ## if only a scalar is provided, we recycle it
+    if (length(fit.weights) == 1) {
+      fit.weights <- rep(fit.weights, length(y.Error))
+    } else {
+      ## we ask the user to provide weights of length corresponding to the
+      ## size of the input, but we keep only those we actually need
+      .validate_length(fit.weights, nrow(object))
+      fit.weights <- fit.weights[first.idx:last.idx]
+    }
 
   } else {
     ## the character case

--- a/man/fit_DoseResponseCurve.Rd
+++ b/man/fit_DoseResponseCurve.Rd
@@ -58,10 +58,8 @@ the origin in either case, so this option will have no effect.}
 \item{fit.weights}{\link{character} \link{numeric} (\emph{with default}):
 weighting approach to be used for the fitting. Options are \code{inverse_var}
 (default), \code{inverse_std}, \code{norm_inverse_std}, a \link{numeric} vector, or \code{NULL}
-(no weighting).
-If the input is a numeric vector, is must of the same length as the
-number of data points to fit (usually the \code{LxTx} values). If the number differs,
-they are recycled or reduced to the desired length with a warning. See details.}
+(no weighting). If the input is a numeric vector, it must have length equal
+to the number of data points to fit (usually the \code{LxTx} values). See details.}
 
 \item{fit.includingRepeatedRegPoints}{\link{logical} (\emph{with default}):
 includes repeated points for fitting (\code{TRUE}/\code{FALSE}).}
@@ -273,9 +271,9 @@ common nls fitting methods.}
 }
 
 If the option \code{fit.weights =  NULL} all weights are set to 1, which disables
-weighting all along. If \code{fit.weights} is a \link{numeric} vector of correct length (same number of rows
-such as the input \code{LxTx}), then those fit weights are used. This comes in
-handy if you want to compare different fitting algorithms that have
+weighting all along. If \code{fit.weights} is a \link{numeric} vector of correct length
+(same number of rows as the input \code{LxTx}), then those fit weights are used.
+This may be helpful to compare different fitting algorithms that have
 implemented fit weights differently.
 
 \strong{Error estimation using Monte Carlo simulation}

--- a/tests/testthat/test_fit_DoseResponseCurve.R
+++ b/tests/testthat/test_fit_DoseResponseCurve.R
@@ -57,10 +57,8 @@ test_that("input validation", {
                "'fit.weights' should be one of 'inverse_var', 'inverse_std' or 'norm_inverse_std'")
   expect_error(fit_DoseResponseCurve(LxTxData, fit.weights = iris),
                "'fit.weights' should be of class 'character', 'numeric' or NULL")
-  SW({
-  expect_warning(fit_DoseResponseCurve(LxTxData, fit.weights = c(1,2)),
-               "'fit.weights' should have length 6")
-  })
+  expect_error(fit_DoseResponseCurve(LxTxData, fit.weights = c(1, 2)),
+               "'fit.weights' should have length 7")
   expect_error(fit_DoseResponseCurve(LxTxData,
                                      fit.includingRepeatedRegPoints = "error"),
                "'fit.includingRepeatedRegPoints' should be a single logical")
@@ -197,7 +195,7 @@ test_that("snapshot tests", {
   expect_snapshot_RLum(fit_DoseResponseCurve(
     LxTxData,
     fit.method = "EXP",
-    fit.weights = 1/LxTxData[[3]][-1]^2,
+    fit.weights = 1 / LxTxData[[3]]^2,
     verbose = FALSE,
     n.MC = 10
   ), tolerance = snapshot.tolerance)
@@ -611,7 +609,7 @@ temp_OTORX_alt <-
       LxTxData,
       mode = "alternate",
       fit.method = "EXP",
-      fit.weights = 1/LxTxData[[3]]^2,
+      fit.weights = 1,
       verbose = FALSE
     ),
     "RLum.Results"


### PR DESCRIPTION
This provides better user experience, as weights can have the same length as the input dataset. This also avoids throwing warning if a single value is given.

This addresses the comments in https://github.com/R-Lum/Luminescence/pull/1536#discussion_r3101272201 and https://github.com/R-Lum/Luminescence/pull/1539#discussion_r3122668863.