### PR TITLE
calc_Statistics: Change accepted values for the weight.calc argument

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -174,6 +174,14 @@ only the last calibration date specified will be applied. This ensures that
 the source dose rates are computed consistently, rather than depending on R's
 recycling rules for vectors (#1611).
 
+### `calc_Statistics()`
+
+* The values accepted by the `weight.calc` argument have been changed to
+align to the terminology used in `fit_DoseResponseCurve()`. Therefore, option
+`"square"` is now called `"inverse_var"`, and `"reciprocal"` is now called
+`"inverse_std"`. The previous names will continue to work, but will now raise
+a deprecation warning (#1615).
+
 ### `convert_Second2Gray()`
 
 * Input validation was strengthened to avoid two possible crashes (#1537).

--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,14 @@ parameters are now called
   ensures that the source dose rates are computed consistently, rather
   than depending on R’s recycling rules for vectors (#1611).
 
+### `calc_Statistics()`
+
+- The values accepted by the `weight.calc` argument have been changed to
+  align to the terminology used in `fit_DoseResponseCurve()`. Therefore,
+  option `"square"` is now called `"inverse_var"`, and `"reciprocal"` is
+  now called `"inverse_std"`. The previous names will continue to work,
+  but will now raise a deprecation warning (#1615).
+
 ### `convert_Second2Gray()`
 
 - Input validation was strengthened to avoid two possible crashes

--- a/R/calc_Statistics.R
+++ b/R/calc_Statistics.R
@@ -17,8 +17,8 @@
 #' for [data.frame] two columns: De (`data[, 1]`) and De error (`data[, 2]`).
 #'
 #' @param weight.calc [character] (*with default*):
-#' type of weight calculation. One out of `"reciprocal"` (weight is 1/error),
-#' `"square"` (weight is 1/error^2). Default is `"square"`.
+#' type of weight calculation, either `"inverse_var"` (weight is 1/error^2,
+#' default) or `"inverse_std"` (weight is 1/error).
 #'
 #' @param digits [integer] (*with default*):
 #' number of decimal places to be used when rounding numbers. If set to `NULL`
@@ -33,7 +33,7 @@
 #'
 #' @return Returns a list with weighted and unweighted statistic measures.
 #'
-#' @section Function version: 0.1.7
+#' @section Function version: 0.1.8
 #'
 #' @keywords datagen
 #'
@@ -62,7 +62,7 @@
 #' @export
 calc_Statistics <- function(
   data,
-  weight.calc = c("square", "reciprocal"),
+  weight.calc = c("inverse_var", "inverse_std"),
   digits = NULL,
   n.MCM = NULL,
   na.rm = TRUE
@@ -103,10 +103,21 @@ calc_Statistics <- function(
     data[,2] <- rep(x = 10^-9, length(data[,2]))
   }
 
-  weight.calc <- .validate_args(weight.calc, c("square", "reciprocal"))
-  if(weight.calc == "reciprocal") {
+  ## deprecated names
+  deprecated <- c(inverse_var = "square", "inverse_std" = "reciprocal")
+  weight.calc <- .validate_args(weight.calc,
+                                c("inverse_var", "inverse_std", deprecated))
+  if (weight.calc %in% deprecated) {
+    new <- names(deprecated[match(weight.calc, deprecated)])
+    .deprecated(old = sprintf("weight.calc = \"%s\"", weight.calc),
+                new = sprintf("weight.calc = \"%s\"", new),
+                since = "1.3.0")
+    weight.calc <- new
+   }
+
+  if (weight.calc == "inverse_std") {
     S.weights <- 1 / data[,2]
-  } else if(weight.calc == "square") {
+  } else if (weight.calc == "inverse_var") {
     S.weights <- 1 / data[,2]^2
   }
 

--- a/man/calc_Statistics.Rd
+++ b/man/calc_Statistics.Rd
@@ -6,7 +6,7 @@
 \usage{
 calc_Statistics(
   data,
-  weight.calc = c("square", "reciprocal"),
+  weight.calc = c("inverse_var", "inverse_std"),
   digits = NULL,
   n.MCM = NULL,
   na.rm = TRUE
@@ -17,8 +17,8 @@ calc_Statistics(
 for \link{data.frame} two columns: De (\code{data[, 1]}) and De error (\code{data[, 2]}).}
 
 \item{weight.calc}{\link{character} (\emph{with default}):
-type of weight calculation. One out of \code{"reciprocal"} (weight is 1/error),
-\code{"square"} (weight is 1/error^2). Default is \code{"square"}.}
+type of weight calculation, either \code{"inverse_var"} (weight is 1/error^2,
+default) or \code{"inverse_std"} (weight is 1/error).}
 
 \item{digits}{\link{integer} (\emph{with default}):
 number of decimal places to be used when rounding numbers. If set to \code{NULL}
@@ -50,7 +50,7 @@ values. See Dietze et al. (2016, Quaternary Geochronology) and the function
 \link{plot_AbanicoPlot} for details.
 }
 \section{Function version}{
- 0.1.7
+ 0.1.8
 }
 
 \examples{

--- a/tests/testthat/test_calc_Statistics.R
+++ b/tests/testthat/test_calc_Statistics.R
@@ -19,7 +19,7 @@ test_that("Test certain input scenarios", {
                  "All errors are NA or zero, automatically set to")
 
   df <- ExampleData.DeValues$BT998
-  expect_silent(calc_Statistics(df, weight.calc = "reciprocal"))
+  expect_silent(calc_Statistics(df, weight.calc = "inverse_std"))
 })
 
 test_that("input validation", {
@@ -35,13 +35,17 @@ test_that("input validation", {
   expect_error(calc_Statistics(data.frame(a = NA)),
                "'data' contains only NA values")
   expect_error(calc_Statistics(data = df, weight.calc = "error"),
-               "'weight.calc' should be one of 'square' or 'reciprocal'")
+               "'weight.calc' should be one of 'inverse_var', 'inverse_std'")
   expect_error(calc_Statistics(df, digits = 2.4),
                "'digits' should be a single positive integer value")
   expect_error(calc_Statistics(df, n.MCM = "error"),
                "'n.MCM' should be a single positive integer value")
   expect_error(calc_Statistics(df, na.rm = iris),
                "'na.rm' should be a single logical value")
+
+  ## deprecated names
+  expect_warning(calc_Statistics(df, weight.calc = "reciprocal"),
+                 "was deprecated in v1.3.0, use 'weight.calc = \"inverse_std\"")
 })
 
 test_that("snapshot tests", {


### PR DESCRIPTION
This aligns them to the names used in `fit_DoseResponseCurve()`.

Fixes #1615.