### PR TITLE
fit_DoseResponseCurve: Ensure that data.MC is always a matrix

### DIFF
--- a/R/fit_DoseResponseCurve.R
+++ b/R/fit_DoseResponseCurve.R
@@ -554,7 +554,7 @@ fit_DoseResponseCurve <- function(
   first.idx <- ifelse(mode == "interpolation", 2, 1)
   last.idx <- fit.NumberRegPoints + 1
 
-  data.MC <- t(vapply(
+  data.MC <- t(matrix(vapply(
       X = first.idx:last.idx,
       FUN = function(x) {
         sample(rnorm(
@@ -566,7 +566,7 @@ fit_DoseResponseCurve <- function(
         replace = TRUE)
       },
       FUN.VALUE = numeric(n.MC)
-    ))
+    ), nrow = n.MC))
 
   if (mode == "interpolation") {
     #1.3 Do the same for the natural signal

--- a/tests/testthat/test_fit_DoseResponseCurve.R
+++ b/tests/testthat/test_fit_DoseResponseCurve.R
@@ -726,8 +726,6 @@ temp_OTORX_alt <-
       verbose = TRUE,
       n.MC = 10),
       "Fit failed for OTORX")
-
-
 })
 
 test_that("regression tests", {
@@ -805,6 +803,12 @@ test_that("regression tests", {
   ## issue 1541
   expect_output(fit_DoseResponseCurve(df_odd, fit.method = "QDR"),
                 "Fit: QDR (interpolation) | De = 35.08", fixed = TRUE)
+
+  ## issue 1543
+  expect_output(fit_DoseResponseCurve(LxTxData, fit.method = "LIN", n.MC = 1),
+                "Fit: LIN (interpolation) | De = 1673.02", fixed = TRUE)
+  expect_output(fit_DoseResponseCurve(LxTxData, fit.method = "QDR", n.MC = 1),
+                "Fit: QDR (interpolation) | De = 1646.83", fixed = TRUE)
 })
 
 test_that("test internal functions", {


### PR DESCRIPTION
This avoid crashes in LIN and QDR if `n.MC = 1`. 

Fixes #1543.