### PR TITLE
analyse_SAR.CWOSL: Match the grain field case insensitively

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -26,8 +26,9 @@ different from expected when `fit_DoseResponseCurve()` returned `NULL`, which
 meant that merging the results from multiple aliquots would fail if any such
 result was present. This was a regression introduced in v1.1.1 (#1623).
 
-* The `POS` column in the `$data` field of the result object is now correctly
-populated also for XSYG files, instead of being set to `NA` (#1625).
+* The `POS` and `GRAIN` columns in the `$data` field of the result object are
+now correctly populated also for XSYG files, instead of being set to `NA`.
+This was a regression introduced in v1.1.2 (#1625).
 
 ### `read_XSYG2R()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,9 +18,9 @@
   would fail if any such result was present. This was a regression
   introduced in v1.1.1 (#1623).
 
-- The `POS` column in the `$data` field of the result object is now
-  correctly populated also for XSYG files, instead of being set to `NA`
-  (#1625).
+- The `POS` and `GRAIN` columns in the `$data` field of the result
+  object are now correctly populated also for XSYG files, instead of
+  being set to `NA`. This was a regression introduced in v1.1.2 (#1625).
 
 ### `read_XSYG2R()`
 

--- a/R/analyse_SAR.CWOSL.R
+++ b/R/analyse_SAR.CWOSL.R
@@ -1040,7 +1040,12 @@ analyse_SAR.CWOSL<- function(
 
   ## get grain numbers
   GRAIN <- unique(vapply(object@records,
-                         function(x) x@info$GRAIN %||% NA,
+                         function(x) {
+                              ## case insensitive matching
+                              idx <- match("grain", tolower(names(x@info)))
+                              if (is.na(idx)) return(NA)
+                              x@info[[idx]]
+                            },
                          FUN.VALUE = numeric(1)))[1]
 
   ## Results object ---------------------------------------------------------

--- a/tests/testthat/test_analyse_SAR.CWOSL.R
+++ b/tests/testthat/test_analyse_SAR.CWOSL.R
@@ -577,12 +577,14 @@ test_that("check functionality", {
 
   ## simulate the info object of an XSYG file (issue 1625)
   data <- object[[1]]
-  data@records[[1]]@info$POSITION <- NULL
+  data@records[[1]]@info[c("POSITION", "GRAIN")] <- NULL
   data@records[[1]]@info$position <- 12
+  data@records[[1]]@info$grain <- 33
   res <- analyse_SAR.CWOSL(data, signal_integral = 1:4,
                            background_integral = 150:250,
                            verbose = FALSE, plot = FALSE)
   expect_equal(res@data$data$POS, 12)
+  expect_equal(res@data$data$GRAIN, 33)
 })
 
 test_that("advance tests run", {


### PR DESCRIPTION
This is the second half of the regression fix. Fixes #1625.