### PR TITLE
plot_AbanicoPlot: Reset a misspecified bw to 'SJ'

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -190,6 +190,9 @@ renders a usable plot (#1664, #1696)
 * The function no longer crashes when using a list of data frames with
 different column names (#1705).
 
+* A misspecified `bw` argument now reverts to the default value of `"SJ"`
+recommemded by base R, instead of the historical setting of `"nrd0"` (#1708).
+
 ### `plot_DetPlot()`
 
 * The `multicore` argument has been deprecated and is no longer functional.

--- a/NEWS.md
+++ b/NEWS.md
@@ -188,6 +188,10 @@
 - The function no longer crashes when using a list of data frames with
   different column names (#1705).
 
+- A misspecified `bw` argument now reverts to the default value of
+  `"SJ"` recommemded by base R, instead of the historical setting of
+  `"nrd0"` (#1708).
+
 ### `plot_DetPlot()`
 
 - The `multicore` argument has been deprecated and is no longer

--- a/R/plot_AbanicoPlot.R
+++ b/R/plot_AbanicoPlot.R
@@ -167,7 +167,9 @@
 #' Option to add a rug to the KDE part, to indicate the location of individual values.
 #'
 #' @param kde [logical] (*with default*):
-#' Option to add a KDE plot to the dispersion part, default is `TRUE`.
+#' Option to add a KDE plot to the dispersion part (`TRUE` by default). The
+#' smoothing bandwidth can be controlled by setting the `bw` argument (`"SJ"`
+#' by default; see [stats::density] for details).
 #'
 #' @param hist [logical] (*with default*):
 #' Option to add a histogram to the dispersion part. Only meaningful when only
@@ -230,15 +232,12 @@
 #'
 #' Default is `1`.
 #'
-#' @param bw [character] (*with default*):
-#' bin-width for KDE, choose a numeric value for manual setting.
-#'
 #' @param interactive [logical] (*with default*):
 #' create an interactive abanico plot (requires the `'plotly'` package)
 #'
 #' @param ... Further plot arguments to pass (see [graphics::plot.default]).
 #' Supported are: `main`, `sub`, `ylab`, `xlab`, `zlab`, `zlim`, `ylim`, `cex`,
-#' `lty`, `lwd`, `pch`, `col`, `at`, `breaks`. `xlab` must be
+#' `lty`, `lwd`, `pch`, `col`, `at`, `bw`, `breaks`. `xlab` must be
 #' a vector of length two, specifying the upper and lower x-axis labels.
 #'
 #' Please note that in the interactive mode, if you are using an expression,
@@ -247,7 +246,7 @@
 #' @return
 #' Returns a plot object and, optionally, a list with plot calculus data.
 #'
-#' @section Function version: 0.1.23
+#' @section Function version: 0.1.24
 #'
 #' @author
 #' Michael Dietze, GFZ Potsdam (Germany)\cr
@@ -475,7 +474,6 @@ plot_AbanicoPlot <- function(
   line.label = NULL,
   grid.col = NULL,
   frame = 1,
-  bw = "SJ",
   interactive = FALSE,
   ...
 ) {
@@ -684,13 +682,14 @@ plot_AbanicoPlot <- function(
   De.global <- unlist(lapply(data, function(x) x[, 1]))
 
   ## check/set bw-parameter
+  bw <- extraArgs$bw %||% "SJ"
   for(i in 1:length(data)) {
     bw.test <- try(density(x = data[[i]][,1],
                            bw = bw),
                    silent = TRUE)
     if (inherits(bw.test, "try-error")) {
-      bw <- "nrd0"
-      .throw_warning("Option for 'bw' not valid, reset to 'nrd0'")
+      bw <- "SJ"
+      .throw_warning("Option for 'bw' not valid, reset to 'SJ'")
     }
   }
 

--- a/man/plot_AbanicoPlot.Rd
+++ b/man/plot_AbanicoPlot.Rd
@@ -34,7 +34,6 @@ plot_AbanicoPlot(
   line.label = NULL,
   grid.col = NULL,
   frame = 1,
-  bw = "SJ",
   interactive = FALSE,
   ...
 )
@@ -127,7 +126,9 @@ One or more out of the following:
 Option to add a rug to the KDE part, to indicate the location of individual values.}
 
 \item{kde}{\link{logical} (\emph{with default}):
-Option to add a KDE plot to the dispersion part, default is \code{TRUE}.}
+Option to add a KDE plot to the dispersion part (\code{TRUE} by default). The
+smoothing bandwidth can be controlled by setting the \code{bw} argument (\code{"SJ"}
+by default; see \link[stats:density]{stats::density} for details).}
 
 \item{hist}{\link{logical} (\emph{with default}):
 Option to add a histogram to the dispersion part. Only meaningful when only
@@ -192,15 +193,12 @@ option to modify the plot frame type. Can be one out of
 
 Default is \code{1}.}
 
-\item{bw}{\link{character} (\emph{with default}):
-bin-width for KDE, choose a numeric value for manual setting.}
-
 \item{interactive}{\link{logical} (\emph{with default}):
 create an interactive abanico plot (requires the \code{'plotly'} package)}
 
 \item{...}{Further plot arguments to pass (see \link[graphics:plot.default]{graphics::plot.default}).
 Supported are: \code{main}, \code{sub}, \code{ylab}, \code{xlab}, \code{zlab}, \code{zlim}, \code{ylim}, \code{cex},
-\code{lty}, \code{lwd}, \code{pch}, \code{col}, \code{at}, \code{breaks}. \code{xlab} must be
+\code{lty}, \code{lwd}, \code{pch}, \code{col}, \code{at}, \code{bw}, \code{breaks}. \code{xlab} must be
 a vector of length two, specifying the upper and lower x-axis labels.
 
 Please note that in the interactive mode, if you are using an expression,
@@ -298,7 +296,7 @@ documentation of \code{axis}. Specifying tick positions manually overrides a
 }
 }
 \section{Function version}{
- 0.1.23
+ 0.1.24
 }
 
 \examples{

--- a/tests/testthat/test_plot_AbanicoPlot.R
+++ b/tests/testthat/test_plot_AbanicoPlot.R
@@ -291,7 +291,7 @@ test_that("more coverage", {
   ## further edge tests ... check for wrong bw parameter
   expect_warning(
     object = plot_AbanicoPlot(data = ExampleData.DeValues, bw = "tests"),
-    regexp = "Option for 'bw' not valid, reset to 'nrd0'")
+    regexp = "Option for 'bw' not valid, reset to 'SJ'")
 
   ## negative values
   df <-  ExampleData.DeValues


### PR DESCRIPTION
This also removes the explicit argument, making it accepted via `...`, for consistency with the `break` argument.

Fixes #1708.