### PR TITLE
analyse_SAR.CWOSL: Match the position field case insensitively

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -26,6 +26,9 @@ different from expected when `fit_DoseResponseCurve()` returned `NULL`, which
 meant that merging the results from multiple aliquots would fail if any such
 result was present. This was a regression introduced in v1.1.1 (#1623).
 
+* The `POS` column in the `$data` field of the result object is now correctly
+populated also for XSYG files, instead of being set to `NA` (#1625).
+
 ### `read_XSYG2R()`
 
 * Prevent function from crashing if it found an empty `<sequence />` node. This happens 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
   would fail if any such result was present. This was a regression
   introduced in v1.1.1 (#1623).
 
+- The `POS` column in the `$data` field of the result object is now
+  correctly populated also for XSYG files, instead of being set to `NA`
+  (#1625).
+
 ### `read_XSYG2R()`
 
 - Prevent function from crashing if it found an empty `<sequence />`

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -1030,7 +1030,12 @@ analyse_SAR.CWOSL<- function(
 
   ## get position numbers
   POSITION <- unique(vapply(object@records,
-                            function(x) x@info$POSITION %||% NA,
+                            function(x) {
+                              ## case insensitive matching
+                              idx <- match("position", tolower(names(x@info)))
+                              if (is.na(idx)) return(NA)
+                              x@info[[idx]]
+                            },
                             FUN.VALUE = numeric(1)))[1]
 
   ## get grain numbers

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -574,6 +574,15 @@ test_that("check functionality", {
       plot = FALSE, verbose = FALSE)
   expect_equal(res$rejection.criteria$Status[1:2],
                c("OK", "OK"))
+
+  ## simulate the info object of an XSYG file (issue 1625)
+  data <- object[[1]]
+  data@records[[1]]@info$POSITION <- NULL
+  data@records[[1]]@info$position <- 12
+  res <- analyse_SAR.CWOSL(data, signal_integral = 1:4,
+                           background_integral = 150:250,
+                           verbose = FALSE, plot = FALSE)
+  expect_equal(res@data$data$POS, 12)
 })
 
 test_that("advance tests run", {


### PR DESCRIPTION
This allows to store a valid position in the results object also for `XSYG` data (which use `$position` instead of `$POSITION`), instead of always setting it to `NA`.

Fixes #1625.