### PR TITLE
analyse_pIRIRSequence: Fix crash on an empty RLum.Analysis object

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -75,6 +75,11 @@ by setting `cores = NULL` (#1668).
 * A warning message shown in case of failure of the test parameters has been
 improved to avoid reporting a spurious `NA` (#1715).
 
+### `analyse_pIRIRSequence()`
+
+* The function no longer crashes when presented with an empty `RLum.Analysis`
+object (#1725; thanks to Annette Kadereit for reporting).
+
 ### `analyse_SAR.CWOSL()`
 
 * The ordering of columns in the `$data` field of the result object was

--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,12 @@
 - A warning message shown in case of failure of the test parameters has
   been improved to avoid reporting a spurious `NA` (#1715).
 
+### `analyse_pIRIRSequence()`
+
+- The function no longer crashes when presented with an empty
+  `RLum.Analysis` object (#1725; thanks to Annette Kadereit for
+  reporting).
+
 ### `analyse_SAR.CWOSL()`
 
 - The ordering of columns in the `$data` field of the result object was

--- a/R/analyse_pIRIRSequence.R
+++ b/R/analyse_pIRIRSequence.R
@@ -310,7 +310,7 @@ analyse_pIRIRSequence <- function(
 
   ## try to account for a very common mistake
   idx.TL <- grepl("TL", sequence.structure, fixed = TRUE)
-  if (length(idx.TL) > 0 &&
+  if (sum(idx.TL) > 0 &&
       !any(grepl("TL", temp.sequence.structure$recordType, fixed = TRUE))) {
     sequence.structure <- sequence.structure[-idx.TL]
     .throw_warning("'sequence.structure' contains 'TL' but your sequence does ",
@@ -344,6 +344,11 @@ analyse_pIRIRSequence <- function(
     temp.sequence.structure$protocol.step <- rep(sequence.structure, num.cycles)
 
     .throw_warning(length(rm.id), " records have been removed due to EXCLUDE")
+  }
+
+  if (length(object) == 0) {
+    .throw_message("'object' contains no records, NULL returned")
+    return(NULL)
   }
 
 ##============================================================================##

--- a/tests/testthat/test_analyse_pIRIRSequence.R
+++ b/tests/testthat/test_analyse_pIRIRSequence.R
@@ -198,6 +198,12 @@ test_that("input validation", {
                  "'sequence.structure' changed to c('IR50', 'pIRIR225')",
                  fixed = TRUE)
   })
+
+  expect_message(expect_null(analyse_pIRIRSequence(set_RLum("RLum.Analysis"),
+                                                   signal_integral = 1:2,
+                                                   background_integral = 100:200,
+                                                   sequence.structure = c("IR50"))),
+                 "'object' contains no records, NULL returned")
 })
 
 test_that("check class and length of output", {


### PR DESCRIPTION
Fixes #1725.